### PR TITLE
feat: 모임 상세보기 페이지 API 요청 및 응답 처리 로직 구현

### DIFF
--- a/frontend/src/components/TeamJoinModalForm.tsx
+++ b/frontend/src/components/TeamJoinModalForm.tsx
@@ -40,7 +40,9 @@ const TeamJoinModalForm = ({ onClickCloseButton }: TeamJoinModalFormProp) => {
     }
   );
 
-  const handleTeamJoinSubmit: React.FormEventHandler<HTMLFormElement> = () => {
+  const handleTeamJoinSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
     if (!REGEX.USERNAME.test(nickname)) {
       alert("닉네임은 한글, 영어, 숫자만 가능합니다.");
       return;

--- a/frontend/src/components/TeamJoinModalForm.tsx
+++ b/frontend/src/components/TeamJoinModalForm.tsx
@@ -7,11 +7,11 @@ import UnderlineInput from "@/components/UnderlineInput";
 
 import { REGEX } from "@/constants";
 
-const TeamJoinModalForm = ({
-  onClickCloseButton,
-}: {
+interface TeamJoinModalFormProp {
   onClickCloseButton: React.MouseEventHandler<HTMLButtonElement>;
-}) => {
+}
+
+const TeamJoinModalForm = ({ onClickCloseButton }: TeamJoinModalFormProp) => {
   const [username, setUsername] = useState("");
 
   return (

--- a/frontend/src/components/TeamJoinModalForm.tsx
+++ b/frontend/src/components/TeamJoinModalForm.tsx
@@ -1,5 +1,9 @@
 import React, { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useMutation } from "react-query";
 import styled from "@emotion/styled";
+
+import appClient from "@/api";
 
 import LineButton from "@/components/LineButton";
 import Modal from "@/components/Modal";
@@ -11,20 +15,51 @@ interface TeamJoinModalFormProp {
   onClickCloseButton: React.MouseEventHandler<HTMLButtonElement>;
 }
 
+interface TeamJoinFormInfo {
+  nickname: string;
+}
+
 const TeamJoinModalForm = ({ onClickCloseButton }: TeamJoinModalFormProp) => {
-  const [username, setUsername] = useState("");
+  const navigate = useNavigate();
+  const { teamId } = useParams();
+  const [nickname, setNickname] = useState("");
+
+  const { mutate: joinTeam } = useMutation(
+    async ({ nickname }: TeamJoinFormInfo) => {
+      const response = await appClient.post(`/teams/${teamId}`, { nickname });
+      return response.data;
+    },
+    {
+      onSuccess: () => {
+        alert("가입 성공!");
+        navigate(`/teams/${teamId}`);
+      },
+      onError: (error) => {
+        console.log(error);
+      },
+    }
+  );
+
+  const handleTeamJoinSubmit: React.FormEventHandler<HTMLFormElement> = () => {
+    if (!REGEX.USERNAME.test(nickname)) {
+      alert("닉네임은 한글, 영어, 숫자만 가능합니다.");
+      return;
+    }
+
+    joinTeam({ nickname });
+  };
 
   return (
     <Modal onClickCloseButton={onClickCloseButton}>
-      <StyledJoinForm>
+      <StyledJoinForm onSubmit={handleTeamJoinSubmit}>
         <p>모임에서 사용할 닉네임을 입력해주세요. (2 ~ 20자)</p>
         <UnderlineInput
-          value={username}
-          setValue={setUsername}
+          value={nickname}
+          setValue={setNickname}
           pattern={REGEX.USERNAME.source}
           errorMessage="한글, 영어, 숫자 / 2 ~ 20자"
         />
-        <LineButton>모임 가입하기</LineButton>
+        <LineButton type="submit">모임 가입하기</LineButton>
       </StyledJoinForm>
     </Modal>
   );

--- a/frontend/src/components/TeamJoinSection.tsx
+++ b/frontend/src/components/TeamJoinSection.tsx
@@ -54,7 +54,7 @@ const TeamJoinSection = () => {
       </StyledRollingpaperListHead>
       <StyledRollingpaperList>
         {dummyRollingpapers.map((rollingpaper) => (
-          <RollingpaperListItem {...rollingpaper} />
+          <RollingpaperListItem key={rollingpaper.id} {...rollingpaper} />
         ))}
       </StyledRollingpaperList>
       {isOpenJoinForm && (

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -132,19 +132,37 @@ export const handlers = [
     return res(ctx.status(200), ctx.json(dummyRollingpapers));
   }),
 
-  // 팀 상세정보 조회
+  // 모임 상세정보 조회
   rest.get("/api/v1/teams/:teamId", (req, res, ctx) => {
     const { teamId } = req.params;
 
-    const teamDetail = {
-      id: teamId,
-      name: "우아한테크코스 4기",
-      description: "우아한테크코스 4기 프론트앤드와 백엔드 모임입니다.",
-      emoji: "😀",
-      color: "#BAE6FF",
-      joined: true,
-    };
+    const teamDetails = [
+      {
+        id: 1,
+        name: "우아한테크코스 4기",
+        description: "우아한테크코스 4기 FE, BE 모임입니다.",
+        emoji: "😀",
+        color: "#FFF598",
+        joined: true,
+      },
+      {
+        id: 2,
+        name: "내 편💕",
+        description: "우아한테크코스 4기 프로젝트 내 편",
+        emoji: "😀",
+        color: "#98DAFF",
+        joined: false,
+      },
+    ];
 
-    return res(ctx.status(200), ctx.json(teamDetail));
+    return res(ctx.status(200), ctx.json(teamDetails[teamId]));
+  }),
+
+  // 모임 가입
+  rest.post("/api/v1/teams/:teamId", (req, res, ctx) => {
+    const { teamId } = req.params;
+    const { nickname } = req.body;
+
+    return res(ctx.status(204));
   }),
 ];

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -104,7 +104,7 @@ export const handlers = [
 
   // 롤링페이퍼 목록 조회
   rest.get("/api/v1/teams/:teamId/rollingpapers", (req, res, ctx) => {
-    const { teamId, rollingpaperId } = req.params;
+    const { teamId } = req.params;
 
     const dummyRollingpapers = [
       {
@@ -130,5 +130,21 @@ export const handlers = [
     ];
 
     return res(ctx.status(200), ctx.json(dummyRollingpapers));
+  }),
+
+  // 팀 상세정보 조회
+  rest.get("/api/v1/teams/:teamId", (req, res, ctx) => {
+    const { teamId } = req.params;
+
+    const teamDetail = {
+      id: teamId,
+      name: "우아한테크코스 4기",
+      description: "우아한테크코스 4기 프론트앤드와 백엔드 모임입니다.",
+      emoji: "😀",
+      color: "#BAE6FF",
+      joined: true,
+    };
+
+    return res(ctx.status(200), ctx.json(teamDetail));
   }),
 ];

--- a/frontend/src/mocks/handlers.js
+++ b/frontend/src/mocks/handlers.js
@@ -101,4 +101,34 @@ export const handlers = [
 
     return res(ctx.status(201));
   }),
+
+  // 롤링페이퍼 목록 조회
+  rest.get("/api/v1/teams/:teamId/rollingpapers", (req, res, ctx) => {
+    const { teamId, rollingpaperId } = req.params;
+
+    const dummyRollingpapers = [
+      {
+        id: 1,
+        title: "우테코 고마워",
+        to: "우아한테크코스",
+      },
+      {
+        id: 2,
+        title: "소피아 생일 축하해 🎉",
+        to: "소피아",
+      },
+      {
+        id: 3,
+        title: "오늘의 내 편 데일리 미팅",
+        to: "내 편",
+      },
+      {
+        id: 4,
+        title: "이번 주 우리의 한 마디",
+        to: "우아한테크코스",
+      },
+    ];
+
+    return res(ctx.status(200), ctx.json(dummyRollingpapers));
+  }),
 ];

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -8,6 +8,15 @@ import appClient from "@/api";
 import RollingpaperList from "@/components/RollingpaperList";
 import TeamJoinSection from "@/components/TeamJoinSection";
 
+interface Team {
+  id: number;
+  name: string;
+  description: string;
+  emoji: string;
+  color: string;
+  joined: boolean;
+}
+
 interface Rollingpaper {
   id: number;
   title: string;
@@ -19,6 +28,14 @@ const TeamDetailPage = () => {
   const navigate = useNavigate();
 
   const {
+    isLoading: isLoadingTeamDetail,
+    isError: isErrorTeamDetail,
+    data: TeamDetail,
+  } = useQuery<Team>(["team"], () =>
+    appClient.get(`/teams/${teamId}`).then((response) => response.data)
+  );
+
+  const {
     isLoading: isLoadingGetTeamRollingpaperList,
     isError: isErrorGetTeamRollingpaperList,
     data: rollingpaperList,
@@ -28,11 +45,16 @@ const TeamDetailPage = () => {
       .then((response) => response.data)
   );
 
-  if (isLoadingGetTeamRollingpaperList) {
+  if (isLoadingTeamDetail || isLoadingGetTeamRollingpaperList) {
     return <div>로딩중</div>;
   }
 
-  if (isErrorGetTeamRollingpaperList || !rollingpaperList) {
+  if (
+    isErrorTeamDetail ||
+    !TeamDetail ||
+    isErrorGetTeamRollingpaperList ||
+    !rollingpaperList
+  ) {
     return <div>에러</div>;
   }
 
@@ -43,8 +65,11 @@ const TeamDetailPage = () => {
         title="테스트"
         description="테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ"
       />
-      <RollingpaperList rollingpapers={rollingpaperList} />
-      <TeamJoinSection />
+      {!TeamDetail.joined ? (
+        <TeamJoinSection />
+      ) : (
+        <RollingpaperList rollingpapers={rollingpaperList} />
+      )}
     </StyledMain>
   );
 };

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -61,9 +61,10 @@ const TeamDetailPage = () => {
   return (
     <StyledMain>
       <TeamDescriptionBox
-        emoji="💕"
-        title="테스트"
-        description="테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ"
+        emoji={teamDetail.emoji}
+        name={teamDetail.name}
+        description={teamDetail.description}
+        color={teamDetail.color}
       />
       {teamDetail.joined ? (
         <RollingpaperList rollingpapers={rollingpaperList} />
@@ -74,20 +75,27 @@ const TeamDetailPage = () => {
   );
 };
 
-interface TeamDescriptionBoxProp {
-  emoji: string;
-  title: string;
+interface TeamDescriptionBoxProps {
+  name: string;
   description: string;
+  emoji: string;
+  color: string;
 }
 
+type StyledTeamDescriptionContainerProps = Pick<
+  TeamDescriptionBoxProps,
+  "color"
+>;
+
 const TeamDescriptionBox = ({
-  emoji,
-  title,
+  name,
   description,
-}: TeamDescriptionBoxProp) => {
+  emoji,
+  color,
+}: TeamDescriptionBoxProps) => {
   return (
-    <StyledTeamDescriptionContainer>
-      <h3>{`${emoji} ${title}`}</h3>
+    <StyledTeamDescriptionContainer color={color}>
+      <h3>{`${emoji} ${name}`}</h3>
       <p>{description}</p>
     </StyledTeamDescriptionContainer>
   );
@@ -103,12 +111,12 @@ const StyledMain = styled.main`
   padding: 28px 0;
 `;
 
-const StyledTeamDescriptionContainer = styled.div`
+const StyledTeamDescriptionContainer = styled.div<StyledTeamDescriptionContainerProps>`
   width: 80%;
 
   padding: 28px 16px;
   border-radius: 8px;
-  background-color: ${({ theme }) => theme.colors.YELLOW_200};
+  background-color: ${({ color }) => `${color}AB`};
 
   h3 {
     font-size: 32px;

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useQuery } from "react-query";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import styled from "@emotion/styled";
 
 import appClient from "@/api";
@@ -25,7 +25,6 @@ interface Rollingpaper {
 
 const TeamDetailPage = () => {
   const { teamId } = useParams();
-  const navigate = useNavigate();
 
   const {
     isLoading: isLoadingTeamDetail,

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -30,7 +30,7 @@ const TeamDetailPage = () => {
   const {
     isLoading: isLoadingTeamDetail,
     isError: isErrorTeamDetail,
-    data: TeamDetail,
+    data: teamDetail,
   } = useQuery<Team>(["team"], () =>
     appClient.get(`/teams/${teamId}`).then((response) => response.data)
   );
@@ -51,7 +51,7 @@ const TeamDetailPage = () => {
 
   if (
     isErrorTeamDetail ||
-    !TeamDetail ||
+    !teamDetail ||
     isErrorGetTeamRollingpaperList ||
     !rollingpaperList
   ) {
@@ -65,10 +65,10 @@ const TeamDetailPage = () => {
         title="테스트"
         description="테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ"
       />
-      {!TeamDetail.joined ? (
-        <TeamJoinSection />
-      ) : (
+      {teamDetail.joined ? (
         <RollingpaperList rollingpapers={rollingpaperList} />
+      ) : (
+        <TeamJoinSection />
       )}
     </StyledMain>
   );

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -8,6 +8,8 @@ import appClient from "@/api";
 import RollingpaperList from "@/components/RollingpaperList";
 import TeamJoinSection from "@/components/TeamJoinSection";
 
+import { Rollingpaper } from "@/types";
+
 interface Team {
   id: number;
   name: string;
@@ -15,12 +17,6 @@ interface Team {
   emoji: string;
   color: string;
   joined: boolean;
-}
-
-interface Rollingpaper {
-  id: number;
-  title: string;
-  to: string;
 }
 
 const TeamDetailPage = () => {
@@ -38,7 +34,7 @@ const TeamDetailPage = () => {
     isLoading: isLoadingGetTeamRollingpaperList,
     isError: isErrorGetTeamRollingpaperList,
     data: rollingpaperList,
-  } = useQuery<Rollingpaper[]>(["rollingpaperList"], () =>
+  } = useQuery<Omit<Rollingpaper, "messages">[]>(["rollingpaperList"], () =>
     appClient
       .get(`/teams/${teamId}/rollingpapers`)
       .then((response) => response.data)

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -119,6 +119,7 @@ const StyledTeamDescriptionContainer = styled.div<StyledTeamDescriptionContainer
 
   h3 {
     font-size: 32px;
+    margin-bottom: 10px;
   }
 `;
 

--- a/frontend/src/pages/TeamDetailPage.tsx
+++ b/frontend/src/pages/TeamDetailPage.tsx
@@ -1,35 +1,40 @@
 import React from "react";
+import { useQuery } from "react-query";
 import { useParams, useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
+
+import appClient from "@/api";
+
 import RollingpaperList from "@/components/RollingpaperList";
 import TeamJoinSection from "@/components/TeamJoinSection";
 
-const dummyRollingpapers = [
-  {
-    id: 1,
-    title: "우테코 고마워",
-    to: "우아한테크코스",
-  },
-  {
-    id: 2,
-    title: "소피아 생일 축하해 🎉",
-    to: "소피아",
-  },
-  {
-    id: 3,
-    title: "오늘의 내 편 데일리 미팅",
-    to: "내 편",
-  },
-  {
-    id: 4,
-    title: "이번 주 우리의 한 마디",
-    to: "우아한테크코스",
-  },
-];
+interface Rollingpaper {
+  id: number;
+  title: string;
+  to: string;
+}
 
 const TeamDetailPage = () => {
   const { teamId } = useParams();
   const navigate = useNavigate();
+
+  const {
+    isLoading: isLoadingGetTeamRollingpaperList,
+    isError: isErrorGetTeamRollingpaperList,
+    data: rollingpaperList,
+  } = useQuery<Rollingpaper[]>(["rollingpaperList"], () =>
+    appClient
+      .get(`/teams/${teamId}/rollingpapers`)
+      .then((response) => response.data)
+  );
+
+  if (isLoadingGetTeamRollingpaperList) {
+    return <div>로딩중</div>;
+  }
+
+  if (isErrorGetTeamRollingpaperList || !rollingpaperList) {
+    return <div>에러</div>;
+  }
 
   return (
     <StyledMain>
@@ -38,6 +43,7 @@ const TeamDetailPage = () => {
         title="테스트"
         description="테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ테스트용 모임 설명이다다ㅏㅏㅏㅏㅏㅏ"
       />
+      <RollingpaperList rollingpapers={rollingpaperList} />
       <TeamJoinSection />
     </StyledMain>
   );


### PR DESCRIPTION
## 구현 사항
- 모임 상세보기 페이지에서 모임 단건 조회 요청(GET)을 보내고 응답을 처리한다.
- 모임 상세보기 페이지에서 모임의 롤링페이퍼 목록 조회 요청(GET)을 보내고 응답을 처리한다.
- 모임 상세보기 페이지에서 모임 가입 요청(POST)을 보내고 응답을 처리한다.
- 모임 단건 조회 요청(GET) mocking 코드를 작성한다.
- 모임의 롤링페이퍼 목록 조회 요청(GET) mocking 코드를 작성한다.
- 모임 가입 요청(POST) mocking 코드를 작성한다.

close #119 