### PR TITLE
test: 회원 관련 인수 테스트를 작성한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/MemberController.java
@@ -8,7 +8,13 @@ import com.woowacourse.naepyeon.service.MemberService;
 import com.woowacourse.naepyeon.service.dto.MemberResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 import java.net.URI;

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/MemberController.java
@@ -6,18 +6,12 @@ import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
 import com.woowacourse.naepyeon.controller.dto.MemberUpdateRequest;
 import com.woowacourse.naepyeon.service.MemberService;
 import com.woowacourse.naepyeon.service.dto.MemberResponseDto;
-import java.net.URI;
-import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor
@@ -49,11 +43,10 @@ public class MemberController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{memberId}")
+    @DeleteMapping("/me")
     public ResponseEntity<Void> deleteMember(
-            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
-            @PathVariable final Long memberId) {
-        memberService.delete(memberId);
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest) {
+        memberService.delete(loginMemberRequest.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/MemberService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/MemberService.java
@@ -42,6 +42,8 @@ public class MemberService {
     }
 
     public void delete(final Long memberId) {
+        memberRepository.findById(memberId)
+                .orElseThrow(() -> new NotFoundMemberException(memberId));
         memberRepository.delete(memberId);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
@@ -1,10 +1,6 @@
 package com.woowacourse.naepyeon.acceptance;
 
-import com.woowacourse.naepyeon.controller.dto.CreateResponse;
-import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
-import com.woowacourse.naepyeon.controller.dto.MemberUpdateRequest;
-import com.woowacourse.naepyeon.controller.dto.TeamRequest;
-import com.woowacourse.naepyeon.controller.dto.TokenRequest;
+import com.woowacourse.naepyeon.controller.dto.*;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -96,8 +92,8 @@ public class AcceptanceFixture {
         return put(tokenResponseDto, memberUpdateRequest, "/api/v1/members/me");
     }
 
-    public static ExtractableResponse<Response> 회원_삭제(final TokenResponseDto tokenResponseDto, final Long id) {
-        return delete(tokenResponseDto, "/api/v1/members/" + id);
+    public static ExtractableResponse<Response> 회원_삭제(final TokenResponseDto tokenResponseDto) {
+        return delete(tokenResponseDto, "/api/v1/members/me");
     }
 
     public static ExtractableResponse<Response> 모임_추가(final TokenResponseDto tokenResponseDto,

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
@@ -1,6 +1,10 @@
 package com.woowacourse.naepyeon.acceptance;
 
-import com.woowacourse.naepyeon.controller.dto.*;
+import com.woowacourse.naepyeon.controller.dto.CreateResponse;
+import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
+import com.woowacourse.naepyeon.controller.dto.MemberUpdateRequest;
+import com.woowacourse.naepyeon.controller.dto.TeamRequest;
+import com.woowacourse.naepyeon.controller.dto.TokenRequest;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/MemberAcceptanceTest.java
@@ -1,39 +1,47 @@
 package com.woowacourse.naepyeon.acceptance;
 
-
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_삭제;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_유저네임_수정;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_추가;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원가입_후_로그인;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
 import com.woowacourse.naepyeon.controller.dto.MemberUpdateRequest;
+import com.woowacourse.naepyeon.controller.dto.TokenRequest;
+import com.woowacourse.naepyeon.service.dto.MemberResponseDto;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.로그인_응답;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_삭제;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_유저네임_수정;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_조회;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_추가;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원가입_후_로그인;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class MemberAcceptanceTest extends AcceptanceTest {
 
     @Test
-    @DisplayName("회원 추가")
+    @DisplayName("회원을 추가하고 검증한다.")
     void addMember() {
-        //회원 생성
+        //회원 정보
         final MemberRegisterRequest member =
                 new MemberRegisterRequest("seungpang", "email@email.com", "12345678aA!");
-        final ExtractableResponse<Response> response = 회원_추가(member);
 
-        //회원이 추가됨
-        회원이_추가됨(response);
+        //회원 추가 및 토큰
+        final ExtractableResponse<Response> response = 회원_추가(member);
+        final TokenResponseDto token = 로그인_응답(new TokenRequest("email@email.com", "12345678aA!"))
+                .as(TokenResponseDto.class);
+
+        //회원추가 검증 및 회원검증
+        회원이_추가됨(response, token, member);
     }
 
     @Test
-    @DisplayName("이미 가입된 회원이 추가되는 경우 예외를 발생시킨다.")
+    @DisplayName("회원가입 시, 이미 가입된 회원이 추가되는 경우 예외가 발생한다.")
     void addDuplicationMember() {
         final MemberRegisterRequest member =
                 new MemberRegisterRequest("seungpang", "email@email.com", "12345678aA!");
@@ -44,53 +52,173 @@ class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
+    @ParameterizedTest
+    @DisplayName("회원가입 시, 회원이름이 2 ~ 20자 및 한글, 영어, 숫자가 아닌 경우 예외가 발생한다.")
+    @ValueSource(strings = {"0", "012345678901234567891", "+특수문자+"})
+    void failSignUpUsername(final String failUsername) {
+        final MemberRegisterRequest member =
+                new MemberRegisterRequest(failUsername, "email@email.com", "12345678aA!");
+
+        final ExtractableResponse<Response> response = 회원_추가(member);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @ParameterizedTest
+    @DisplayName("회원가입 시, 이메일이 기본 이메일 형식이 아닌 경우 예외가 발생한다.")
+    @ValueSource(strings = {"fail", "fail@email"})
+    void failSignUpEmail(final String failEmail) {
+        final MemberRegisterRequest member =
+                new MemberRegisterRequest("zero", failEmail, "12345678aA!");
+
+        final ExtractableResponse<Response> response = 회원_추가(member);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @ParameterizedTest
+    @DisplayName("회원가입 시, 비밀번호가 8 ~ 20자 및 영어, 숫자가 포함되지 않는 경우 예외가 발생한다.")
+    @ValueSource(strings = {"password", "pass123", "passwordPassword12345"})
+    void failSignUpPassword(final String failPassword) {
+        final MemberRegisterRequest member =
+                new MemberRegisterRequest("zero", "email@email.com", failPassword);
+
+        final ExtractableResponse<Response> response = 회원_추가(member);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
     @Test
     @DisplayName("올바르지 않은 토큰으로 마이페이지를 조회할 경우 예외를 발생시킨다.")
     void loginInvalidToken() {
-        final ExtractableResponse<Response> response = RestAssured.given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .auth().oauth2("invalidToken")
-                .when().get("/api/v1/members/me")
-                .then().log().all()
-                .extract();
+        final ExtractableResponse<Response> response = 회원_조회(new TokenResponseDto("invalidToken"));
 
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
     @Test
-    @DisplayName("회원 유저이름 수정")
+    @DisplayName("존재하지 않는 id로 회원 조회를 하려 하는 경우 예외를 발생시킨다.")
+    void loginInvalidId() {
+        //회원 정보
+        final MemberRegisterRequest member =
+                new MemberRegisterRequest("zero", "email@email.com", "12345678aA!");
+
+        //없는 회원 조회
+        final TokenResponseDto token = 회원가입_후_로그인(member);
+        회원_삭제(token);
+        final ExtractableResponse<Response> response = 회원_조회(token);
+
+        //회원조회 실패
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("회원정보를 수정할 수 있다.")
     void updateMember() {
         //회원 생성
         final MemberRegisterRequest member =
                 new MemberRegisterRequest("seungpang", "email@email.com", "12345678aA!");
-        final TokenResponseDto tokenResponseDto = 회원가입_후_로그인(member);
+        final TokenResponseDto token = 회원가입_후_로그인(member);
 
         //회원정보 수정
         final MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("zero");
-        final ExtractableResponse<Response> response = 회원_유저네임_수정(tokenResponseDto, memberUpdateRequest);
+        final ExtractableResponse<Response> response = 회원_유저네임_수정(token, memberUpdateRequest);
 
         //회원정보가 수정됨
         회원정보가_수정됨(response);
     }
 
     @Test
-    @DisplayName("회원 삭제")
+    @DisplayName("올바르지 않은 토큰으로 수정할 경우 예외가 발생한다.")
+    void updateInvalidToken() {
+        //회원생성
+        final MemberRegisterRequest member =
+                new MemberRegisterRequest("zero", "email@email.com", "12345678aA!");
+        회원가입_후_로그인(member);
+
+        //회원정보 수정
+        final MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("kei");
+        final ExtractableResponse<Response> response = 회원_유저네임_수정(new TokenResponseDto("invalidToken"), memberUpdateRequest);
+
+        //회원정보 수정 실패
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @ParameterizedTest
+    @DisplayName("회원수정 시, 회원이름이 2 ~ 20자 및 한글, 영어, 숫자가 아닌 경우 예외가 발생한다.")
+    @ValueSource(strings = {"0", "012345678901234567891", "+특수문자+"})
+    void failUpdateUsername(String failUsername) {
+        //회원생성
+        final MemberRegisterRequest member =
+                new MemberRegisterRequest("zero", "email@email.com", "12345678aA!");
+        final TokenResponseDto token = 회원가입_후_로그인(member);
+
+        //회원정보 수정
+        final MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest(failUsername);
+        final ExtractableResponse<Response> response = 회원_유저네임_수정(token, memberUpdateRequest);
+
+        //회원정보 수정 실패
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("회원을 삭제할 수 있다.")
     void deleteMember() {
         //회원 생성
         final MemberRegisterRequest member =
                 new MemberRegisterRequest("seungpang", "email@email.com", "12345678aA!");
-        final TokenResponseDto tokenResponseDto = 회원가입_후_로그인(member);
+        final TokenResponseDto token = 회원가입_후_로그인(member);
 
         //회원 삭제
-        final ExtractableResponse<Response> response = 회원_삭제(tokenResponseDto, 1L);
+        final ExtractableResponse<Response> response = 회원_삭제(token);
 
         //회원이 삭제됨
         회원_삭제됨(response);
     }
 
-    private void 회원이_추가됨(final ExtractableResponse<Response> response) {
+    @Test
+    @DisplayName("올바르지 않은 토큰으로 삭제할 경우 예외가 발생한다.")
+    void deleteInvalidToken() {
+        //회원 생성
+        final MemberRegisterRequest member =
+                new MemberRegisterRequest("seungpang", "email@email.com", "12345678aA!");
+        회원가입_후_로그인(member);
+
+        //회원 삭제
+        final ExtractableResponse<Response> response = 회원_삭제(new TokenResponseDto("invalidToken"));
+
+        //회원정보 삭제 실패
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원을 삭제하려 하는 경우 예외가 발생한다.")
+    void failDeleteMember() {
+        //회원 생성 및 삭제
+        final MemberRegisterRequest member =
+                new MemberRegisterRequest("seungpang", "email@email.com", "12345678aA!");
+        final TokenResponseDto token = 회원가입_후_로그인(member);
+        회원_삭제(token);
+
+        //없는 회원 삭제
+        final ExtractableResponse<Response> response = 회원_삭제(token);
+
+        //회원 삭제 실패
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    private void 회원이_추가됨(final ExtractableResponse<Response> response, final TokenResponseDto token, final MemberRegisterRequest member) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
         assertThat(response.header("Location")).isNotBlank();
+        회원조회_확인(token, member);
+    }
+
+    private void 회원조회_확인(final TokenResponseDto token, final MemberRegisterRequest member) {
+        final MemberResponseDto findMember = 회원_조회(token).as(MemberResponseDto.class);
+        assertAll(
+                () -> assertThat(findMember.getUsername()).isEqualTo(member.getUsername()),
+                () -> assertThat(findMember.getEmail()).isEqualTo(member.getEmail())
+        );
     }
 
     private void 회원정보가_수정됨(final ExtractableResponse<Response> response) {


### PR DESCRIPTION
### 회원 ATDD
- 회원 추가
   - 회원을 추가하고 검증한다. (회원추가, 단건조회)
   - 이미 가입된 회원이 추가되는 경우 예외를 발생한다.
   - 회원 가입 시, 회원 이름이 2 ~ 20자 및 한글, 영어, 숫자가 아닌 경우 예외가 발생한다.
   - 회원 가입 시, 이메일이 기본 이메일 형식이 아닌 경우 예외가 발생한다.
   - 회원 가입 시, 비밀번호가 8 ~ 20자 및 영어, 숫자가 포함되지 않는 경우 예외가 발생한다.
- 회원 조회
   - 올바르지 않은 토큰으로 마이페이지를 조회할 경우 예외가 발생한다.
   - 존재하지 않는 id로 회원 조회를 하려 하는 경우 예외가 발생한다.
- 회원 수정
   - 회원 정보를 수정할 수 있다.
   - 올바르지 않은 토큰으로 수정할 경우 예외가 발생한다.
   - 회원 수정 시, 회원 이름이 2 ~ 20자 및 한글, 영어, 숫자가 아닌 경우 예외가 발생한다.
- 회원 삭제
   - 회원을 삭제할 수 있다.
   - 올바르지 않은 토큰으로 삭제할 경우 예외가 발생한다.
   - 존재하지 않는 회원을 삭제하려 하는 경우 예외가 발생한다.

확인부탁드립니다!

close #82 