### PR TITLE
fix: @GeneratedValue를 IDENTITY로 수정했을 때 테스트 격리를 시킨다.

### DIFF
--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceTest.java
@@ -6,10 +6,11 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
+@AutoConfigureTestDatabase
 public class AcceptanceTest {
 
     @LocalServerPort


### PR DESCRIPTION
## 상황설명
`@GeneratedValue`를 auto인 상황에서 IDENTITY로 수정하고 테스트 코드를 돌렸을때
email 유니크 제약조건으로 인한 에러가 발생했습니다.

## 1차적인 문제
`@GeneratedValue`가 auto일 경우 h2 db에서는 SEQUENCE 전략이 선택됩니다.
em.persist()로 member를 영속화할 때 id 생성을 위해서 DB가 관리하는 SEQUENCE OBJECT에서 id 값을 가져오는데
<img width="361" alt="스크린샷 2022-07-06 오후 9 47 16" src="https://user-images.githubusercontent.com/37570657/177553555-1ef37e5a-291d-42fd-9cf6-d5e617332976.png">

SEQUENCE 전략은 굳이 INSERT 쿼리가 DB에 나가지 않아도 id 값을 알 수 있으므로 AUTO 일 땐 INSERT 쿼리가 나가지 않습니다.
그래서 db를 거치지 않아서 email 유니크 제약조건이 걸리지 않았던 것입니다.

## 근본적인 문제
gradle로 테스트 코드가 동작되면 테스트 격리가 정상적으로 이루어지지만 Junit으로 테스트 코드가 동작되면 테스트 격리가 정상적으로
이루어지지 않는 현상이 있습니다. 일단은 gradle이나 Junit으로 테스트 코드가 동작되더라도 깨지지 않는 형태로 수정하였습니다.

## 해결방안
`@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)`로 변경하면 gradle, Junit에서도 다 성공적으로 동작됩니다. 다만 DB가 변경되더라도 해당 테스트코드에 대한 변경이 없게 하려고 `@AutoConfigureTestDatabase`를 유지하는 방안으로 했습니다.

---
+ `@AutoConfigureTestDatabase`: 설정해놓은 DB가 아닌 in-memory DB를 활용해서 테스트가 실행됩니다.
+ `@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)`: application.yml에서 설정한 환경값에 따라 데이터소스가 적용됩니다.

close #50 

