### PR TITLE
feat: osiv 옵션을 해제한다.

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -19,6 +19,7 @@ spring:
         #        show_sql: true
         format_sql: true
         default_batch_fetch_size: 1000 #최적화 옵션
+    open-in-view: false
 
 logging.level:
   org.hibernate.SQL: debug


### PR DESCRIPTION
## 구현한 내용
- OSIV 옵션을 해제했다.
![image](https://user-images.githubusercontent.com/57135043/177672886-2898b80d-cd16-4f0e-a738-434df27d851c.png)
```yml
jpa.open-in-view: false
```
[참고 링크](https://ykh6242.tistory.com/entry/JPA-OSIVOpen-Session-In-View%EC%99%80-%EC%84%B1%EB%8A%A5-%EC%B5%9C%EC%A0%81%ED%99%94)
- 영속성 컨텍스트를 컨트롤러, 뷰 영역에까지 끌고 오지 않음.
  - 트랜잭션을 서비스 레이어에서까지만 관리할 수 있음.

close #34 