### PR TITLE
feat: 컨트롤러에 더미데이터로 응답값을 전달하도록 변경한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/TestDataInit.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/TestDataInit.java
@@ -26,9 +26,9 @@ public class TestDataInit {
     public void initData() {
         final Team team = new Team("mypyeon");
         final Member member1 =
-                new Member("kth990303", "kth990303@gmail.com", "abc@@1234");
+                new Member("케이(김태현)", "kth990303@gmail.com", "abc@@1234");
         final Member member2 =
-                new Member("yxxnghwan", "yxxnghwan@gmail.com", "abc@@1234");
+                new Member("알렉스(이영환)", "yxxnghwan@gmail.com", "abc@@1234");
         dummyMember1 = memberJpaDao.save(member1);
         dummyMember2 = memberJpaDao.save(member2);
         dummyTeam = teamJpaDao.save(team);

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/MessageController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/MessageController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.naepyeon.controller;
 
+import com.woowacourse.naepyeon.TestDataInit;
 import com.woowacourse.naepyeon.controller.dto.MessageRequest;
 import com.woowacourse.naepyeon.controller.dto.MessageUpdateContentRequest;
 import com.woowacourse.naepyeon.service.MessageService;
@@ -17,6 +18,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.woowacourse.naepyeon.TestDataInit.*;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/rollingpapers/{rollingpaperId}/messages")
@@ -27,7 +30,9 @@ public class MessageController {
     @PostMapping
     public ResponseEntity<Void> createMessage(@RequestBody @Valid final MessageRequest messageRequest,
                                               @PathVariable final Long rollingpaperId) {
-        final Long messageId = messageService.saveMessage(messageRequest.getContent(), messageRequest.getAuthorId(),
+//        final Long messageId = messageService.saveMessage(messageRequest.getContent(), messageRequest.getAuthorId(),
+//                rollingpaperId);
+        final Long messageId = messageService.saveMessage(messageRequest.getContent(), dummyMember1.getId(),
                 rollingpaperId);
         return ResponseEntity.created(
                 URI.create("/api/v1/rollingpapers/" + rollingpaperId + "/messages/" + messageId)

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/RollingpaperController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/RollingpaperController.java
@@ -27,7 +27,6 @@ import static com.woowacourse.naepyeon.TestDataInit.*;
 public class RollingpaperController {
 
     private final RollingpaperService rollingpaperService;
-    //
 
     @PostMapping
     public ResponseEntity<Void> createRollingpaper(

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/RollingpaperController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/RollingpaperController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.naepyeon.controller;
 
+import com.woowacourse.naepyeon.TestDataInit;
 import com.woowacourse.naepyeon.controller.dto.RollingpaperCreateRequest;
 import com.woowacourse.naepyeon.controller.dto.RollingpaperUpdateRequest;
 import com.woowacourse.naepyeon.service.RollingpaperService;
@@ -18,20 +19,27 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import static com.woowacourse.naepyeon.TestDataInit.*;
+
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/teams/{teamId}/rollingpapers")
 public class RollingpaperController {
 
     private final RollingpaperService rollingpaperService;
+    //
 
     @PostMapping
     public ResponseEntity<Void> createRollingpaper(
             @PathVariable final Long teamId,
             @RequestBody @Valid final RollingpaperCreateRequest rollingpaperCreateRequest) {
-        final Long rollingpaperId = rollingpaperService.createRollingpaper(rollingpaperCreateRequest.getTitle(), teamId,
-                rollingpaperCreateRequest.getMemberId());
-        return ResponseEntity.created(URI.create("/api/v1/teams/" + teamId + "/rollingpapers/" + rollingpaperId))
+//        final Long rollingpaperId = rollingpaperService.createRollingpaper(rollingpaperCreateRequest.getTitle(), teamId,
+//                rollingpaperCreateRequest.getMemberId());
+//        return ResponseEntity.created(URI.create("/api/v1/teams/" + teamId + "/rollingpapers/" + rollingpaperId))
+//                .build();
+        final Long rollingpaperId = rollingpaperService.createRollingpaper(rollingpaperCreateRequest.getTitle(), dummyTeam.getId(),
+                dummyMember2.getId());
+        return ResponseEntity.created(URI.create("/api/v1/teams/" + dummyTeam.getId() + "/rollingpapers/" + rollingpaperId))
                 .build();
     }
 
@@ -44,7 +52,8 @@ public class RollingpaperController {
 
     @GetMapping
     public ResponseEntity<RollingpapersResponseDto> findRollingpapers(@PathVariable final Long teamId) {
-        final RollingpapersResponseDto rollingpapersResponseDto = rollingpaperService.findByTeamId(teamId);
+//        final RollingpapersResponseDto rollingpapersResponseDto = rollingpaperService.findByTeamId(teamId);
+        final RollingpapersResponseDto rollingpapersResponseDto = rollingpaperService.findByTeamId(dummyTeam.getId());
         return ResponseEntity.ok(rollingpapersResponseDto);
     }
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/TeamAcceptanceTest.java
@@ -91,5 +91,4 @@ public class TeamAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
         assertThat(response.header("Location")).isNotBlank();
     }
-
 }


### PR DESCRIPTION
- 회원 및 모임은 1차 데모데이 구현사항에 해당되지 않는다.
- 회원, 모임은 백엔드에서 구현한 더미데이터 https://github.com/woowacourse-teams/2022-nae-pyeon/issues/6 을 사용하도록 변경한다.
 이 더미데이터는 이후에 회원, 모임이 본격적으로 구현되면 삭제한다.

close #41 