### PR TITLE
fix: 메시지 삭제 시, 롤링페이퍼와 연관해서 삭제 관련된 버그 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Message.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Message.java
@@ -30,7 +30,7 @@ public class Message {
     @JoinColumn(name = "member_id")
     private Member author;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "rollingpaper_id")
     private Rollingpaper rollingpaper;
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/TeamMember.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/TeamMember.java
@@ -25,11 +25,11 @@ public class TeamMember {
     @Column(name = "team_member_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_id")
     private Team team;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 


### PR DESCRIPTION
## 구현한 내용
Message, TEAM_MEMBER에서 `cascade=CascadeType.REMOVE` 옵션 삭제
- 옵션이 걸려있을 경우, 메시지를 삭제할 때 롤링페이퍼도 삭제됨. (부모가 삭제되면 자식도 삭제됨. 이 옵션을 부모에 걸어야 되는데 우리는 Message에 걸었음.)
  - 단방향 연관관계여서 rollingpaper에 걸지 못했음.
  - 논리적 삭제를 고려하면 옵션을 해제하는 게 맞음.
- 메시지가 2개 이상일 때 삭제하려 하는 경우, 다른 메시지가 이미 존재하기 때문에 삭제가 되지 않았던 것. 

## 추후 논의할 내용
- 논리적 삭제를 적용하자 vs 양방향 연관관계로 `cascade=CascadeType.REMOVE`를 적용하자
  - 삭제 정책이 정해지면, 설계 방향이 잡히고 인수 테스트를 명확하게 작성할 수 있을 듯함.

close #52  