### PR TITLE
feat: 생성일자, 수정일자 필드 추가

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/NaepyeonApplication.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/NaepyeonApplication.java
@@ -2,7 +2,9 @@ package com.woowacourse.naepyeon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class NaepyeonApplication {
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/NaepyeonApplication.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/NaepyeonApplication.java
@@ -2,9 +2,7 @@ package com.woowacourse.naepyeon;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class NaepyeonApplication {
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.woowacourse.naepyeon.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/BaseEntity.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.woowacourse.naepyeon.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/BaseEntity.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/BaseEntity.java
@@ -12,12 +12,13 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 @Getter
-public class BaseEntity {
+abstract public class BaseEntity {
 
     @CreatedDate
-    @Column(updatable = false)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdDate;
 
     @LastModifiedDate
+    @Column(name = "last_modified_at", nullable = false)
     private LocalDateTime lastModifiedDate;
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Member.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseEntity {
 
     public static final int MIN_USERNAME_LENGTH = 2;
     public static final int MAX_USERNAME_LENGTH = 20;

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Member.java
@@ -12,12 +12,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "member")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Member.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Member.java
@@ -28,21 +28,21 @@ public class Member extends BaseEntity {
 
     private static final Pattern USER_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9]+$");
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
-    private static final Pattern PASSWORD_PATTERN = Pattern.compile(
-            "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d~!@#$%^&*()+|=]*$");
+    private static final Pattern PASSWORD_PATTERN =
+            Pattern.compile("^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d~!@#$%^&*()+|=]*$");
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "member_id")
     private Long id;
 
-    @Column(length = 20, nullable = false)
+    @Column(name = "username", length = 20, nullable = false)
     private String username;
 
-    @Column(length = 255, nullable = false, unique = true)
+    @Column(name = "email", length = 255, nullable = false, unique = true)
     private String email;
 
-    @Column(length = 255, nullable = false)
+    @Column(name = "password", length = 255, nullable = false)
     private String password;
 
     public Member(final String username, final String email, final String password) {

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Message.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Message.java
@@ -9,12 +9,14 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "message")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Message extends BaseEntity {
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Message.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Message.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Message {
+public class Message extends BaseEntity {
 
     public static final int MAX_CONTENT_LENGTH = 500;
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Message.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Message.java
@@ -25,15 +25,15 @@ public class Message extends BaseEntity {
     @Column(name = "message_id")
     private Long id;
 
-    @Column(length = 500, nullable = false)
+    @Column(name = "content", length = 500, nullable = false)
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member author;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "rollingpaper_id")
+    @JoinColumn(name = "rollingpaper_id", nullable = false)
     private Rollingpaper rollingpaper;
 
     public Message(final String content, final Member author, final Rollingpaper rollingpaper) {

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Rollingpaper.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Rollingpaper.java
@@ -27,7 +27,7 @@ public class Rollingpaper extends BaseEntity {
     @Column(name = "rollingpaper_id")
     private Long id;
 
-    @Column(length = 20, nullable = false)
+    @Column(name = "title", length = 20, nullable = false)
     private String title;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -35,7 +35,7 @@ public class Rollingpaper extends BaseEntity {
     private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
     public Rollingpaper(final String title, final Team team, final Member member) {

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Rollingpaper.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Rollingpaper.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "rollingpaper")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Rollingpaper {
+public class Rollingpaper extends BaseEntity {
 
     public static final int MAX_TITLE_LENGTH = 20;
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Team.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Team.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Team {
+public class Team extends BaseEntity {
 
     public static final int MAX_TEAMNAME_LENGTH = 20;
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Team.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Team.java
@@ -25,13 +25,13 @@ public class Team extends BaseEntity {
     @Column(name = "team_name", length = 20, nullable = false, unique = true)
     private String name;
 
-    @Column(length = 100, nullable = false)
+    @Column(name = "description", length = 100, nullable = false)
     private String description;
 
-    @Column(nullable = false)
+    @Column(name = "emoji", nullable = false)
     private String emoji;
 
-    @Column(length = 15, nullable = false)
+    @Column(name = "color", length = 15, nullable = false)
     private String color;
 
     public Team(final String name, final String description, final String emoji, final String color) {

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/Team.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/Team.java
@@ -6,12 +6,14 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Table(name = "team")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Team extends BaseEntity {
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/TeamParticipation.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/TeamParticipation.java
@@ -27,7 +27,7 @@ import lombok.NoArgsConstructor;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TeamParticipation {
+public class TeamParticipation extends BaseEntity {
 
     public static final int MAX_NICKNAME_LENGTH = 20;
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/TeamParticipation.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/TeamParticipation.java
@@ -37,14 +37,14 @@ public class TeamParticipation extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "team_id")
+    @JoinColumn(name = "team_id", nullable = false)
     private Team team;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @Column(length = 20, nullable = false)
+    @Column(name = "nickname", length = 20, nullable = false)
     private String nickname;
 
     public TeamParticipation(final Team team, final Member member, final String nickname) {

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/MemberRepositoryTest.java
@@ -3,6 +3,8 @@ package com.woowacourse.naepyeon.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.woowacourse.naepyeon.domain.Member;
+import java.time.LocalDateTime;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +17,9 @@ class MemberRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager em;
 
     @Test
     @DisplayName("회원을 id값으로 찾는다.")
@@ -45,5 +50,30 @@ class MemberRepositoryTest {
         // then
         assertThat(memberRepository.findById(memberId))
                 .isEmpty();
+    }
+
+    @Test
+    @DisplayName("회원을 생성할 때 생성일자가 올바르게 나온다.")
+    void createMemberWhen() {
+        final Member member = new Member("alex", "alex@naepyeon.com", "abc12345");
+        final Long memberId = memberRepository.save(member);
+
+        final Member actual = memberRepository.findById(memberId)
+                .orElseThrow();
+        assertThat(actual.getCreatedDate()).isAfter(LocalDateTime.MIN);
+    }
+
+    @Test
+    @DisplayName("회원 정보를 수정할 때 수정일자가 올바르게 나온다.")
+    void updateMemberWhen() {
+        final Member member = new Member("alex", "alex@naepyeon.com", "abc12345");
+        final Long memberId = memberRepository.save(member);
+
+        member.changeUsername("kth990303");
+        em.flush();
+
+        final Member actual = memberRepository.findById(memberId)
+                .orElseThrow();
+        assertThat(actual.getLastModifiedDate()).isAfter(actual.getCreatedDate());
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
@@ -7,7 +7,9 @@ import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Message;
 import com.woowacourse.naepyeon.domain.Rollingpaper;
 import com.woowacourse.naepyeon.domain.Team;
+import java.time.LocalDateTime;
 import java.util.List;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +23,21 @@ class MessageRepositoryTest {
 
     private static final String content = "안녕하세요";
 
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private RollingpaperRepository rollingpaperRepository;
+
+    @Autowired
+    private MessageRepository messageRepository;
+
+    @Autowired
+    private EntityManager em;
+
     private final Team team = new Team(
             "nae-pyeon",
             "테스트 모임입니다.",
@@ -30,15 +47,6 @@ class MessageRepositoryTest {
     private final Member member = new Member("member", "email1@email.com", "password123");
     private final Member author = new Member("author", "email2@email.com", "password123");
     private final Rollingpaper rollingpaper = new Rollingpaper("AlexAndKei", team, member);
-
-    @Autowired
-    private TeamRepository teamRepository;
-    @Autowired
-    private MemberRepository memberRepository;
-    @Autowired
-    private RollingpaperRepository rollingpaperRepository;
-    @Autowired
-    private MessageRepository messageRepository;
 
     @BeforeEach
     void setUp() {
@@ -110,6 +118,31 @@ class MessageRepositoryTest {
 
         assertThat(messageRepository.findById(messageId))
                 .isEmpty();
+    }
+
+    @Test
+    @DisplayName("메시지를 생성할 때 생성일자가 올바르게 나온다.")
+    void createMemberWhen() {
+        final Message message = createMessage();
+        final Long messageId = messageRepository.save(message);
+
+        final Message actual = messageRepository.findById(messageId)
+                .orElseThrow();
+        assertThat(actual.getCreatedDate()).isAfter(LocalDateTime.MIN);
+    }
+
+    @Test
+    @DisplayName("메시지를 수정할 때 수정일자가 올바르게 나온다.")
+    void updateMemberWhen() {
+        final Message message = createMessage();
+        final Long messageId = messageRepository.save(message);
+
+        message.changeContent("updateupdate");
+        em.flush();
+
+        final Message actual = messageRepository.findById(messageId)
+                .orElseThrow();
+        assertThat(actual.getLastModifiedDate()).isAfter(actual.getCreatedDate());
     }
 
     private Message createMessage() {

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/RollingpaperRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/RollingpaperRepositoryTest.java
@@ -8,7 +8,9 @@ import com.woowacourse.naepyeon.domain.Rollingpaper;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.repository.jpa.MemberJpaDao;
 import com.woowacourse.naepyeon.repository.jpa.TeamJpaDao;
+import java.time.LocalDateTime;
 import java.util.List;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +24,18 @@ class RollingpaperRepositoryTest {
 
     private static final String rollingPaperTitle = "AlexAndKei";
 
+    @Autowired
+    private TeamJpaDao teamJpaDao;
+
+    @Autowired
+    private MemberJpaDao memberJpaDao;
+
+    @Autowired
+    private RollingpaperRepository rollingpaperRepository;
+
+    @Autowired
+    private EntityManager em;
+
     private final Team team = new Team(
             "nae-pyeon",
             "테스트 모임입니다.",
@@ -29,13 +43,6 @@ class RollingpaperRepositoryTest {
             "#123456"
     );
     private final Member member = new Member("member", "m@hello.com", "abc@@1234");
-
-    @Autowired
-    private TeamJpaDao teamJpaDao;
-    @Autowired
-    private MemberJpaDao memberJpaDao;
-    @Autowired
-    private RollingpaperRepository rollingpaperRepository;
 
     @BeforeEach
     void setUp() {
@@ -111,6 +118,31 @@ class RollingpaperRepositoryTest {
 
         assertThat(rollingpaperRepository.findById(rollingPaperId))
                 .isEmpty();
+    }
+
+    @Test
+    @DisplayName("롤링페이퍼를 생성할 때 생성일자가 올바르게 나온다.")
+    void createMemberWhen() {
+        final Rollingpaper message = createRollingPaper();
+        final Long rollingpaperId = rollingpaperRepository.save(message);
+
+        final Rollingpaper actual = rollingpaperRepository.findById(rollingpaperId)
+                .orElseThrow();
+        assertThat(actual.getCreatedDate()).isAfter(LocalDateTime.MIN);
+    }
+
+    @Test
+    @DisplayName("롤링페이퍼를 수정할 때 수정일자가 올바르게 나온다.")
+    void updateMemberWhen() {
+        final Rollingpaper rollingpaper = createRollingPaper();
+        final Long rollingpaperId = rollingpaperRepository.save(rollingpaper);
+
+        rollingpaper.changeTitle("updateupdate");
+        em.flush();
+
+        final Rollingpaper actual = rollingpaperRepository.findById(rollingpaperId)
+                .orElseThrow();
+        assertThat(actual.getLastModifiedDate()).isAfter(actual.getCreatedDate());
     }
 
     private Rollingpaper createRollingPaper() {

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.naepyeon.domain.Member;
+import com.woowacourse.naepyeon.domain.Rollingpaper;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
 import com.woowacourse.naepyeon.exception.DuplicateTeamPaticipateException;
+import java.time.LocalDateTime;
 import java.util.List;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +31,9 @@ class TeamParticipationRepositoryTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager em;
 
     private final Member member1 = new Member("내편이1", "naePyeon1@test.com", "testtest123");
     private final Member member2 = new Member("내편이2", "naePyeon2@test.com", "testtest123");
@@ -134,5 +140,16 @@ class TeamParticipationRepositoryTest {
                 () -> assertThat(teamParticipationRepository.isJoinedMember(member1.getId(), team1.getId())).isTrue(),
                 () -> assertThat(teamParticipationRepository.isJoinedMember(member2.getId(), team1.getId())).isFalse()
         );
+    }
+
+    @Test
+    @DisplayName("회원 가입일자가 올바르게 나온다.")
+    void createMemberWhen() {
+        final TeamParticipation teamParticipation = new TeamParticipation(team1, member1, "닉네임1");
+        final Long teamParticipationId = teamParticipationRepository.save(teamParticipation);
+
+        final TeamParticipation actual = teamParticipationRepository.findById(teamParticipationId)
+                .orElseThrow();
+        assertThat(actual.getCreatedDate()).isAfter(LocalDateTime.MIN);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamRepositoryTest.java
@@ -6,7 +6,9 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.exception.NotFoundTeamException;
+import java.time.LocalDateTime;
 import java.util.List;
+import javax.persistence.EntityManager;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +21,9 @@ class TeamRepositoryTest {
 
     @Autowired
     private TeamRepository teamRepository;
+
+    @Autowired
+    private EntityManager em;
 
     @Test
     @DisplayName("모임을 id로 찾는다.")
@@ -78,5 +83,30 @@ class TeamRepositoryTest {
                 () -> assertThat(teams).contains(team1, team2),
                 () -> assertThat(teams).doesNotContain(team3)
         );
+    }
+
+    @Test
+    @DisplayName("모임을 생성할 때 생성일자가 올바르게 나온다.")
+    void createMemberWhen() {
+        final Team team = new Team("woowacourse", "테스트 모임입니다.", "testEmoji", "#123456");
+        final Long teamId = teamRepository.save(team);
+
+        final Team actual = teamRepository.findById(teamId)
+                .orElseThrow();
+        assertThat(actual.getCreatedDate()).isAfter(LocalDateTime.MIN);
+    }
+
+    @Test
+    @DisplayName("모임을 수정할 때 수정일자가 올바르게 나온다.")
+    void updateMemberWhen() {
+        final Team team = new Team("woowacourse", "테스트 모임입니다.", "testEmoji", "#123456");
+        final Long teamId = teamRepository.save(team);
+
+        team.changeName("updateupdate");
+        em.flush();
+
+        final Team actual = teamRepository.findById(teamId)
+                .orElseThrow();
+        assertThat(actual.getLastModifiedDate()).isAfter(actual.getCreatedDate());
     }
 }


### PR DESCRIPTION
close #88

## 개발 이슈
### 증상
- 수정일자를 테스트하기 위해 Entitymanager의 flush 기능이 필요해서 RepositoryTest에 `@Autowired`로 EntityManager를 주입받았으나 아래 사진처럼 빨간줄이 발생하면서 `Could not autowire. No beans of 'EntityManager' type found.`에러 발생
<img width="660" alt="image" src="https://user-images.githubusercontent.com/57135043/180748263-9105f9ea-17d5-4502-80ff-3a6d1bee7b89.png">
- `@SpringBootTest` 또는 `@DataJpaTest`를 사용하면 EntityManager는 자동으로 스프링 빈으로 관리되기 때문에 `@Autowired`를 사용하면 EntityManager이 호출돼야 정상인데 위처럼 빨간줄이 발생함.

### 원인
스프링부트 2.7.1 버전의 버그.

### 해결방법
1. 스프링부트 버전을 2.6.9 이하로 내리면 해결된다.
2. 해당 빨간줄은 버그일 뿐, 테스트 및 실행에 아무런 문제가 없으므로 무시한다. -> **채택**
