### PR TITLE
feat: 롤링페이퍼 인수 테스트 작성

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/MemberController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/MemberController.java
@@ -6,6 +6,8 @@ import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
 import com.woowacourse.naepyeon.controller.dto.MemberUpdateRequest;
 import com.woowacourse.naepyeon.service.MemberService;
 import com.woowacourse.naepyeon.service.dto.MemberResponseDto;
+import java.net.URI;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -15,9 +17,6 @@ import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import javax.validation.Valid;
-import java.net.URI;
 
 @RestController
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/RollingpaperController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/RollingpaperController.java
@@ -35,8 +35,7 @@ public class RollingpaperController {
             @RequestBody @Valid final RollingpaperCreateRequest rollingpaperCreateRequest) {
         final Long rollingpaperId = rollingpaperService.createRollingpaper(rollingpaperCreateRequest.getTitle(), teamId,
                 loginMemberRequest.getId(), rollingpaperCreateRequest.getAddresseeId());
-        return ResponseEntity.created(
-                        URI.create("/api/v1/teams/" + teamId + "/rollingpapers/" + rollingpaperId))
+        return ResponseEntity.created(URI.create("/api/v1/teams/" + teamId + "/rollingpapers/" + rollingpaperId))
                 .body(new CreateResponse(rollingpaperId));
     }
 
@@ -44,8 +43,8 @@ public class RollingpaperController {
     public ResponseEntity<RollingpaperResponseDto> findRollingpaper(
             @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
             @PathVariable final Long teamId, @PathVariable final Long rollingpaperId) {
-        final RollingpaperResponseDto rollingpaperResponseDto = rollingpaperService.findById(rollingpaperId, teamId,
-                loginMemberRequest.getId());
+        final RollingpaperResponseDto rollingpaperResponseDto =
+                rollingpaperService.findById(rollingpaperId, teamId, loginMemberRequest.getId());
         return ResponseEntity.ok(rollingpaperResponseDto);
     }
 
@@ -62,8 +61,8 @@ public class RollingpaperController {
     public ResponseEntity<RollingpapersResponseDto> findMemberRollingpapers(
             @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
             @PathVariable final Long teamId) {
-        final RollingpapersResponseDto rollingpapersResponseDto = rollingpaperService.findByMemberId(teamId,
-                loginMemberRequest.getId());
+        final RollingpapersResponseDto rollingpapersResponseDto =
+                rollingpaperService.findByMemberId(teamId, loginMemberRequest.getId());
         return ResponseEntity.ok(rollingpapersResponseDto);
     }
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/RollingpaperController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/RollingpaperController.java
@@ -1,6 +1,8 @@
 package com.woowacourse.naepyeon.controller;
 
+import com.woowacourse.naepyeon.controller.auth.AuthenticationPrincipal;
 import com.woowacourse.naepyeon.controller.dto.CreateResponse;
+import com.woowacourse.naepyeon.controller.dto.LoginMemberRequest;
 import com.woowacourse.naepyeon.controller.dto.RollingpaperCreateRequest;
 import com.woowacourse.naepyeon.controller.dto.RollingpaperUpdateRequest;
 import com.woowacourse.naepyeon.service.RollingpaperService;
@@ -28,38 +30,59 @@ public class RollingpaperController {
 
     @PostMapping
     public ResponseEntity<CreateResponse> createRollingpaper(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
             @PathVariable final Long teamId,
             @RequestBody @Valid final RollingpaperCreateRequest rollingpaperCreateRequest) {
         final Long rollingpaperId = rollingpaperService.createRollingpaper(rollingpaperCreateRequest.getTitle(), teamId,
-                rollingpaperCreateRequest.getMemberId());
+                loginMemberRequest.getId(), rollingpaperCreateRequest.getAddresseeId());
         return ResponseEntity.created(
                         URI.create("/api/v1/teams/" + teamId + "/rollingpapers/" + rollingpaperId))
                 .body(new CreateResponse(rollingpaperId));
     }
 
     @GetMapping("/{rollingpaperId}")
-    public ResponseEntity<RollingpaperResponseDto> findRollingpaper(@PathVariable final Long teamId,
-                                                                    @PathVariable final Long rollingpaperId) {
-        final RollingpaperResponseDto rollingpaper = rollingpaperService.findById(rollingpaperId);
-        return ResponseEntity.ok(rollingpaper);
+    public ResponseEntity<RollingpaperResponseDto> findRollingpaper(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
+            @PathVariable final Long teamId, @PathVariable final Long rollingpaperId) {
+        final RollingpaperResponseDto rollingpaperResponseDto = rollingpaperService.findById(rollingpaperId, teamId,
+                loginMemberRequest.getId());
+        return ResponseEntity.ok(rollingpaperResponseDto);
     }
 
     @GetMapping
-    public ResponseEntity<RollingpapersResponseDto> findRollingpapers(@PathVariable final Long teamId) {
-        final RollingpapersResponseDto rollingpapersResponseDto = rollingpaperService.findByTeamId(teamId);
+    public ResponseEntity<RollingpapersResponseDto> findTeamRollingpapers(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
+            @PathVariable final Long teamId) {
+        final RollingpapersResponseDto rollingpapersResponseDto = rollingpaperService.findByTeamId(teamId,
+                loginMemberRequest.getId());
+        return ResponseEntity.ok(rollingpapersResponseDto);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<RollingpapersResponseDto> findMemberRollingpapers(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
+            @PathVariable final Long teamId) {
+        final RollingpapersResponseDto rollingpapersResponseDto = rollingpaperService.findByMemberId(teamId,
+                loginMemberRequest.getId());
         return ResponseEntity.ok(rollingpapersResponseDto);
     }
 
     @PutMapping("/{rollingpaperId}")
-    public ResponseEntity<Void> updateRollingpaper(@PathVariable final Long rollingpaperId,
-                                                   @RequestBody final RollingpaperUpdateRequest updateRequest) {
-        rollingpaperService.updateTitle(rollingpaperId, updateRequest.getTitle());
+    public ResponseEntity<Void> updateRollingpaper(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
+            @PathVariable final Long teamId,
+            @PathVariable final Long rollingpaperId,
+            @RequestBody final RollingpaperUpdateRequest updateRequest) {
+        rollingpaperService.updateTitle(rollingpaperId, updateRequest.getTitle(), teamId, loginMemberRequest.getId());
         return ResponseEntity.noContent().build();
     }
 
     @DeleteMapping("/{rollingpaperId}")
-    public ResponseEntity<Void> deleteRollingpaper(@PathVariable final Long rollingpaperId) {
-        rollingpaperService.deleteRollingpaper(rollingpaperId);
+    public ResponseEntity<Void> deleteRollingpaper(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
+            @PathVariable final Long teamId,
+            @PathVariable final Long rollingpaperId) {
+        rollingpaperService.deleteRollingpaper(rollingpaperId, teamId, loginMemberRequest.getId());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/dto/RollingpaperCreateRequest.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/dto/RollingpaperCreateRequest.java
@@ -14,5 +14,5 @@ public class RollingpaperCreateRequest {
     @NotBlank(message = "1002:롤링페이퍼 제목은 공백일 수 없습니다.")
     private String title;
 
-    private Long memberId;
+    private Long addresseeId;
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/NotFoundMemberException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/NotFoundMemberException.java
@@ -6,7 +6,7 @@ public final class NotFoundMemberException extends NaePyeonException {
 
     public NotFoundMemberException(final Long memberId) {
         super(
-                String.format("해당 회원가 존재하지 않습니다. id={%d}", memberId),
+                String.format("해당 회원이 존재하지 않습니다. id={%d}", memberId),
                 "올바르지 않은 회원입니다.",
                 HttpStatus.NOT_FOUND,
                 "3000"

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/NotFoundTeamMemberException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/NotFoundTeamMemberException.java
@@ -1,0 +1,15 @@
+package com.woowacourse.naepyeon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public final class NotFoundTeamMemberException extends NaePyeonException {
+
+    public NotFoundTeamMemberException(final Long memberId) {
+        super(
+                String.format("해당 모임에 가입되지 않은 회원입니다. memberId={%d}", memberId),
+                "해당 모임에 가입되지 않은 회원입니다.",
+                HttpStatus.NOT_FOUND,
+                "4012"
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/UncertificationTeamMemberException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/UncertificationTeamMemberException.java
@@ -1,0 +1,15 @@
+package com.woowacourse.naepyeon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public final class UncertificationTeamMemberException extends NaePyeonException {
+
+    public UncertificationTeamMemberException(final Long teamId) {
+        super(
+                String.format("해당 모임에 가입해야 가능한 작업입니다. teamId={%d}", teamId),
+                "해당 모임에 가입해야 가능한 작업입니다.",
+                HttpStatus.FORBIDDEN,
+                "4013"
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaRollingpaperRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaRollingpaperRepository.java
@@ -26,6 +26,11 @@ public class JpaRollingpaperRepository implements RollingpaperRepository {
     }
 
     @Override
+    public List<Rollingpaper> findByMemberId(final Long memberId) {
+        return rollingpaperJpaDao.findByMemberId(memberId);
+    }
+
+    @Override
     public List<Rollingpaper> findByTeamId(final Long teamId) {
         return rollingpaperJpaDao.findByTeamId(teamId);
     }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/RollingpaperRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/RollingpaperRepository.java
@@ -10,6 +10,8 @@ public interface RollingpaperRepository {
 
     Optional<Rollingpaper> findById(final Long rollingpaperId);
 
+    List<Rollingpaper> findByMemberId(final Long memberId);
+
     List<Rollingpaper> findByTeamId(final Long teamId);
 
     void update(final Long rollingpaperId, final String newTitle);

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/RollingpaperJpaDao.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/RollingpaperJpaDao.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RollingpaperJpaDao extends JpaRepository<Rollingpaper, Long> {
 
     List<Rollingpaper> findByTeamId(final Long teamId);
+
+    List<Rollingpaper> findByMemberId(final Long memberId);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
@@ -54,11 +54,11 @@ public class RollingpaperService {
 
     @Transactional(readOnly = true)
     public RollingpaperResponseDto findById(final Long rollingpaperId, final Long teamId, final Long loginMemberId) {
+        final Rollingpaper rollingpaper = rollingpaperRepository.findById(rollingpaperId)
+                .orElseThrow(() -> new NotFoundRollingpaperException(rollingpaperId));
         if (checkMemberNotIncludedTeam(teamId, loginMemberId)) {
             throw new UncertificationTeamMemberException(teamId);
         }
-        final Rollingpaper rollingpaper = rollingpaperRepository.findById(rollingpaperId)
-                .orElseThrow(() -> new NotFoundRollingpaperException(rollingpaperId));
         return new RollingpaperResponseDto(
                 rollingpaperId,
                 rollingpaper.getTitle(),

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
@@ -32,8 +32,8 @@ public class RollingpaperService {
     private final TeamMemberRepository teamMemberRepository;
     private final MemberRepository memberRepository;
 
-    public Long createRollingpaper(final String title, final Long teamId, final Long loginMemberId,
-                                   final Long memberId) {
+    public Long createRollingpaper(final String title, final Long teamId,
+                                   final Long loginMemberId, final Long memberId) {
         final Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new NotFoundTeamException(teamId));
         final Member member = memberRepository.findById(memberId)

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
@@ -6,9 +6,12 @@ import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.exception.NotFoundMemberException;
 import com.woowacourse.naepyeon.exception.NotFoundRollingpaperException;
 import com.woowacourse.naepyeon.exception.NotFoundTeamException;
+import com.woowacourse.naepyeon.exception.NotFoundTeamMemberException;
+import com.woowacourse.naepyeon.exception.UncertificationTeamMemberException;
+import com.woowacourse.naepyeon.repository.MemberRepository;
 import com.woowacourse.naepyeon.repository.RollingpaperRepository;
-import com.woowacourse.naepyeon.repository.jpa.MemberJpaDao;
-import com.woowacourse.naepyeon.repository.jpa.TeamJpaDao;
+import com.woowacourse.naepyeon.repository.TeamMemberRepository;
+import com.woowacourse.naepyeon.repository.TeamRepository;
 import com.woowacourse.naepyeon.service.dto.RollingpaperPreviewResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpaperResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpapersResponseDto;
@@ -25,20 +28,35 @@ public class RollingpaperService {
 
     private final RollingpaperRepository rollingpaperRepository;
     private final MessageService messageService;
-    private final TeamJpaDao teamJpaDao; //todo: #20 머지 후 teamRepository로 변경
-    private final MemberJpaDao memberJpaDao; //todo: #19 머지 후 memberRepository로 변경
+    private final TeamRepository teamRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final MemberRepository memberRepository;
 
-    public Long createRollingpaper(final String title, final Long teamId, final Long memberId) {
-        final Team team = teamJpaDao.findById(teamId)
+    public Long createRollingpaper(final String title, final Long teamId, final Long loginMemberId,
+                                   final Long memberId) {
+        final Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new NotFoundTeamException(teamId));
-        final Member member = memberJpaDao.findById(memberId)
+        final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundMemberException(memberId));
+        validateTeamAndMember(teamId, loginMemberId, memberId);
         final Rollingpaper rollingpaper = new Rollingpaper(title, team, member);
         return rollingpaperRepository.save(rollingpaper);
     }
 
+    private void validateTeamAndMember(final Long teamId, final Long loginMemberId, final Long memberId) {
+        if (checkMemberNotIncludedTeam(teamId, loginMemberId)) {
+            throw new UncertificationTeamMemberException(teamId);
+        }
+        if (checkMemberNotIncludedTeam(teamId, memberId)) {
+            throw new NotFoundTeamMemberException(memberId);
+        }
+    }
+
     @Transactional(readOnly = true)
-    public RollingpaperResponseDto findById(final Long rollingpaperId) {
+    public RollingpaperResponseDto findById(final Long rollingpaperId, final Long teamId, final Long loginMemberId) {
+        if (checkMemberNotIncludedTeam(teamId, loginMemberId)) {
+            throw new UncertificationTeamMemberException(teamId);
+        }
         final Rollingpaper rollingpaper = rollingpaperRepository.findById(rollingpaperId)
                 .orElseThrow(() -> new NotFoundRollingpaperException(rollingpaperId));
         return new RollingpaperResponseDto(
@@ -50,7 +68,10 @@ public class RollingpaperService {
     }
 
     @Transactional(readOnly = true)
-    public RollingpapersResponseDto findByTeamId(final Long teamId) {
+    public RollingpapersResponseDto findByTeamId(final Long teamId, final Long loginMemberId) {
+        if (checkMemberNotIncludedTeam(teamId, loginMemberId)) {
+            throw new UncertificationTeamMemberException(teamId);
+        }
         final List<Rollingpaper> rollingpapers = rollingpaperRepository.findByTeamId(teamId);
         final List<RollingpaperPreviewResponseDto> rollingpaperPreviewResponseDtos = rollingpapers.stream()
                 .map(RollingpaperPreviewResponseDto::from)
@@ -58,11 +79,35 @@ public class RollingpaperService {
         return new RollingpapersResponseDto(rollingpaperPreviewResponseDtos);
     }
 
-    public void updateTitle(final Long rollingpaperId, final String newTitle) {
+    @Transactional(readOnly = true)
+    public RollingpapersResponseDto findByMemberId(final Long teamId, final Long loginMemberId) {
+        final List<Rollingpaper> rollingpapers = rollingpaperRepository.findByMemberId(loginMemberId);
+        final List<RollingpaperPreviewResponseDto> rollingpaperPreviewResponseDtos = rollingpapers.stream()
+                .map(RollingpaperPreviewResponseDto::from)
+                .collect(Collectors.toUnmodifiableList());
+        return new RollingpapersResponseDto(rollingpaperPreviewResponseDtos);
+    }
+
+    public void updateTitle(final Long rollingpaperId, final String newTitle, final Long teamId,
+                            final Long loginMemberId) {
+        if (checkMemberNotIncludedTeam(teamId, loginMemberId)) {
+            throw new UncertificationTeamMemberException(teamId);
+        }
         rollingpaperRepository.update(rollingpaperId, newTitle);
     }
 
-    public void deleteRollingpaper(final Long rollingpaperId) {
+    public void deleteRollingpaper(final Long rollingpaperId, final Long teamId, final Long loginMemberId) {
+        if (checkMemberNotIncludedTeam(teamId, loginMemberId)) {
+            throw new UncertificationTeamMemberException(teamId);
+        }
         rollingpaperRepository.delete(rollingpaperId);
+    }
+
+    private boolean checkMemberNotIncludedTeam(final Long teamId, final Long memberId) {
+        final List<Long> joinedTeamsId = teamMemberRepository.findTeamsByJoinedMemberId(memberId)
+                .stream()
+                .map(Team::getId)
+                .collect(Collectors.toUnmodifiableList());
+        return !joinedTeamsId.contains(teamId);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
@@ -4,6 +4,8 @@ import com.woowacourse.naepyeon.controller.dto.CreateResponse;
 import com.woowacourse.naepyeon.controller.dto.JoinTeamMemberRequest;
 import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
 import com.woowacourse.naepyeon.controller.dto.MemberUpdateRequest;
+import com.woowacourse.naepyeon.controller.dto.RollingpaperCreateRequest;
+import com.woowacourse.naepyeon.controller.dto.RollingpaperUpdateRequest;
 import com.woowacourse.naepyeon.controller.dto.TeamRequest;
 import com.woowacourse.naepyeon.controller.dto.TokenRequest;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
@@ -133,5 +135,32 @@ public class AcceptanceFixture {
 
     public static ExtractableResponse<Response> 가입한_모임_조회(final TokenResponseDto tokenResponseDto) {
         return get(tokenResponseDto, "/api/v1/teams/me");
+    }
+
+    public static ExtractableResponse<Response> 회원_롤링페이퍼_생성(final TokenResponseDto tokenResponseDto,
+                                                            final Long teamId,
+                                                            final RollingpaperCreateRequest rollingpaperCreateRequest) {
+        return post(tokenResponseDto, rollingpaperCreateRequest, "/api/v1/teams/" + teamId + "/rollingpapers");
+    }
+
+    public static ExtractableResponse<Response> 롤링페이퍼_내꺼_조회(final TokenResponseDto tokenResponseDto,
+                                                            final Long teamId) {
+        return get(tokenResponseDto, "/api/v1/teams/" + teamId + "/rollingpapers/me");
+    }
+
+    public static ExtractableResponse<Response> 롤링페이퍼_특정_조회(final TokenResponseDto tokenResponseDto,
+                                                            final Long teamId, final Long rollingpaperId) {
+        return get(tokenResponseDto, "/api/v1/teams/" + teamId + "/rollingpapers/" + rollingpaperId);
+    }
+
+    public static ExtractableResponse<Response> 모임_모든_회원들_롤링페이퍼_조회(final TokenResponseDto tokenResponseDto,
+                                                                   final Long teamId) {
+        return get(tokenResponseDto, "/api/v1/teams/" + teamId + "/rollingpapers");
+    }
+
+    public static ExtractableResponse<Response> 롤링페이퍼_제목_수정(final TokenResponseDto tokenResponseDto, final Long teamId,
+                                                            final Long rollingpaperId,
+                                                            final RollingpaperUpdateRequest updateRequest) {
+        return put(tokenResponseDto, updateRequest, "/api/v1/teams/" + teamId + "/rollingpapers/" + rollingpaperId);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
@@ -143,7 +143,7 @@ public class AcceptanceFixture {
         return post(tokenResponseDto, rollingpaperCreateRequest, "/api/v1/teams/" + teamId + "/rollingpapers");
     }
 
-    public static ExtractableResponse<Response> 롤링페이퍼_내꺼_조회(final TokenResponseDto tokenResponseDto,
+    public static ExtractableResponse<Response> 나의_롤링페이퍼_조회(final TokenResponseDto tokenResponseDto,
                                                             final Long teamId) {
         return get(tokenResponseDto, "/api/v1/teams/" + teamId + "/rollingpapers/me");
     }

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/MemberAcceptanceTest.java
@@ -1,5 +1,14 @@
 package com.woowacourse.naepyeon.acceptance;
 
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.로그인_응답;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_삭제;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_유저네임_수정;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_조회;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_추가;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원가입_후_로그인;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
 import com.woowacourse.naepyeon.controller.dto.MemberUpdateRequest;
 import com.woowacourse.naepyeon.controller.dto.TokenRequest;
@@ -12,15 +21,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
-
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.로그인_응답;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_삭제;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_유저네임_수정;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_조회;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_추가;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원가입_후_로그인;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 class MemberAcceptanceTest extends AcceptanceTest {
 
@@ -138,7 +138,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
 
         //회원정보 수정
         final MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("kei");
-        final ExtractableResponse<Response> response = 회원_유저네임_수정(new TokenResponseDto("invalidToken"), memberUpdateRequest);
+        final ExtractableResponse<Response> response = 회원_유저네임_수정(new TokenResponseDto("invalidToken"),
+                memberUpdateRequest);
 
         //회원정보 수정 실패
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
@@ -207,7 +208,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
     }
 
-    private void 회원이_추가됨(final ExtractableResponse<Response> response, final TokenResponseDto token, final MemberRegisterRequest member) {
+    private void 회원이_추가됨(final ExtractableResponse<Response> response, final TokenResponseDto token,
+                         final MemberRegisterRequest member) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
         assertThat(response.header("Location")).isNotBlank();
         회원조회_확인(token, member);

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
@@ -108,6 +108,25 @@ public class RollingpaperAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
+    @DisplayName("모임에 속하지 않은 사람이 해당 모임에서 롤링페이퍼를 생성하는 경우 예외를 발생시킨다.")
+    void createRollingpaperWithAnonymous() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
+        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
+
+        // 모임에 가입하지는 않음
+        final TokenResponseDto tokenResponseDto3 = 회원가입_후_로그인(member3);
+
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final ExtractableResponse<Response> response = 회원_롤링페이퍼_생성(tokenResponseDto3, teamId,
+                rollingpaperCreateRequest);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
     @DisplayName("특정 모임의 회원들 전체가 받은 롤링페이퍼 목록을 조회한다.")
     void findRollingpapersWithTeam() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
@@ -1,6 +1,6 @@
 package com.woowacourse.naepyeon.acceptance;
 
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.롤링페이퍼_내꺼_조회;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.나의_롤링페이퍼_조회;
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.롤링페이퍼_제목_수정;
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.롤링페이퍼_특정_조회;
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_가입;
@@ -51,13 +51,13 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
 
         // when: seungpang이 yxxnghwan에게 롤링페이퍼 작성
-        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이알렉스", 2L);
         final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
                 .as(CreateResponse.class)
                 .getId();
 
         // then: yxxnghwan이 받은 롤링페이퍼 조회
-        final List<Long> actual = 롤링페이퍼_내꺼_조회(tokenResponseDto2, teamId).as(RollingpapersResponseDto.class)
+        final List<Long> actual = 나의_롤링페이퍼_조회(tokenResponseDto2, teamId).as(RollingpapersResponseDto.class)
                 .getRollingpapers()
                 .stream()
                 .map(RollingpaperPreviewResponseDto::getId)
@@ -87,7 +87,7 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
                 .getId();
 
         // then: yxxnghwan이 받은 롤링페이퍼 조회
-        final List<Long> actual = 롤링페이퍼_내꺼_조회(tokenResponseDto2, teamId).as(RollingpapersResponseDto.class)
+        final List<Long> actual = 나의_롤링페이퍼_조회(tokenResponseDto2, teamId).as(RollingpapersResponseDto.class)
                 .getRollingpapers()
                 .stream()
                 .map(RollingpaperPreviewResponseDto::getId)
@@ -117,13 +117,10 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
         final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
                 .getId();
 
-        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
-        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
-
         // 모임에 가입하지는 않음
         final TokenResponseDto tokenResponseDto3 = 회원가입_후_로그인(member3);
 
-        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이승팡", 1L);
         final ExtractableResponse<Response> response = 회원_롤링페이퍼_생성(tokenResponseDto3, teamId,
                 rollingpaperCreateRequest);
 
@@ -196,15 +193,14 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
 
-        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이알렉스", 2L);
         final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
                 .as(CreateResponse.class)
                 .getId();
 
         final String expected = "알고리즘좀그만해!";
         final RollingpaperUpdateRequest rollingpaperUpdateRequest = new RollingpaperUpdateRequest("알고리즘좀그만해!");
-        final ExtractableResponse<Response> response = 롤링페이퍼_제목_수정(tokenResponseDto1, teamId, rollingpaperId,
-                rollingpaperUpdateRequest);
+        롤링페이퍼_제목_수정(tokenResponseDto1, teamId, rollingpaperId, rollingpaperUpdateRequest);
 
         final String actual = 롤링페이퍼_특정_조회(tokenResponseDto1, teamId, rollingpaperId).as(RollingpaperResponseDto.class)
                 .getTitle();
@@ -221,13 +217,13 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
 
-        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이알렉스", 2L);
         final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
                 .as(CreateResponse.class)
                 .getId();
 
         final RollingpaperUpdateRequest rollingpaperUpdateRequest =
-                new RollingpaperUpdateRequest("케이. 사실은 나도 알고리즘 좋아하는데 숨기는 거였어...");
+                new RollingpaperUpdateRequest("알렉스. 사실은 나도 케이만큼 알고리즘 좋아하는데 숨기는 거였어...");
         final ExtractableResponse<Response> response = 롤링페이퍼_제목_수정(tokenResponseDto1, teamId, rollingpaperId,
                 rollingpaperUpdateRequest);
 
@@ -247,12 +243,11 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
         // 모임에 가입하지는 않음
         final TokenResponseDto tokenResponseDto3 = 회원가입_후_로그인(member3);
 
-        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이알렉스", 2L);
         final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
                 .as(CreateResponse.class)
                 .getId();
 
-        final String expected = "알고리즘좀그만해!";
         final RollingpaperUpdateRequest rollingpaperUpdateRequest = new RollingpaperUpdateRequest("알고리즘좀그만해!");
         final ExtractableResponse<Response> response = 롤링페이퍼_제목_수정(tokenResponseDto3, teamId, rollingpaperId,
                 rollingpaperUpdateRequest);

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
@@ -1,0 +1,235 @@
+package com.woowacourse.naepyeon.acceptance;
+
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.롤링페이퍼_내꺼_조회;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.롤링페이퍼_제목_수정;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.롤링페이퍼_특정_조회;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_가입;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_모든_회원들_롤링페이퍼_조회;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_추가;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원_롤링페이퍼_생성;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.회원가입_후_로그인;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.naepyeon.controller.dto.CreateResponse;
+import com.woowacourse.naepyeon.controller.dto.JoinTeamMemberRequest;
+import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
+import com.woowacourse.naepyeon.controller.dto.RollingpaperCreateRequest;
+import com.woowacourse.naepyeon.controller.dto.RollingpaperUpdateRequest;
+import com.woowacourse.naepyeon.controller.dto.TeamRequest;
+import com.woowacourse.naepyeon.service.dto.RollingpaperPreviewResponseDto;
+import com.woowacourse.naepyeon.service.dto.RollingpaperResponseDto;
+import com.woowacourse.naepyeon.service.dto.RollingpapersResponseDto;
+import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+public class RollingpaperAcceptanceTest extends AcceptanceTest {
+
+    private final TeamRequest teamRequest = new TeamRequest(
+            "woowacourse", "테스트 모임입니다.", "testEmoji", "#123456"
+    );
+    private final MemberRegisterRequest member1 =
+            new MemberRegisterRequest("seungpang", "email@email.com", "12345678aA!");
+    private final MemberRegisterRequest member2 =
+            new MemberRegisterRequest("yxxnghwan", "yxxnghwan@email.com", "12345678aA!");
+    private final MemberRegisterRequest member3 =
+            new MemberRegisterRequest("kth990303", "kth990303@email.com", "12345678aA!");
+
+    @Test
+    @DisplayName("특정 회원에게 롤링페이퍼를 생성하고 조회한다.")
+    void createRollingpaperToMember() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
+        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
+
+        // when: seungpang이 yxxnghwan에게 롤링페이퍼 작성
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
+                .as(CreateResponse.class)
+                .getId();
+
+        // then: yxxnghwan이 받은 롤링페이퍼 조회
+        final List<Long> actual = 롤링페이퍼_내꺼_조회(tokenResponseDto2, teamId).as(RollingpapersResponseDto.class)
+                .getRollingpapers()
+                .stream()
+                .map(RollingpaperPreviewResponseDto::getId)
+                .collect(Collectors.toUnmodifiableList());
+
+        assertThat(actual).contains(rollingpaperId);
+    }
+
+    @Test
+    @DisplayName("특정 회원에게 롤링페이퍼를 여러 번 생성할 수 있다.")
+    void createRollingpapersToMember() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
+        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
+
+        // when: seungpang이 yxxnghwan에게 롤링페이퍼 2개 작성
+        final RollingpaperCreateRequest rollingpaperCreateRequest1 = new RollingpaperCreateRequest("하이알렉스", 2L);
+        final Long rollingpaperId1 = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest1)
+                .as(CreateResponse.class)
+                .getId();
+        final RollingpaperCreateRequest rollingpaperCreateRequest2 = new RollingpaperCreateRequest("반가워", 2L);
+        final Long rollingpaperId2 = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest2)
+                .as(CreateResponse.class)
+                .getId();
+
+        // then: yxxnghwan이 받은 롤링페이퍼 조회
+        final List<Long> actual = 롤링페이퍼_내꺼_조회(tokenResponseDto2, teamId).as(RollingpapersResponseDto.class)
+                .getRollingpapers()
+                .stream()
+                .map(RollingpaperPreviewResponseDto::getId)
+                .collect(Collectors.toUnmodifiableList());
+
+        assertThat(actual).contains(rollingpaperId1, rollingpaperId2);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원에게 롤링페이퍼를 생성하는 경우 예외를 발생시킨다.")
+    void createRollingpaperWithNotFoundMember() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이알렉스", 2L);
+        final ExtractableResponse<Response> response = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId,
+                rollingpaperCreateRequest);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NOT_FOUND.value());
+    }
+
+    @Test
+    @DisplayName("특정 모임의 회원들 전체가 받은 롤링페이퍼 목록을 조회한다.")
+    void findRollingpapersWithTeam() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
+        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
+
+        final TokenResponseDto tokenResponseDto3 = 회원가입_후_로그인(member3);
+        모임_가입(tokenResponseDto3, teamId, new JoinTeamMemberRequest("알고리즘이좋아요"));
+
+        // when: seungpang이 yxxnghwan, kth990303에게 각각 롤링페이퍼 작성
+        final RollingpaperCreateRequest rollingpaperCreateRequest1 = new RollingpaperCreateRequest("하이알렉스", 2L);
+        final Long rollingpaperId1 = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest1)
+                .as(CreateResponse.class)
+                .getId();
+        final RollingpaperCreateRequest rollingpaperCreateRequest2 = new RollingpaperCreateRequest("알고리즘좀그만해!", 3L);
+        final Long rollingpaperId2 = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest2)
+                .as(CreateResponse.class)
+                .getId();
+
+        // then
+        final List<Long> actual = 모임_모든_회원들_롤링페이퍼_조회(tokenResponseDto2, teamId).as(RollingpapersResponseDto.class)
+                .getRollingpapers()
+                .stream()
+                .map(RollingpaperPreviewResponseDto::getId)
+                .collect(Collectors.toUnmodifiableList());
+
+        assertThat(actual).contains(rollingpaperId1, rollingpaperId2);
+    }
+
+    @Test
+    @DisplayName("모임에 속하지 않은 회원이 롤링페이퍼를 조회할 경우 예외를 발생시킨다.")
+    void findRollingpaperWithAnonymous() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
+        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
+
+        // 모임에 가입하지는 않음
+        final TokenResponseDto tokenResponseDto3 = 회원가입_후_로그인(member3);
+
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
+                .as(CreateResponse.class)
+                .getId();
+
+        final ExtractableResponse<Response> response = 롤링페이퍼_특정_조회(tokenResponseDto3, teamId, rollingpaperId);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    @DisplayName("롤링페이퍼 이름을 수정한다.")
+    void updateRollingpaperTitle() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
+        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
+
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
+                .as(CreateResponse.class)
+                .getId();
+
+        final String expected = "알고리즘좀그만해!";
+        final RollingpaperUpdateRequest rollingpaperUpdateRequest = new RollingpaperUpdateRequest("알고리즘좀그만해!");
+        final ExtractableResponse<Response> response = 롤링페이퍼_제목_수정(tokenResponseDto1, teamId, rollingpaperId,
+                rollingpaperUpdateRequest);
+
+        final String actual = 롤링페이퍼_특정_조회(tokenResponseDto1, teamId, rollingpaperId).as(RollingpaperResponseDto.class)
+                .getTitle();
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("롤링페이퍼 이름을 20자 초과하여 수정할 경우 예외를 발생시킨다.")
+    void updateRollingpaperTitleWithExceedTitleLength() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
+        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
+
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
+                .as(CreateResponse.class)
+                .getId();
+
+        final RollingpaperUpdateRequest rollingpaperUpdateRequest =
+                new RollingpaperUpdateRequest("케이. 사실은 나도 알고리즘 좋아하는데 숨기는 거였어...");
+        final ExtractableResponse<Response> response = 롤링페이퍼_제목_수정(tokenResponseDto1, teamId, rollingpaperId,
+                rollingpaperUpdateRequest);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    @DisplayName("모임에 속하지 않은 회원이 롤링페이퍼를 이름을 수정할 경우 예외를 발생시킨다.")
+    void updateRollingpaperTitleWithAnonymous() {
+        final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+
+        final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
+        모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
+
+        // 모임에 가입하지는 않음
+        final TokenResponseDto tokenResponseDto3 = 회원가입_후_로그인(member3);
+
+        final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이케이", 2L);
+        final Long rollingpaperId = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId, rollingpaperCreateRequest)
+                .as(CreateResponse.class)
+                .getId();
+
+        final String expected = "알고리즘좀그만해!";
+        final RollingpaperUpdateRequest rollingpaperUpdateRequest = new RollingpaperUpdateRequest("알고리즘좀그만해!");
+        final ExtractableResponse<Response> response = 롤링페이퍼_제목_수정(tokenResponseDto3, teamId, rollingpaperId,
+                rollingpaperUpdateRequest);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+    }
+}
+

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 
-public class RollingpaperAcceptanceTest extends AcceptanceTest {
+class RollingpaperAcceptanceTest extends AcceptanceTest {
 
     private final TeamRequest teamRequest = new TeamRequest(
             "woowacourse", "테스트 모임입니다.", "testEmoji", "#123456"

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/RollingpaperAcceptanceTest.java
@@ -44,7 +44,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("특정 회원에게 롤링페이퍼를 생성하고 조회한다.")
     void createRollingpaperToMember() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
@@ -69,7 +70,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("특정 회원에게 롤링페이퍼를 여러 번 생성할 수 있다.")
     void createRollingpapersToMember() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
@@ -98,7 +100,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("존재하지 않는 회원에게 롤링페이퍼를 생성하는 경우 예외를 발생시킨다.")
     void createRollingpaperWithNotFoundMember() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final RollingpaperCreateRequest rollingpaperCreateRequest = new RollingpaperCreateRequest("하이알렉스", 2L);
         final ExtractableResponse<Response> response = 회원_롤링페이퍼_생성(tokenResponseDto1, teamId,
@@ -111,7 +114,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("모임에 속하지 않은 사람이 해당 모임에서 롤링페이퍼를 생성하는 경우 예외를 발생시킨다.")
     void createRollingpaperWithAnonymous() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
@@ -130,7 +134,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("특정 모임의 회원들 전체가 받은 롤링페이퍼 목록을 조회한다.")
     void findRollingpapersWithTeam() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
@@ -162,7 +167,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("모임에 속하지 않은 회원이 롤링페이퍼를 조회할 경우 예외를 발생시킨다.")
     void findRollingpaperWithAnonymous() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
@@ -184,7 +190,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("롤링페이퍼 이름을 수정한다.")
     void updateRollingpaperTitle() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
@@ -208,7 +215,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("롤링페이퍼 이름을 20자 초과하여 수정할 경우 예외를 발생시킨다.")
     void updateRollingpaperTitleWithExceedTitleLength() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));
@@ -230,7 +238,8 @@ class RollingpaperAcceptanceTest extends AcceptanceTest {
     @DisplayName("모임에 속하지 않은 회원이 롤링페이퍼를 이름을 수정할 경우 예외를 발생시킨다.")
     void updateRollingpaperTitleWithAnonymous() {
         final TokenResponseDto tokenResponseDto1 = 회원가입_후_로그인(member1);
-        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class).getId();
+        final Long teamId = 모임_추가(tokenResponseDto1, teamRequest).as(CreateResponse.class)
+                .getId();
 
         final TokenResponseDto tokenResponseDto2 = 회원가입_후_로그인(member2);
         모임_가입(tokenResponseDto2, teamId, new JoinTeamMemberRequest("영환이형도좋아요"));

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/RollingpaperRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/RollingpaperRepositoryTest.java
@@ -77,6 +77,17 @@ class RollingpaperRepositoryTest {
     }
 
     @Test
+    @DisplayName("롤링페이퍼들을 memberId로 찾는다.")
+    void findByMemberId() {
+        final Rollingpaper rollingPaper1 = createRollingPaper();
+        rollingpaperRepository.save(rollingPaper1);
+
+        final List<Rollingpaper> rollingpapers = rollingpaperRepository.findByMemberId(member.getId());
+
+        assertThat(rollingpapers).hasSize(1);
+    }
+
+    @Test
     @DisplayName("롤링페이퍼 타이틀을 변경한다.")
     void update() {
         final Rollingpaper rollingPaper = createRollingPaper();

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/RollingpaperServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/RollingpaperServiceTest.java
@@ -3,11 +3,10 @@ package com.woowacourse.naepyeon.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.woowacourse.naepyeon.controller.dto.TeamRequest;
 import com.woowacourse.naepyeon.domain.Member;
-import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.exception.NotFoundRollingpaperException;
 import com.woowacourse.naepyeon.repository.jpa.MemberJpaDao;
-import com.woowacourse.naepyeon.repository.jpa.TeamJpaDao;
 import com.woowacourse.naepyeon.service.dto.RollingpaperPreviewResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpaperResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpapersResponseDto;
@@ -25,33 +24,38 @@ class RollingpaperServiceTest {
 
     private static final String rollingPaperTitle = "AlexAndKei";
 
-    private final Team team = new Team(
+    private final TeamRequest teamRequest = new TeamRequest(
             "nae-pyeon",
             "테스트 모임입니다.",
             "testEmoji",
             "#123456");
-    private final Member member = new Member("member", "m@hello.com", "abc@@1234");
+    private Long teamId;
+    private Member member;
+    private Member member2;
 
     @Autowired
-    private TeamJpaDao teamJpaDao;
-    @Autowired
     private MemberJpaDao memberJpaDao;
+    @Autowired
+    private TeamService teamService;
     @Autowired
     private RollingpaperService rollingpaperService;
 
     @BeforeEach
     void setUp() {
-        teamJpaDao.save(team);
-        memberJpaDao.save(member);
+        member = memberJpaDao.save(new Member("member", "m@hello.com", "abc@@1234"));
+        member2 = memberJpaDao.save(new Member("writer", "w@hello.com", "abc@@1234"));
+        teamId = teamService.save(teamRequest, member.getId());
+        teamService.joinMember(teamId, member2.getId(), "안뇽안뇽");
     }
 
     @Test
     @DisplayName("롤링페이퍼를 저장하고 id값으로 찾는다.")
     void saveRollingpaperAndFind() {
         final Long rollingpaperId =
-                rollingpaperService.createRollingpaper(rollingPaperTitle, team.getId(), member.getId());
+                rollingpaperService.createRollingpaper(rollingPaperTitle, teamId, member2.getId(), member.getId());
 
-        final RollingpaperResponseDto rollingpaperResponse = rollingpaperService.findById(rollingpaperId);
+        final RollingpaperResponseDto rollingpaperResponse = rollingpaperService.findById(rollingpaperId, teamId,
+                member.getId());
 
         assertThat(rollingpaperResponse).extracting("title", "to", "messages")
                 .containsExactly(rollingPaperTitle, member.getUsername(), List.of());
@@ -62,13 +66,33 @@ class RollingpaperServiceTest {
     void findRollingpapersByTeamId() {
         // given
         final Long rollingpaperId1 =
-                rollingpaperService.createRollingpaper(rollingPaperTitle, team.getId(), member.getId());
+                rollingpaperService.createRollingpaper(rollingPaperTitle, teamId, member2.getId(), member.getId());
         final Long rollingpaperId2 =
-                rollingpaperService.createRollingpaper(rollingPaperTitle, team.getId(), member.getId());
+                rollingpaperService.createRollingpaper(rollingPaperTitle, teamId, member2.getId(), member.getId());
         final List<RollingpaperPreviewResponseDto> expected = convertPreviewDto(rollingpaperId1, rollingpaperId2);
 
         // when
-        final RollingpapersResponseDto responseDto = rollingpaperService.findByTeamId(team.getId());
+        final RollingpapersResponseDto responseDto = rollingpaperService.findByTeamId(teamId, member.getId());
+        final List<RollingpaperPreviewResponseDto> rollingpaperPreviewResponseDtos = responseDto.getRollingpapers();
+
+        // then
+        assertThat(rollingpaperPreviewResponseDtos)
+                .usingRecursiveComparison()
+                .isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("롤링페이퍼들을 memberId로 찾는다.")
+    void findRollingpapersByMemberId() {
+        // given
+        final Long rollingpaperId1 =
+                rollingpaperService.createRollingpaper(rollingPaperTitle, teamId, member2.getId(), member.getId());
+        final Long rollingpaperId2 =
+                rollingpaperService.createRollingpaper(rollingPaperTitle, teamId, member2.getId(), member.getId());
+        final List<RollingpaperPreviewResponseDto> expected = convertPreviewDto(rollingpaperId1, rollingpaperId2);
+
+        // when
+        final RollingpapersResponseDto responseDto = rollingpaperService.findByMemberId(teamId, member.getId());
         final List<RollingpaperPreviewResponseDto> rollingpaperPreviewResponseDtos = responseDto.getRollingpapers();
 
         // then
@@ -79,8 +103,10 @@ class RollingpaperServiceTest {
 
     private List<RollingpaperPreviewResponseDto> convertPreviewDto(final Long rollingpaperId1,
                                                                    final Long rollingpaperId2) {
-        final RollingpaperResponseDto rollingpaperResponseDto1 = rollingpaperService.findById(rollingpaperId1);
-        final RollingpaperResponseDto rollingpaperResponseDto2 = rollingpaperService.findById(rollingpaperId2);
+        final RollingpaperResponseDto rollingpaperResponseDto1 = rollingpaperService.findById(rollingpaperId1, teamId,
+                member.getId());
+        final RollingpaperResponseDto rollingpaperResponseDto2 = rollingpaperService.findById(rollingpaperId2, teamId,
+                member.getId());
         return List.of(
                 new RollingpaperPreviewResponseDto(rollingpaperResponseDto1.getId(),
                         rollingpaperResponseDto1.getTitle(), rollingpaperResponseDto1.getTo()),
@@ -93,24 +119,25 @@ class RollingpaperServiceTest {
     @DisplayName("롤링페이퍼 타이틀을 수정한다.")
     void updateTitle() {
         final Long rollingpaperId =
-                rollingpaperService.createRollingpaper(rollingPaperTitle, team.getId(), member.getId());
+                rollingpaperService.createRollingpaper(rollingPaperTitle, teamId, member2.getId(), member.getId());
         final String expected = "woowacourse";
 
-        rollingpaperService.updateTitle(rollingpaperId, expected);
+        rollingpaperService.updateTitle(rollingpaperId, expected, teamId, member.getId());
 
-        final RollingpaperResponseDto rollingpaperResponse = rollingpaperService.findById(rollingpaperId);
+        final RollingpaperResponseDto rollingpaperResponse = rollingpaperService.findById(rollingpaperId, teamId,
+                member.getId());
         assertThat(rollingpaperResponse.getTitle()).isEqualTo(expected);
     }
 
     @Test
-    @DisplayName("롤링페이를 id로 제거한다.")
+    @DisplayName("롤링페이퍼를 id로 제거한다.")
     void deleteRollingpaper() {
         final Long rollingpaperId =
-                rollingpaperService.createRollingpaper(rollingPaperTitle, team.getId(), member.getId());
+                rollingpaperService.createRollingpaper(rollingPaperTitle, teamId, member2.getId(), member.getId());
 
-        rollingpaperService.deleteRollingpaper(rollingpaperId);
+        rollingpaperService.deleteRollingpaper(rollingpaperId, teamId, member.getId());
 
-        assertThatThrownBy(() -> rollingpaperService.findById(rollingpaperId))
+        assertThatThrownBy(() -> rollingpaperService.findById(rollingpaperId, teamId, member.getId()))
                 .isInstanceOf(NotFoundRollingpaperException.class);
     }
 }


### PR DESCRIPTION
close #104 

## 추가한 에러 명세 및 클래스
### `UncertificationTeamMemberException`
- 403 Forbidden 
- 4013: 해당 모임에 가입해야 가능한 작업입니다.
### `NotFoundTeamMemberException`
- 404 Not Found
- 4012: 해당 모임에 가입되지 않은 회원입니다.

## 추가한 기능
- 해당 회원이 받은 롤링페이퍼 목록 조회 기능 및 api 추가
- 롤링페이퍼 api에서, 모임에 속하지 않은 회원이 작업을 하려 하는 경우 예외를 터뜨리도록 수정
```java
private boolean checkMemberNotIncludedTeam(final Long teamId, final Long memberId) {
    final List<Long> joinedTeamsId = teamMemberRepository.findTeamsByJoinedMemberId(memberId)
            .stream()
            .map(Team::getId)
            .collect(Collectors.toUnmodifiableList());
    return !joinedTeamsId.contains(teamId);
}
```

```java
if (checkMemberNotIncludedTeam(teamId, loginMemberId)) {
    throw new UncertificationTeamMemberException(teamId);
}
if (checkMemberNotIncludedTeam(teamId, memberId)) {
    throw new NotFoundTeamMemberException(memberId);
}
```
- service layer에서 `RollingpaperDao`, `MemberDao`를 상태로 갖던 임시작업 수정
- 인수테스트 작성

## 집중적으로 코드리뷰 받고 싶은 부분
1. 스프린트2 기준으로 인수 테스트에 빠진 기능 테스트가 없는지
2. 비즈니스 로직에서 예외처리를 제대로 하고 있는지
3. final, 컨벤션 불일치 등이 존재하는지