### PR TITLE
feat: Feature/137 paper adressee nickname

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Rollingpaper.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Rollingpaper.java
@@ -55,4 +55,8 @@ public class Rollingpaper {
         validateRollingpaper(title);
         this.title = title;
     }
+
+    public Long getAddresseeId() {
+        return member.getId();
+    }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
@@ -3,7 +3,7 @@ package com.woowacourse.naepyeon.repository;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
 import com.woowacourse.naepyeon.exception.DuplicateTeamPaticipateException;
-import com.woowacourse.naepyeon.repository.jpa.TeamMemberJpaDao;
+import com.woowacourse.naepyeon.repository.jpa.TeamParticipationJpaDao;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -14,12 +14,12 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class JpaTeamParticipationRepository implements TeamParticipationRepository {
 
-    private final TeamMemberJpaDao teamMemberJpaDao;
+    private final TeamParticipationJpaDao teamParticipationJpaDao;
 
     @Override
     public Long save(final TeamParticipation teamParticipation) {
         try {
-            return teamMemberJpaDao.save(teamParticipation)
+            return teamParticipationJpaDao.save(teamParticipation)
                     .getId();
         } catch (final DataIntegrityViolationException e) {
             throw new DuplicateTeamPaticipateException(
@@ -31,32 +31,27 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
 
     @Override
     public Optional<TeamParticipation> findById(final Long id) {
-        return teamMemberJpaDao.findById(id);
+        return teamParticipationJpaDao.findById(id);
     }
 
     @Override
     public List<TeamParticipation> findByTeamId(final Long teamId) {
-        return teamMemberJpaDao.findByTeamId(teamId);
+        return teamParticipationJpaDao.findByTeamId(teamId);
     }
 
     @Override
     public List<Team> findTeamsByJoinedMemberId(final Long memberId) {
-        return teamMemberJpaDao.findTeamsByJoinedMemberId(memberId);
-    }
-
-    @Override
-    public List<TeamParticipation> findMembersByTeamId(final Long teamId) {
-        return teamMemberJpaDao.findMembersByTeamId(teamId);
+        return teamParticipationJpaDao.findTeamsByJoinedMemberId(memberId);
     }
 
     @Override
     public String findNicknameByMemberId(final Long addresseeId, final Long teamId) {
-        return teamMemberJpaDao.findNicknameByMemberId(addresseeId, teamId);
+        return teamParticipationJpaDao.findNicknameByMemberId(addresseeId, teamId);
     }
 
     @Override
     public boolean isJoinedMember(final Long memberId, final Long teamId) {
-        final List<Team> teams = teamMemberJpaDao.findTeamsByJoinedMemberId(memberId);
+        final List<Team> teams = teamParticipationJpaDao.findTeamsByJoinedMemberId(memberId);
         return teams.stream()
                 .anyMatch(team -> team.getId().equals(teamId));
     }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
-public class JpaTeamMemberRepository implements TeamMemberRepository {
+public class JpaTeamParticipationRepository implements TeamParticipationRepository {
 
     private final TeamMemberJpaDao teamMemberJpaDao;
 
@@ -47,6 +47,11 @@ public class JpaTeamMemberRepository implements TeamMemberRepository {
     @Override
     public List<TeamParticipation> findMembersByTeamId(final Long teamId) {
         return teamMemberJpaDao.findMembersByTeamId(teamId);
+    }
+
+    @Override
+    public String findNicknameByMemberId(final Long addresseeId, final Long teamId) {
+        return teamMemberJpaDao.findNicknameByMemberId(addresseeId, teamId);
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
@@ -46,7 +46,7 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
 
     @Override
     public String findNicknameByMemberId(final Long addresseeId, final Long teamId) {
-        return teamParticipationJpaDao.findNicknameByMemberId(addresseeId, teamId);
+        return teamParticipationJpaDao.findNicknameByMemberIdAndTeamId(addresseeId, teamId);
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
@@ -5,7 +5,7 @@ import com.woowacourse.naepyeon.domain.TeamParticipation;
 import java.util.List;
 import java.util.Optional;
 
-public interface TeamMemberRepository {
+public interface TeamParticipationRepository {
 
     Long save(final TeamParticipation teamParticipation);
 
@@ -16,6 +16,8 @@ public interface TeamMemberRepository {
     List<Team> findTeamsByJoinedMemberId(final Long memberId);
 
     List<TeamParticipation> findMembersByTeamId(final Long teamId);
+
+    String findNicknameByMemberId(final Long addresseeId, final Long teamId);
 
     boolean isJoinedMember(final Long memberId, final Long teamId);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
@@ -15,8 +15,6 @@ public interface TeamParticipationRepository {
 
     List<Team> findTeamsByJoinedMemberId(final Long memberId);
 
-    List<TeamParticipation> findMembersByTeamId(final Long teamId);
-
     String findNicknameByMemberId(final Long addresseeId, final Long teamId);
 
     boolean isJoinedMember(final Long memberId, final Long teamId);

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamMemberJpaDao.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamMemberJpaDao.java
@@ -20,4 +20,9 @@ public interface TeamMemberJpaDao extends JpaRepository<TeamParticipation, Long>
             + "from TeamParticipation p "
             + "where p.team.id = :teamId")
     List<TeamParticipation> findMembersByTeamId(@Param("teamId") final Long teamId);
+
+    @Query("select p.nickname "
+            + "from TeamParticipation p "
+            + "where p.member.id = :memberId and p.team.id = :teamId")
+    String findNicknameByMemberId(@Param("memberId") final Long memberId, @Param("teamId") final Long teamId);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
@@ -19,5 +19,5 @@ public interface TeamParticipationJpaDao extends JpaRepository<TeamParticipation
     @Query("select p.nickname "
             + "from TeamParticipation p "
             + "where p.member.id = :memberId and p.team.id = :teamId")
-    String findNicknameByMemberId(@Param("memberId") final Long memberId, @Param("teamId") final Long teamId);
+    String findNicknameByMemberIdAndTeamId(@Param("memberId") final Long memberId, @Param("teamId") final Long teamId);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface TeamMemberJpaDao extends JpaRepository<TeamParticipation, Long> {
+public interface TeamParticipationJpaDao extends JpaRepository<TeamParticipation, Long> {
 
     List<TeamParticipation> findByTeamId(final Long teamId);
 
@@ -15,11 +15,6 @@ public interface TeamMemberJpaDao extends JpaRepository<TeamParticipation, Long>
             + "from TeamParticipation p "
             + "where p.member.id = :memberId")
     List<Team> findTeamsByJoinedMemberId(@Param("memberId") final Long memberId);
-
-    @Query("select p "
-            + "from TeamParticipation p "
-            + "where p.team.id = :teamId")
-    List<TeamParticipation> findMembersByTeamId(@Param("teamId") final Long teamId);
 
     @Query("select p.nickname "
             + "from TeamParticipation p "

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
@@ -62,7 +62,7 @@ public class RollingpaperService {
         return new RollingpaperResponseDto(
                 rollingpaperId,
                 rollingpaper.getTitle(),
-                rollingpaper.getMember().getUsername(),
+                findRollingpaperAddresseeNickname(rollingpaper),
                 messageService.findMessages(rollingpaperId)
         );
     }
@@ -74,7 +74,9 @@ public class RollingpaperService {
         }
         final List<Rollingpaper> rollingpapers = rollingpaperRepository.findByTeamId(teamId);
         final List<RollingpaperPreviewResponseDto> rollingpaperPreviewResponseDtos = rollingpapers.stream()
-                .map(RollingpaperPreviewResponseDto::from)
+                .map(rollingpaper -> RollingpaperPreviewResponseDto.from(
+                        rollingpaper, findRollingpaperAddresseeNickname(rollingpaper))
+                )
                 .collect(Collectors.toUnmodifiableList());
         return new RollingpapersResponseDto(rollingpaperPreviewResponseDtos);
     }
@@ -83,9 +85,17 @@ public class RollingpaperService {
     public RollingpapersResponseDto findByMemberId(final Long teamId, final Long loginMemberId) {
         final List<Rollingpaper> rollingpapers = rollingpaperRepository.findByMemberId(loginMemberId);
         final List<RollingpaperPreviewResponseDto> rollingpaperPreviewResponseDtos = rollingpapers.stream()
-                .map(RollingpaperPreviewResponseDto::from)
-                .collect(Collectors.toUnmodifiableList());
+                .map(rollingpaper -> RollingpaperPreviewResponseDto.from(
+                        rollingpaper, findRollingpaperAddresseeNickname(rollingpaper))
+                ).collect(Collectors.toUnmodifiableList());
         return new RollingpapersResponseDto(rollingpaperPreviewResponseDtos);
+    }
+
+    private String findRollingpaperAddresseeNickname(final Rollingpaper rollingpaper) {
+        final Long addresseeId = rollingpaper.getAddresseeId();
+        return teamMemberRepository.findById(rollingpaper.getAddresseeId())
+                .orElseThrow(() -> new NotFoundTeamMemberException(addresseeId))
+                .getNickname();
     }
 
     public void updateTitle(final Long rollingpaperId, final String newTitle, final Long teamId,

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
@@ -92,7 +92,7 @@ public class TeamService {
     }
 
     public JoinedMembersResponseDto findJoinedMembers(final Long teamId) {
-        final List<TeamParticipation> participations = teamParticipationRepository.findMembersByTeamId(teamId);
+        final List<TeamParticipation> participations = teamParticipationRepository.findByTeamId(teamId);
 
         final List<JoinedMemberResponseDto> joinedMembers = participations.stream()
                 .map(

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
@@ -7,7 +7,7 @@ import com.woowacourse.naepyeon.domain.TeamParticipation;
 import com.woowacourse.naepyeon.exception.NotFoundMemberException;
 import com.woowacourse.naepyeon.exception.NotFoundTeamException;
 import com.woowacourse.naepyeon.repository.MemberRepository;
-import com.woowacourse.naepyeon.repository.TeamMemberRepository;
+import com.woowacourse.naepyeon.repository.TeamParticipationRepository;
 import com.woowacourse.naepyeon.repository.TeamRepository;
 import com.woowacourse.naepyeon.service.dto.JoinedMemberResponseDto;
 import com.woowacourse.naepyeon.service.dto.JoinedMembersResponseDto;
@@ -26,7 +26,7 @@ public class TeamService {
 
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
-    private final TeamMemberRepository teamMemberRepository;
+    private final TeamParticipationRepository teamParticipationRepository;
 
     @Transactional
     public Long save(final TeamRequest teamRequest, final Long memberId) {
@@ -39,7 +39,7 @@ public class TeamService {
         final Long createdTeamId = teamRepository.save(team);
         final Member owner = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundMemberException(memberId));
-        teamMemberRepository.save(new TeamParticipation(team, owner, "마스터"));
+        teamParticipationRepository.save(new TeamParticipation(team, owner, "마스터"));
         return createdTeamId;
     }
 
@@ -50,13 +50,13 @@ public class TeamService {
         final Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new NotFoundMemberException(memberId));
         final TeamParticipation teamParticipation = new TeamParticipation(team, member, nickname);
-        return teamMemberRepository.save(teamParticipation);
+        return teamParticipationRepository.save(teamParticipation);
     }
 
     public TeamResponseDto findById(final Long teamId, final Long memberId) {
         final Team team = teamRepository.findById(teamId)
                 .orElseThrow(() -> new NotFoundTeamException(teamId));
-        return TeamResponseDto.of(team, teamMemberRepository.isJoinedMember(memberId, teamId));
+        return TeamResponseDto.of(team, teamParticipationRepository.isJoinedMember(memberId, teamId));
     }
 
     @Transactional
@@ -73,7 +73,7 @@ public class TeamService {
 
     public TeamsResponseDto findAll(final Long memberId) {
         final List<Team> teams = teamRepository.findAll();
-        final List<Team> joinedTeams = teamMemberRepository.findTeamsByJoinedMemberId(memberId);
+        final List<Team> joinedTeams = teamParticipationRepository.findTeamsByJoinedMemberId(memberId);
 
         final List<TeamResponseDto> teamResponseDtos = teams.stream()
                 .map(team -> TeamResponseDto.of(team, joinedTeams.contains(team)))
@@ -83,7 +83,7 @@ public class TeamService {
     }
 
     public TeamsResponseDto findByJoinedMemberId(final Long memberId) {
-        final List<Team> teams = teamMemberRepository.findTeamsByJoinedMemberId(memberId);
+        final List<Team> teams = teamParticipationRepository.findTeamsByJoinedMemberId(memberId);
         final List<TeamResponseDto> teamResponseDtos = teams.stream()
                 .map(team -> TeamResponseDto.of(team, true))
                 .collect(Collectors.toList());
@@ -92,7 +92,7 @@ public class TeamService {
     }
 
     public JoinedMembersResponseDto findJoinedMembers(final Long teamId) {
-        final List<TeamParticipation> participations = teamMemberRepository.findMembersByTeamId(teamId);
+        final List<TeamParticipation> participations = teamParticipationRepository.findMembersByTeamId(teamId);
 
         final List<JoinedMemberResponseDto> joinedMembers = participations.stream()
                 .map(
@@ -109,6 +109,6 @@ public class TeamService {
         if (teamRepository.findById(teamId).isEmpty()) {
             throw new NotFoundTeamException(teamId);
         }
-        return teamMemberRepository.isJoinedMember(memberId, teamId);
+        return teamParticipationRepository.isJoinedMember(memberId, teamId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/dto/RollingpaperPreviewResponseDto.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/dto/RollingpaperPreviewResponseDto.java
@@ -16,12 +16,11 @@ public class RollingpaperPreviewResponseDto {
     private String title;
     private String to;
 
-    public static RollingpaperPreviewResponseDto from(final Rollingpaper rollingpaper) {
-        final Member member = rollingpaper.getMember();
+    public static RollingpaperPreviewResponseDto from(final Rollingpaper rollingpaper, final String nickname) {
         return new RollingpaperPreviewResponseDto(
                 rollingpaper.getId(),
                 rollingpaper.getTitle(),
-                member.getUsername()
+                nickname
         );
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/domain/RollingpaperTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/domain/RollingpaperTest.java
@@ -58,6 +58,20 @@ class RollingpaperTest {
 
         assertThatThrownBy(() -> new Rollingpaper("seungpang seungpang seungpang", team, member))
                 .isInstanceOf(ExceedRollingpaperNameLengthException.class);
+    }
 
+    @Test
+    @DisplayName("롤링페이퍼 수신인의 아이디를 올바르게 반환한다.")
+    void getAddresseeId() {
+        final Team team = new Team(
+                "nae-pyeon",
+                "테스트 모임입니다.",
+                "testEmoji",
+                "#123456"
+        );
+        final Member member = new Member("member", "m@hello.com", "abc@@1234");
+        final Rollingpaper rollingpaper = new Rollingpaper("seungpang", team, member);
+
+        assertThat(rollingpaper.getAddresseeId()).isEqualTo(member.getId());
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 class TeamParticipationRepositoryTest {
 
     @Autowired
-    private TeamMemberRepository teamMemberRepository;
+    private TeamParticipationRepository teamParticipationRepository;
 
     @Autowired
     private TeamRepository teamRepository;
@@ -63,9 +63,9 @@ class TeamParticipationRepositoryTest {
     void saveAndFind() {
         final String nickname = "닉네임";
         final TeamParticipation teamParticipation = new TeamParticipation(team1, member1, nickname);
-        final Long savedId = teamMemberRepository.save(teamParticipation);
+        final Long savedId = teamParticipationRepository.save(teamParticipation);
 
-        final TeamParticipation findTeamParticipation = teamMemberRepository.findById(savedId)
+        final TeamParticipation findTeamParticipation = teamParticipationRepository.findById(savedId)
                 .orElseThrow();
 
         assertAll(
@@ -81,12 +81,12 @@ class TeamParticipationRepositoryTest {
         final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member1, "닉네임1");
         final TeamParticipation teamParticipation2 = new TeamParticipation(team2, member1, "닉네임2");
         final TeamParticipation teamParticipation3 = new TeamParticipation(team2, member2, "닉네임3");
-        teamMemberRepository.save(teamParticipation1);
-        teamMemberRepository.save(teamParticipation2);
-        teamMemberRepository.save(teamParticipation3);
+        teamParticipationRepository.save(teamParticipation1);
+        teamParticipationRepository.save(teamParticipation2);
+        teamParticipationRepository.save(teamParticipation3);
 
-        final List<TeamParticipation> findTeam1Members = teamMemberRepository.findByTeamId(team1.getId());
-        final List<TeamParticipation> findTeam2Members = teamMemberRepository.findByTeamId(team2.getId());
+        final List<TeamParticipation> findTeam1Members = teamParticipationRepository.findByTeamId(team1.getId());
+        final List<TeamParticipation> findTeam2Members = teamParticipationRepository.findByTeamId(team2.getId());
 
         assertAll(
                 () -> assertThat(findTeam1Members).contains(teamParticipation1),
@@ -100,11 +100,25 @@ class TeamParticipationRepositoryTest {
         final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member1, "닉네임1");
         final TeamParticipation teamParticipation2 = new TeamParticipation(team3, member1, "닉네임2");
 
-        teamMemberRepository.save(teamParticipation1);
-        teamMemberRepository.save(teamParticipation2);
+        teamParticipationRepository.save(teamParticipation1);
+        teamParticipationRepository.save(teamParticipation2);
 
-        final List<Team> joinedTeams = teamMemberRepository.findTeamsByJoinedMemberId(member1.getId());
+        final List<Team> joinedTeams = teamParticipationRepository.findTeamsByJoinedMemberId(member1.getId());
 
         assertThat(joinedTeams).contains(team1, team3);
+    }
+
+    @Test
+    @DisplayName("회원의 아이디로 특정 팀의 닉네임을 조회한다.")
+    void findNicknameByAddresseeId() {
+        final String expected = "닉네임1";
+        final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member1, expected);
+
+        teamParticipationRepository.save(teamParticipation1);
+
+        final String actual =
+                teamParticipationRepository.findNicknameByMemberId(member1.getId(), team1.getId());
+
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/RollingpaperServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/RollingpaperServiceTest.java
@@ -10,7 +10,6 @@ import com.woowacourse.naepyeon.exception.UncertificationTeamMemberException;
 import com.woowacourse.naepyeon.service.dto.RollingpaperPreviewResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpaperResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpapersResponseDto;
-import com.woowacourse.naepyeon.service.dto.TeamsResponseDto;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -161,7 +160,6 @@ class RollingpaperServiceTest {
         final String expected = "woowacourse";
 
         rollingpaperService.updateTitle(rollingpaperId, expected, teamId, memberId);
-        final TeamsResponseDto teamsResponseDto = teamService.findByJoinedMemberId(memberId);
 
         final RollingpaperResponseDto rollingpaperResponse =
                 rollingpaperService.findById(rollingpaperId, teamId, memberId);

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
@@ -8,7 +8,7 @@ import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
 import com.woowacourse.naepyeon.repository.MemberRepository;
-import com.woowacourse.naepyeon.repository.TeamMemberRepository;
+import com.woowacourse.naepyeon.repository.TeamParticipationRepository;
 import com.woowacourse.naepyeon.repository.TeamRepository;
 import com.woowacourse.naepyeon.service.dto.TeamResponseDto;
 import com.woowacourse.naepyeon.service.dto.TeamsResponseDto;
@@ -54,7 +54,7 @@ class TeamServiceTest {
     @Autowired
     private MemberRepository memberRepository;
     @Autowired
-    private TeamMemberRepository teamMemberRepository;
+    private TeamParticipationRepository teamParticipationRepository;
 
     @BeforeEach
     void setUp() {
@@ -165,7 +165,7 @@ class TeamServiceTest {
     void joinMember() {
         final String nickname = "닉네임";
         final Long joinedId = teamService.joinMember(team1.getId(), member.getId(), nickname);
-        final TeamParticipation findTeamParticipation = teamMemberRepository.findById(joinedId)
+        final TeamParticipation findTeamParticipation = teamParticipationRepository.findById(joinedId)
                 .orElseThrow();
 
         assertAll(
@@ -192,8 +192,8 @@ class TeamServiceTest {
     void findByJoinedMemberId() {
         final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member, "닉네임1");
         final TeamParticipation teamParticipation2 = new TeamParticipation(team3, member, "닉네임2");
-        teamMemberRepository.save(teamParticipation1);
-        teamMemberRepository.save(teamParticipation2);
+        teamParticipationRepository.save(teamParticipation1);
+        teamParticipationRepository.save(teamParticipation2);
 
         final TeamsResponseDto teams = teamService.findByJoinedMemberId(member.getId());
         final List<String> teamNames = teams.getTeams()


### PR DESCRIPTION
close #137 

## 구현사항
- memberId, teamId로 닉네임을 조회하는 dao 기능 구현
  - 서비스 쪽에서 이미 teamId, memberId로 NOT_FOUND, UNCERTIFICATION 에러를 검증해준 후에, 위 로직을 호출하므로 별도의 예외는 두지 않았습니다.
- 서비스 테스트 추가 

## 추가 구현 사항
-`TeamParticipationRepository` 가 아닌, `TeamMemberRepository` 라는 이름으로 돼있어서 수정했습니다.