### PR TITLE
test: 모임 관련 서비스, 레포지토리 테스트 보충

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
@@ -40,8 +40,8 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
     }
 
     @Override
-    public List<Team> findTeamsByJoinedMemberId(final Long memberId) {
-        return teamParticipationJpaDao.findTeamsByJoinedMemberId(memberId);
+    public List<Team> findTeamsByMemberId(final Long memberId) {
+        return teamParticipationJpaDao.findTeamsByMemberId(memberId);
     }
 
     @Override
@@ -51,7 +51,7 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
 
     @Override
     public boolean isJoinedMember(final Long memberId, final Long teamId) {
-        final List<Team> teams = teamParticipationJpaDao.findTeamsByJoinedMemberId(memberId);
+        final List<Team> teams = teamParticipationJpaDao.findTeamsByMemberId(memberId);
         return teams.stream()
                 .anyMatch(team -> team.getId().equals(teamId));
     }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
@@ -13,7 +13,7 @@ public interface TeamParticipationRepository {
 
     List<TeamParticipation> findByTeamId(final Long teamId);
 
-    List<Team> findTeamsByJoinedMemberId(final Long memberId);
+    List<Team> findTeamsByMemberId(final Long memberId);
 
     String findNicknameByMemberId(final Long addresseeId, final Long teamId);
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
@@ -14,7 +14,7 @@ public interface TeamParticipationJpaDao extends JpaRepository<TeamParticipation
     @Query("select p.team "
             + "from TeamParticipation p "
             + "where p.member.id = :memberId")
-    List<Team> findTeamsByJoinedMemberId(@Param("memberId") final Long memberId);
+    List<Team> findTeamsByMemberId(@Param("memberId") final Long memberId);
 
     @Query("select p.nickname "
             + "from TeamParticipation p "

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
@@ -111,7 +111,7 @@ public class RollingpaperService {
     }
 
     private boolean checkMemberNotIncludedTeam(final Long teamId, final Long memberId) {
-        final List<Long> joinedTeamsId = teamParticipationRepository.findTeamsByJoinedMemberId(memberId)
+        final List<Long> joinedTeamsId = teamParticipationRepository.findTeamsByMemberId(memberId)
                 .stream()
                 .map(Team::getId)
                 .collect(Collectors.toUnmodifiableList());

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
@@ -73,7 +73,7 @@ public class TeamService {
 
     public TeamsResponseDto findAll(final Long memberId) {
         final List<Team> teams = teamRepository.findAll();
-        final List<Team> joinedTeams = teamParticipationRepository.findTeamsByJoinedMemberId(memberId);
+        final List<Team> joinedTeams = teamParticipationRepository.findTeamsByMemberId(memberId);
 
         final List<TeamResponseDto> teamResponseDtos = teams.stream()
                 .map(team -> TeamResponseDto.of(team, joinedTeams.contains(team)))
@@ -83,7 +83,7 @@ public class TeamService {
     }
 
     public TeamsResponseDto findByJoinedMemberId(final Long memberId) {
-        final List<Team> teams = teamParticipationRepository.findTeamsByJoinedMemberId(memberId);
+        final List<Team> teams = teamParticipationRepository.findTeamsByMemberId(memberId);
         final List<TeamResponseDto> teamResponseDtos = teams.stream()
                 .map(team -> TeamResponseDto.of(team, true))
                 .collect(Collectors.toList());

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamRepositoryTest.java
@@ -1,8 +1,12 @@
 package com.woowacourse.naepyeon.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.naepyeon.domain.Team;
+import com.woowacourse.naepyeon.exception.NotFoundTeamException;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,18 +22,14 @@ class TeamRepositoryTest {
 
     @Test
     @DisplayName("모임을 id로 찾는다.")
-    public void findById() {
+    void findById() {
         // given
-        final Team team = new Team(
-                "woowacourse",
-                "테스트 모임입니다.",
-                "testEmoji",
-                "#123456"
-        );
+        final Team team = new Team("woowacourse", "테스트 모임입니다.", "testEmoji", "#123456");
         final Long teamId = teamRepository.save(team);
 
         // when
-        final Team findTeam = teamRepository.findById(teamId).get();
+        final Team findTeam = teamRepository.findById(teamId)
+                .orElseThrow();
 
         // then
         assertThat(findTeam)
@@ -39,14 +39,9 @@ class TeamRepositoryTest {
 
     @Test
     @DisplayName("모임을 id로 제거한다.")
-    public void delete() {
+    void delete() {
         // given
-        final Team team = new Team(
-                "woowacourse",
-                "테스트 모임입니다.",
-                "testEmoji",
-                "#123456"
-        );
+        final Team team = new Team("woowacourse", "테스트 모임입니다.", "testEmoji", "#123456");
         final Long teamId = teamRepository.save(team);
 
         // when
@@ -55,5 +50,33 @@ class TeamRepositoryTest {
         // then
         assertThat(teamRepository.findById(teamId))
                 .isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임을 삭제할 경우 예외를 발생시킨다.")
+    void deleteWithNotFoundTeam() {
+        // given
+        final Team team = new Team("woowacourse", "테스트 모임입니다.", "testEmoji", "#123456");
+        final Long teamId = teamRepository.save(team);
+
+        // when // then
+        assertThatThrownBy(() -> teamRepository.delete(teamId + 1L))
+                .isInstanceOf(NotFoundTeamException.class);
+    }
+
+    @Test
+    @DisplayName("모임 전체를 조회한다.")
+    void findAll() {
+        final Team team1 = new Team("a", "it's a.", "testEmoji", "#123456");
+        final Team team2 = new Team("b", "it's b.", "testEmoji", "#123456");
+        final Team team3 = new Team("c", "it's c.", "testEmoji", "#123456");
+        teamRepository.save(team1);
+        teamRepository.save(team2);
+
+        final List<Team> teams = teamRepository.findAll();
+        assertAll(
+                () -> assertThat(teams).contains(team1, team2),
+                () -> assertThat(teams).doesNotContain(team3)
+        );
     }
 }


### PR DESCRIPTION
close #144 

## 추가 구현 사항
- 레포지토리 메서드명 네이밍에 포함된 `joined` 제거
  - db 단에서는 해당 멤버아이디가 모임에 가입됐는지 여부는 중요하지 않음. 단순히 memberId로 team을 조회하는 기능에만 집중하는 메서드라 생각.