### PR TITLE
feat: 메시지 편집 페이지와 상세보기 페이지 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "@emotion/styled": "^11.9.3",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
+    "@types/react-router-dom": "^5.3.3",
     "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Routes, Route } from "react-router-dom";
 import RollingpaperPage from "@/pages/RollingpaperPage";
 import RollingpaperCreationPage from "@/pages/RollingpaperCreationPage";
 import MessageWritePage from "@/pages/MessageWritePage";
+import MessageEditPage from "@/pages/MessageEditPage";
 
 import reset from "./styles/reset";
 
@@ -45,6 +46,10 @@ const App = () => {
           <Route
             path="rollingpaper/:rollingpaperId/message/new"
             element={<MessageWritePage />}
+          />
+          <Route
+            path="rollingpaper/:rollingpaperId/message/:messageId/edit"
+            element={<MessageEditPage />}
           />
         </Routes>
       </StyledPageContainer>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import RollingpaperPage from "@/pages/RollingpaperPage";
 import RollingpaperCreationPage from "@/pages/RollingpaperCreationPage";
 import MessageWritePage from "@/pages/MessageWritePage";
 import MessageEditPage from "@/pages/MessageEditPage";
+import MessageDetailPage from "@/pages/MessageDetailPage";
 
 import reset from "./styles/reset";
 
@@ -46,6 +47,10 @@ const App = () => {
           <Route
             path="rollingpaper/:rollingpaperId/message/new"
             element={<MessageWritePage />}
+          />
+          <Route
+            path="rollingpaper/:rollingpaperId/message/:messageId"
+            element={<MessageDetailPage />}
           />
           <Route
             path="rollingpaper/:rollingpaperId/message/:messageId/edit"

--- a/frontend/src/components/LetterPaper.tsx
+++ b/frontend/src/components/LetterPaper.tsx
@@ -4,15 +4,9 @@ import { useNavigate } from "react-router-dom";
 
 import IconButton from "@components/IconButton";
 import RollingpaperMessage from "@components/RollingpaperMessage";
+import { Message } from "@/types";
 
 import { BiPencil } from "react-icons/bi";
-
-interface Message {
-  id: number;
-  content: string;
-  from: string;
-  authorId: number;
-}
 
 interface LetterPaperProp {
   to: string;

--- a/frontend/src/components/LetterPaper.tsx
+++ b/frontend/src/components/LetterPaper.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 
 import IconButton from "@components/IconButton";
 import RollingpaperMessage from "@components/RollingpaperMessage";
@@ -33,11 +33,13 @@ const LetterPaper = ({ to, messageList }: LetterPaperProp) => {
       </StyledLetterPaperTop>
       <StyledMessageList>
         {messageList.map((message) => (
-          <RollingpaperMessage
-            key={message.id}
-            content={message.content}
-            author={message.from}
-          />
+          <Link to={`message/${message.id}`}>
+            <RollingpaperMessage
+              key={message.id}
+              content={message.content}
+              author={message.from}
+            />
+          </Link>
         ))}
       </StyledMessageList>
     </StyledLetterPaper>

--- a/frontend/src/components/RollingpaperMessageDetail.tsx
+++ b/frontend/src/components/RollingpaperMessageDetail.tsx
@@ -8,11 +8,15 @@ import IconButton from "./IconButton";
 interface RollingpaperMessageDetailProps {
   content: string;
   author: string;
+  handleDeleteButtonClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  handleEditButtonClick: (e: React.MouseEvent<HTMLButtonElement>) => void;
 }
 
 const RollingpaperMessageDetail = ({
   content,
   author,
+  handleDeleteButtonClick,
+  handleEditButtonClick,
 }: RollingpaperMessageDetailProps) => {
   return (
     <StyledMessage>
@@ -20,10 +24,10 @@ const RollingpaperMessageDetail = ({
 
       <StyledBottom>
         <StyledMenu>
-          <IconButton size="small">
+          <IconButton size="small" onClick={handleEditButtonClick}>
             <BiPencil />
           </IconButton>
-          <IconButton size="small">
+          <IconButton size="small" onClick={handleDeleteButtonClick}>
             <BiTrash />
           </IconButton>
         </StyledMenu>

--- a/frontend/src/components/RollingpaperMessageDetail.tsx
+++ b/frontend/src/components/RollingpaperMessageDetail.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+import { BiPencil, BiTrash } from "react-icons/bi";
+
+import IconButton from "./IconButton";
+
+interface RollingpaperMessageDetailProps {
+  content: string;
+  author: string;
+}
+
+const RollingpaperMessageDetail = ({
+  content,
+  author,
+}: RollingpaperMessageDetailProps) => {
+  return (
+    <StyledMessage>
+      <StyledContent>{content}</StyledContent>
+
+      <StyledBottom>
+        <StyledMenu>
+          <IconButton size="small">
+            <BiPencil />
+          </IconButton>
+          <IconButton size="small">
+            <BiTrash />
+          </IconButton>
+        </StyledMenu>
+
+        <StyledAuthor>{author}</StyledAuthor>
+      </StyledBottom>
+    </StyledMessage>
+  );
+};
+
+const StyledContent = styled.div`
+  height: 90%;
+`;
+
+const StyledMenu = styled.div`
+  display: flex;
+  gap: 10px;
+`;
+
+const StyledAuthor = styled.div``;
+
+const StyledBottom = styled.div`
+  height: 10%;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const StyledMessage = styled.div`
+  width: 300px;
+  height: 300px;
+
+  padding: 20px;
+
+  border: none;
+  border-radius: 8px;
+  background-color: #c5ff98;
+
+  @media only screen and (min-width: 960px) {
+    width: 600px;
+    height: 400px;
+  }
+`;
+
+export default RollingpaperMessageDetail;

--- a/frontend/src/components/TextArea.tsx
+++ b/frontend/src/components/TextArea.tsx
@@ -1,9 +1,13 @@
 import React from "react";
 import styled from "@emotion/styled";
 
-const TextArea = React.forwardRef<HTMLTextAreaElement>((props, ref) => {
-  return <StyledTextArea ref={ref} {...props} />;
-});
+type TextAreaAttributes = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const TextArea = React.forwardRef<HTMLTextAreaElement, TextAreaAttributes>(
+  (props, ref) => {
+    return <StyledTextArea ref={ref} {...props} />;
+  }
+);
 
 const StyledTextArea = styled.textarea`
   width: 300px;

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -61,4 +61,15 @@ export const handlers = [
       return res(ctx.status(200), ctx.json(result));
     }
   ),
+
+  // 메시지 수정
+  rest.put(
+    "/api/v1/rollingpapers/:rollingpaperId/messages/:messageId",
+    (req, res, ctx) => {
+      const { rollingpaperId, messageId } = req.params;
+      const { content } = req.body;
+
+      return res(ctx.status(204));
+    }
+  ),
 ];

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -72,4 +72,15 @@ export const handlers = [
       return res(ctx.status(204));
     }
   ),
+
+  // 메시지 삭제
+  rest.delete(
+    "/api/v1/rollingpapers/:rollingpaperId/messages/:messageId",
+    (req, res, ctx) => {
+      const { rollingpaperId, messageId } = req.params;
+      const { content } = req.body;
+
+      return res(ctx.status(204));
+    }
+  ),
 ];

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -44,4 +44,21 @@ export const handlers = [
 
     return res(ctx.status(201), ctx.json(result));
   }),
+
+  // 단건 메시지 조회
+  rest.get(
+    "/api/v1/rollingpapers/:rollingpaperId/messages/:messageId",
+    (req, res, ctx) => {
+      const { rollingpaperId, messageId } = req.params;
+
+      const result = {
+        id: 1,
+        content: "생일축하해",
+        from: "도리",
+        authorId: 1,
+      };
+
+      return res(ctx.status(200), ctx.json(result));
+    }
+  ),
 ];

--- a/frontend/src/pages/MessageDetailPage.tsx
+++ b/frontend/src/pages/MessageDetailPage.tsx
@@ -1,0 +1,100 @@
+import React, { useState, useEffect } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import styled from "@emotion/styled";
+import axios from "axios";
+import { BiChevronLeft } from "react-icons/bi";
+
+import Header from "@/components/Header";
+import IconButton from "@/components/IconButton";
+import RollingpaperMessageDetail from "@/components/RollingpaperMessageDetail";
+
+import { Message } from "@/types";
+
+const MessageDetailPage = () => {
+  const { rollingpaperId, messageId } = useParams();
+  const navigate = useNavigate();
+
+  const [message, setMessage] = useState<Message | null>(null);
+
+  const handleEditButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    navigate(`/rollingpaper/${rollingpaperId}/message/${messageId}/edit`);
+  };
+
+  const handleDeleteButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+
+    axios
+      .delete(`/api/v1/rollingpapers/${rollingpaperId}/messages/${messageId}`)
+      .then((response) => {
+        alert("메시지 삭제 완료");
+        navigate(`/rollingpaper/${rollingpaperId}`, { replace: true });
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
+  useEffect(() => {
+    axios
+      .get(`/api/v1/rollingpapers/${rollingpaperId}/messages/${messageId}`)
+      .then((response) => {
+        setMessage(response.data);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }, []);
+
+  if (!message) {
+    return (
+      <>
+        <Header>
+          <IconButton>
+            <BiChevronLeft />
+          </IconButton>
+        </Header>
+        <StyledMain>
+          <RollingpaperMessageDetail
+            content={""}
+            author={""}
+            handleDeleteButtonClick={handleDeleteButtonClick}
+            handleEditButtonClick={handleEditButtonClick}
+          />
+        </StyledMain>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header>
+        <IconButton>
+          <BiChevronLeft />
+        </IconButton>
+      </Header>
+      <StyledMain>
+        <RollingpaperMessageDetail
+          content={message.content}
+          author={message.from}
+          handleDeleteButtonClick={handleDeleteButtonClick}
+          handleEditButtonClick={handleEditButtonClick}
+        />
+      </StyledMain>
+    </>
+  );
+};
+
+const StyledMain = styled.main`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+
+  padding: 48px 25px;
+
+  button {
+    align-self: flex-end;
+  }
+`;
+
+export default MessageDetailPage;

--- a/frontend/src/pages/MessageEditPage.tsx
+++ b/frontend/src/pages/MessageEditPage.tsx
@@ -1,0 +1,88 @@
+import React, { useState, useEffect, useRef } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import styled from "@emotion/styled";
+import axios from "axios";
+
+import Header from "@/components/Header";
+import Button from "@/components/Button";
+import IconButton from "@/components/IconButton";
+import TextArea from "@/components/TextArea";
+
+import { BiChevronLeft } from "react-icons/bi";
+
+const MessageEditPage = () => {
+  const { rollingpaperId, messageId } = useParams();
+  const navigate = useNavigate();
+
+  const [initialMessageContent, setInitialMessageContent] = useState(null);
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+  const authorId = 123;
+
+  const handleMessageFormSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!contentRef.current) {
+      console.error("ERROR :: No contentRef.current");
+      return;
+    }
+
+    if (!contentRef.current.value) {
+      alert("메시지를 작성해주세요");
+      return;
+    }
+
+    axios
+      .put(`/api/v1/rollingpapers/${rollingpaperId}/messages/${messageId}`, {
+        content: contentRef.current.value,
+      })
+      .then((response) => {
+        alert("메시지 수정 완료");
+        navigate(`/rollingpaper/${rollingpaperId}`, { replace: true });
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
+  useEffect(() => {
+    axios
+      .get(`/api/v1/rollingpapers/${rollingpaperId}/messages/${messageId}`)
+      .then((response) => {
+        setInitialMessageContent(response.data.content);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }, []);
+
+  return (
+    <>
+      <Header>
+        <IconButton>
+          <BiChevronLeft />
+        </IconButton>
+      </Header>
+      <StyledMain onSubmit={handleMessageFormSubmit}>
+        {initialMessageContent && (
+          <TextArea ref={contentRef} defaultValue={initialMessageContent} />
+        )}
+        <Button type="submit">완료</Button>
+      </StyledMain>
+    </>
+  );
+};
+
+const StyledMain = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 40px;
+
+  padding: 48px 25px;
+
+  button {
+    align-self: flex-end;
+  }
+`;
+
+export default MessageEditPage;

--- a/frontend/src/styles/reset.ts
+++ b/frontend/src/styles/reset.ts
@@ -134,6 +134,10 @@ const reset = css`
       background-color: transparent;
       cursor: pointer;
     }
+    a {
+      text-decoration: none;
+      color: black;
+    }
   }
 `;
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,6 @@
+export interface Message {
+  id: number;
+  content: string;
+  from: string;
+  authorId: number;
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -27,7 +27,7 @@
     /* Modules */
     "module": "commonjs" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     "baseUrl": "./" /* Specify the base directory to resolve non-relative module names. */,
     "paths": {
       "@/*": ["src/*"],

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2694,6 +2694,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
@@ -2840,6 +2845,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.5.tgz#330b2d472c22f796e5531446939eacef8378444a"
   integrity sha512-OWPWTUrY/NIrjsAPkAk1wW9LZeIjSvkXRhclsFO8CZcZGCOg2G0YZy4ft+rOyYxy8B7ui5iZzi9OkDebZ7/QSA==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.18"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.18.tgz#c8851884b60bc23733500d86c1266e1cfbbd9ef3"
+  integrity sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==
+  dependencies:
+    "@types/history" "^4.7.11"
     "@types/react" "*"
 
 "@types/react-syntax-highlighter@11.0.5":


### PR DESCRIPTION
## 구현 기능
### 롤링페이퍼 페이지
- 메시지를 누르면 선택한 메시지의 상세보기 페이지로 이동한다.

### 메시지 편집 페이지
- 편집할 메시지 내용을 볼 수 있다.
- 완료 버튼을 누르면 수정한 메시지를 저장한다.

### 메시지 상세보기 페이지
- 선택한 메시지 내용을 볼 수 있다.
- 메시지 편집 버튼을 누르면 메시지 편집 페이지로 이동한다.
- 메시지 삭제 버튼을 누르면 삭제한다.
