### PR TITLE
feat: 모임 마이페이지 기능 구현

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/TeamController.java
@@ -5,9 +5,11 @@ import com.woowacourse.naepyeon.controller.dto.CreateResponse;
 import com.woowacourse.naepyeon.controller.dto.JoinTeamMemberRequest;
 import com.woowacourse.naepyeon.controller.dto.LoginMemberRequest;
 import com.woowacourse.naepyeon.controller.dto.TeamRequest;
+import com.woowacourse.naepyeon.controller.dto.UpdateTeamMemberRequest;
 import com.woowacourse.naepyeon.exception.UncertificationTeamMemberException;
 import com.woowacourse.naepyeon.service.TeamService;
 import com.woowacourse.naepyeon.service.dto.JoinedMembersResponseDto;
+import com.woowacourse.naepyeon.service.dto.TeamMemberResponseDto;
 import com.woowacourse.naepyeon.service.dto.TeamResponseDto;
 import com.woowacourse.naepyeon.service.dto.TeamsResponseDto;
 import java.net.URI;
@@ -94,6 +96,23 @@ public class TeamController {
                                            @PathVariable final Long teamId,
                                            @RequestBody final JoinTeamMemberRequest joinTeamMemberRequest) {
         teamService.joinMember(teamId, loginMemberRequest.getId(), joinTeamMemberRequest.getNickname());
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{teamId}/me")
+    public ResponseEntity<TeamMemberResponseDto> getMyInfoInTeam(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
+            @PathVariable final Long teamId) {
+        final TeamMemberResponseDto responseDto = teamService.findMyInfoInTeam(teamId, loginMemberRequest.getId());
+        return ResponseEntity.ok(responseDto);
+    }
+
+    @PutMapping("/{teamId}/me")
+    public ResponseEntity<Void> updateNickname(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
+            @PathVariable final Long teamId,
+            @RequestBody final UpdateTeamMemberRequest updateTeamMemberRequest) {
+        teamService.updateNickname(teamId, loginMemberRequest.getId(), updateTeamMemberRequest.getNickname());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/TeamController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/TeamController.java
@@ -5,7 +5,7 @@ import com.woowacourse.naepyeon.controller.dto.CreateResponse;
 import com.woowacourse.naepyeon.controller.dto.JoinTeamMemberRequest;
 import com.woowacourse.naepyeon.controller.dto.LoginMemberRequest;
 import com.woowacourse.naepyeon.controller.dto.TeamRequest;
-import com.woowacourse.naepyeon.controller.dto.UpdateTeamMemberRequest;
+import com.woowacourse.naepyeon.controller.dto.UpdateTeamParticipantRequest;
 import com.woowacourse.naepyeon.exception.UncertificationTeamMemberException;
 import com.woowacourse.naepyeon.service.TeamService;
 import com.woowacourse.naepyeon.service.dto.JoinedMembersResponseDto;
@@ -108,11 +108,11 @@ public class TeamController {
     }
 
     @PutMapping("/{teamId}/me")
-    public ResponseEntity<Void> updateNickname(
+    public ResponseEntity<Void> updateMyInfo(
             @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest,
             @PathVariable final Long teamId,
-            @RequestBody final UpdateTeamMemberRequest updateTeamMemberRequest) {
-        teamService.updateNickname(teamId, loginMemberRequest.getId(), updateTeamMemberRequest.getNickname());
+            @RequestBody final UpdateTeamParticipantRequest updateTeamParticipantRequest) {
+        teamService.updateMyInfo(teamId, loginMemberRequest.getId(), updateTeamParticipantRequest.getNickname());
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/dto/UpdateTeamMemberRequest.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/dto/UpdateTeamMemberRequest.java
@@ -1,0 +1,16 @@
+package com.woowacourse.naepyeon.controller.dto;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class UpdateTeamMemberRequest {
+
+    @NotBlank(message = "4009:닉네임은 공백일 수 없습니다.")
+    private String nickname;
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/dto/UpdateTeamParticipantRequest.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/dto/UpdateTeamParticipantRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-public class UpdateTeamMemberRequest {
+public class UpdateTeamParticipantRequest {
 
     @NotBlank(message = "4009:닉네임은 공백일 수 없습니다.")
     private String nickname;

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/DuplicateNicknameException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/DuplicateNicknameException.java
@@ -3,6 +3,7 @@ package com.woowacourse.naepyeon.exception;
 import org.springframework.http.HttpStatus;
 
 public final class DuplicateNicknameException extends NaePyeonException {
+
     public DuplicateNicknameException(final String nickname) {
         super(
                 String.format("이미 존재하는 닉네임입니다. teamName={%s}", nickname),

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/DuplicateNicknameException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/DuplicateNicknameException.java
@@ -1,0 +1,14 @@
+package com.woowacourse.naepyeon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public final class DuplicateNicknameException extends NaePyeonException {
+    public DuplicateNicknameException(final String nickname) {
+        super(
+                String.format("이미 존재하는 닉네임입니다. teamName={%s}", nickname),
+                "이미 존재하는 닉네임이름입니다.",
+                HttpStatus.BAD_REQUEST,
+                "4014"
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/DuplicateNicknameException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/DuplicateNicknameException.java
@@ -6,7 +6,7 @@ public final class DuplicateNicknameException extends NaePyeonException {
     public DuplicateNicknameException(final String nickname) {
         super(
                 String.format("이미 존재하는 닉네임입니다. teamName={%s}", nickname),
-                "이미 존재하는 닉네임이름입니다.",
+                "이미 존재하는 닉네임입니다.",
                 HttpStatus.BAD_REQUEST,
                 "4014"
         );

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
@@ -51,12 +51,12 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
     }
 
     @Override
-    public String findNicknameByMemberId(final Long memberId, final Long teamId) {
+    public String findNicknameByMemberIdAndTeamId(final Long memberId, final Long teamId) {
         return teamParticipationJpaDao.findNicknameByMemberIdAndTeamId(memberId, teamId);
     }
 
     @Override
-    public List<String> findAllNicknames(final Long teamId) {
+    public List<String> findAllNicknamesByTeamId(final Long teamId) {
         return teamParticipationJpaDao.findNicknamesByTeamId(teamId);
     }
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
@@ -1,5 +1,6 @@
 package com.woowacourse.naepyeon.repository;
 
+import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
 import com.woowacourse.naepyeon.exception.DuplicateTeamPaticipateException;
@@ -35,6 +36,11 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
     }
 
     @Override
+    public Member findMemberByMemberIdAndTeamId(final Long memberId, final Long teamId) {
+        return teamParticipationJpaDao.findMemberByMemberIdAndTeamId(memberId, teamId);
+    }
+
+    @Override
     public List<TeamParticipation> findByTeamId(final Long teamId) {
         return teamParticipationJpaDao.findByTeamId(teamId);
     }
@@ -45,8 +51,13 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
     }
 
     @Override
-    public String findNicknameByMemberId(final Long addresseeId, final Long teamId) {
-        return teamParticipationJpaDao.findNicknameByMemberIdAndTeamId(addresseeId, teamId);
+    public String findNicknameByMemberId(final Long memberId, final Long teamId) {
+        return teamParticipationJpaDao.findNicknameByMemberIdAndTeamId(memberId, teamId);
+    }
+
+    @Override
+    public List<String> findAllNicknames(final Long teamId) {
+        return teamParticipationJpaDao.findNicknamesByTeamId(teamId);
     }
 
     @Override
@@ -54,5 +65,10 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
         final List<Team> teams = teamParticipationJpaDao.findTeamsByMemberId(memberId);
         return teams.stream()
                 .anyMatch(team -> team.getId().equals(teamId));
+    }
+
+    @Override
+    public void updateNickname(final String newNickname, final Long memberId, final Long teamId) {
+        teamParticipationJpaDao.updateNickname(newNickname, memberId, teamId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/JpaTeamParticipationRepository.java
@@ -36,8 +36,9 @@ public class JpaTeamParticipationRepository implements TeamParticipationReposito
     }
 
     @Override
-    public Member findMemberByMemberIdAndTeamId(final Long memberId, final Long teamId) {
+    public Optional<Member> findMemberByMemberIdAndTeamId(final Long memberId, final Long teamId) {
         return teamParticipationJpaDao.findMemberByMemberIdAndTeamId(memberId, teamId);
+
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
@@ -12,7 +12,7 @@ public interface TeamParticipationRepository {
 
     Optional<TeamParticipation> findById(final Long id);
 
-    Member findMemberByMemberIdAndTeamId(final Long memberId, final Long teamId);
+    Optional<Member> findMemberByMemberIdAndTeamId(final Long memberId, final Long teamId);
 
     List<TeamParticipation> findByTeamId(final Long teamId);
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
@@ -18,9 +18,9 @@ public interface TeamParticipationRepository {
 
     List<Team> findTeamsByMemberId(final Long memberId);
 
-    String findNicknameByMemberId(final Long memberId, final Long teamId);
+    String findNicknameByMemberIdAndTeamId(final Long memberId, final Long teamId);
 
-    List<String> findAllNicknames(final Long teamId);
+    List<String> findAllNicknamesByTeamId(final Long teamId);
 
     boolean isJoinedMember(final Long memberId, final Long teamId);
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/TeamParticipationRepository.java
@@ -1,5 +1,6 @@
 package com.woowacourse.naepyeon.repository;
 
+import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
 import java.util.List;
@@ -11,11 +12,17 @@ public interface TeamParticipationRepository {
 
     Optional<TeamParticipation> findById(final Long id);
 
+    Member findMemberByMemberIdAndTeamId(final Long memberId, final Long teamId);
+
     List<TeamParticipation> findByTeamId(final Long teamId);
 
     List<Team> findTeamsByMemberId(final Long memberId);
 
-    String findNicknameByMemberId(final Long addresseeId, final Long teamId);
+    String findNicknameByMemberId(final Long memberId, final Long teamId);
+
+    List<String> findAllNicknames(final Long teamId);
 
     boolean isJoinedMember(final Long memberId, final Long teamId);
+
+    void updateNickname(final String newNickname, final Long memberId, final Long teamId);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
@@ -4,6 +4,7 @@ import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -23,7 +24,8 @@ public interface TeamParticipationJpaDao extends JpaRepository<TeamParticipation
             + "from TeamParticipation p "
             + "join Member m on m.id = :memberId "
             + "where p.team.id = :teamId")
-    Member findMemberByMemberIdAndTeamId(@Param("memberId") final Long memberId, @Param("teamId") final Long teamId);
+    Optional<Member> findMemberByMemberIdAndTeamId(@Param("memberId") final Long memberId,
+                                                   @Param("teamId") final Long teamId);
 
     @Query("select p.nickname "
             + "from TeamParticipation p "

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/jpa/TeamParticipationJpaDao.java
@@ -1,9 +1,11 @@
 package com.woowacourse.naepyeon.repository.jpa;
 
+import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -11,13 +13,32 @@ public interface TeamParticipationJpaDao extends JpaRepository<TeamParticipation
 
     List<TeamParticipation> findByTeamId(final Long teamId);
 
-    @Query("select p.team "
+    @Query("select t "
             + "from TeamParticipation p "
+            + "join p.team t "
             + "where p.member.id = :memberId")
     List<Team> findTeamsByMemberId(@Param("memberId") final Long memberId);
+
+    @Query("select p.member "
+            + "from TeamParticipation p "
+            + "join Member m on m.id = :memberId "
+            + "where p.team.id = :teamId")
+    Member findMemberByMemberIdAndTeamId(@Param("memberId") final Long memberId, @Param("teamId") final Long teamId);
 
     @Query("select p.nickname "
             + "from TeamParticipation p "
             + "where p.member.id = :memberId and p.team.id = :teamId")
     String findNicknameByMemberIdAndTeamId(@Param("memberId") final Long memberId, @Param("teamId") final Long teamId);
+
+    @Query("select p.nickname "
+            + "from TeamParticipation p "
+            + "where p.team.id = :teamId")
+    List<String> findNicknamesByTeamId(@Param("teamId") final Long teamId);
+
+    @Query("update TeamParticipation p "
+            + "set p.nickname = :newNickname "
+            + "where p.member.id = :memberId and p.team.id = :teamId")
+    @Modifying(clearAutomatically = true)
+    void updateNickname(@Param("newNickname") final String newNickname,
+                        @Param("memberId") final Long memberId, @Param("teamId") final Long teamId);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/MessageService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/MessageService.java
@@ -56,7 +56,7 @@ public class MessageService {
 
     private String findMessageWriterNickname(final Long teamId, final Message message) {
         final Member author = message.getAuthor();
-        return teamParticipationRepository.findNicknameByMemberId(author.getId(), teamId);
+        return teamParticipationRepository.findNicknameByMemberIdAndTeamId(author.getId(), teamId);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
@@ -92,7 +92,7 @@ public class RollingpaperService {
     }
 
     private String findRollingpaperAddresseeNickname(final Rollingpaper rollingpaper, final Long teamId) {
-        return teamParticipationRepository.findNicknameByMemberId(rollingpaper.getAddresseeId(), teamId);
+        return teamParticipationRepository.findNicknameByMemberIdAndTeamId(rollingpaper.getAddresseeId(), teamId);
     }
 
     public void updateTitle(final Long rollingpaperId, final String newTitle, final Long teamId,

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
@@ -4,13 +4,16 @@ import com.woowacourse.naepyeon.controller.dto.TeamRequest;
 import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
+import com.woowacourse.naepyeon.exception.DuplicateNicknameException;
 import com.woowacourse.naepyeon.exception.NotFoundMemberException;
 import com.woowacourse.naepyeon.exception.NotFoundTeamException;
+import com.woowacourse.naepyeon.exception.UncertificationTeamMemberException;
 import com.woowacourse.naepyeon.repository.MemberRepository;
 import com.woowacourse.naepyeon.repository.TeamParticipationRepository;
 import com.woowacourse.naepyeon.repository.TeamRepository;
 import com.woowacourse.naepyeon.service.dto.JoinedMemberResponseDto;
 import com.woowacourse.naepyeon.service.dto.JoinedMembersResponseDto;
+import com.woowacourse.naepyeon.service.dto.TeamMemberResponseDto;
 import com.woowacourse.naepyeon.service.dto.TeamResponseDto;
 import com.woowacourse.naepyeon.service.dto.TeamsResponseDto;
 import java.util.List;
@@ -105,10 +108,34 @@ public class TeamService {
         return new JoinedMembersResponseDto(joinedMembers);
     }
 
+    public TeamMemberResponseDto findMyInfoInTeam(final Long teamId, final Long memberId) {
+        checkMemberNotIncludedTeam(teamId, memberId);
+        final String nickname = teamParticipationRepository.findNicknameByMemberId(memberId, teamId);
+        return new TeamMemberResponseDto(nickname);
+    }
+
+    @Transactional
+    public void updateNickname(final Long teamId, final Long memberId, final String newNickname) {
+        checkMemberNotIncludedTeam(teamId, memberId);
+        if (teamParticipationRepository.findAllNicknames(teamId).contains(newNickname)) {
+            throw new DuplicateNicknameException(newNickname);
+        }
+        teamParticipationRepository.updateNickname(newNickname, memberId, teamId);
+    }
+
     public boolean isJoinedMember(final Long memberId, final Long teamId) {
         if (teamRepository.findById(teamId).isEmpty()) {
             throw new NotFoundTeamException(teamId);
         }
         return teamParticipationRepository.isJoinedMember(memberId, teamId);
+    }
+
+    private void checkMemberNotIncludedTeam(final Long teamId, final Long memberId) {
+        if (teamRepository.findById(teamId).isEmpty()) {
+            throw new NotFoundTeamException(teamId);
+        }
+        if (!isJoinedMember(memberId, teamId)) {
+            throw new UncertificationTeamMemberException(teamId, memberId);
+        }
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
@@ -124,9 +124,6 @@ public class TeamService {
     }
 
     private void checkMemberNotIncludedTeam(final Long teamId, final Long memberId) {
-        if (teamRepository.findById(teamId).isEmpty()) {
-            throw new NotFoundTeamException(teamId);
-        }
         if (!isJoinedMember(memberId, teamId)) {
             throw new UncertificationTeamMemberException(teamId, memberId);
         }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
@@ -110,14 +110,14 @@ public class TeamService {
 
     public TeamMemberResponseDto findMyInfoInTeam(final Long teamId, final Long memberId) {
         checkMemberNotIncludedTeam(teamId, memberId);
-        final String nickname = teamParticipationRepository.findNicknameByMemberId(memberId, teamId);
+        final String nickname = teamParticipationRepository.findNicknameByMemberIdAndTeamId(memberId, teamId);
         return new TeamMemberResponseDto(nickname);
     }
 
     @Transactional
     public void updateNickname(final Long teamId, final Long memberId, final String newNickname) {
         checkMemberNotIncludedTeam(teamId, memberId);
-        if (teamParticipationRepository.findAllNicknames(teamId).contains(newNickname)) {
+        if (teamParticipationRepository.findAllNicknamesByTeamId(teamId).contains(newNickname)) {
             throw new DuplicateNicknameException(newNickname);
         }
         teamParticipationRepository.updateNickname(newNickname, memberId, teamId);

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
@@ -123,13 +123,6 @@ public class TeamService {
         teamParticipationRepository.updateNickname(newNickname, memberId, teamId);
     }
 
-    public boolean isJoinedMember(final Long memberId, final Long teamId) {
-        if (teamRepository.findById(teamId).isEmpty()) {
-            throw new NotFoundTeamException(teamId);
-        }
-        return teamParticipationRepository.isJoinedMember(memberId, teamId);
-    }
-
     private void checkMemberNotIncludedTeam(final Long teamId, final Long memberId) {
         if (teamRepository.findById(teamId).isEmpty()) {
             throw new NotFoundTeamException(teamId);
@@ -137,5 +130,12 @@ public class TeamService {
         if (!isJoinedMember(memberId, teamId)) {
             throw new UncertificationTeamMemberException(teamId, memberId);
         }
+    }
+
+    public boolean isJoinedMember(final Long memberId, final Long teamId) {
+        if (teamRepository.findById(teamId).isEmpty()) {
+            throw new NotFoundTeamException(teamId);
+        }
+        return teamParticipationRepository.isJoinedMember(memberId, teamId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/TeamService.java
@@ -115,7 +115,7 @@ public class TeamService {
     }
 
     @Transactional
-    public void updateNickname(final Long teamId, final Long memberId, final String newNickname) {
+    public void updateMyInfo(final Long teamId, final Long memberId, final String newNickname) {
         checkMemberNotIncludedTeam(teamId, memberId);
         if (teamParticipationRepository.findAllNicknamesByTeamId(teamId).contains(newNickname)) {
             throw new DuplicateNicknameException(newNickname);

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/dto/TeamMemberResponseDto.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/dto/TeamMemberResponseDto.java
@@ -1,0 +1,14 @@
+package com.woowacourse.naepyeon.service.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class TeamMemberResponseDto {
+
+    private String nickname;
+}

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
@@ -10,7 +10,7 @@ import com.woowacourse.naepyeon.controller.dto.RollingpaperCreateRequest;
 import com.woowacourse.naepyeon.controller.dto.RollingpaperUpdateRequest;
 import com.woowacourse.naepyeon.controller.dto.TeamRequest;
 import com.woowacourse.naepyeon.controller.dto.TokenRequest;
-import com.woowacourse.naepyeon.controller.dto.UpdateTeamMemberRequest;
+import com.woowacourse.naepyeon.controller.dto.UpdateTeamParticipantRequest;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -151,10 +151,10 @@ public class AcceptanceFixture {
         return get(tokenResponseDto, "/api/v1/teams/" + teamId + "/me");
     }
 
-    public static ExtractableResponse<Response> 모임_닉네임_변경(final TokenResponseDto tokenResponseDto,
-                                                          final Long teamId,
-                                                          final UpdateTeamMemberRequest updateTeamMemberRequest) {
-        return put(tokenResponseDto, updateTeamMemberRequest, "/api/v1/teams/" + teamId + "/me");
+    public static ExtractableResponse<Response> 모임_내_닉네임_변경(final TokenResponseDto tokenResponseDto,
+                                                            final Long teamId,
+                                                            final UpdateTeamParticipantRequest updateTeamParticipantRequest) {
+        return put(tokenResponseDto, updateTeamParticipantRequest, "/api/v1/teams/" + teamId + "/me");
     }
 
     public static ExtractableResponse<Response> 회원_롤링페이퍼_생성(final TokenResponseDto tokenResponseDto,
@@ -205,8 +205,8 @@ public class AcceptanceFixture {
     }
 
     public static ExtractableResponse<Response> 메시지_조회(final TokenResponseDto tokenResponseDto,
-                                                final Long rollingpaperId,
-                                                final Long messageId) {
+                                                       final Long rollingpaperId,
+                                                       final Long messageId) {
         return get(tokenResponseDto, "/api/v1/rollingpapers/" + rollingpaperId + "/messages/" + messageId);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceFixture.java
@@ -10,6 +10,7 @@ import com.woowacourse.naepyeon.controller.dto.RollingpaperCreateRequest;
 import com.woowacourse.naepyeon.controller.dto.RollingpaperUpdateRequest;
 import com.woowacourse.naepyeon.controller.dto.TeamRequest;
 import com.woowacourse.naepyeon.controller.dto.TokenRequest;
+import com.woowacourse.naepyeon.controller.dto.UpdateTeamMemberRequest;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -140,9 +141,20 @@ public class AcceptanceFixture {
         return get(tokenResponseDto, "/api/v1/teams/me");
     }
 
-    public static ExtractableResponse<Response> 모임에_가입한_회원_조회(final TokenResponseDto tokenResponseDto,
-                                                              final Long teamId) {
+    public static ExtractableResponse<Response> 모임에_가입한_회원_목록_조회(final TokenResponseDto tokenResponseDto,
+                                                                 final Long teamId) {
         return get(tokenResponseDto, "/api/v1/teams/" + teamId + "/members");
+    }
+
+    public static ExtractableResponse<Response> 모임_가입_정보_조회(final TokenResponseDto tokenResponseDto,
+                                                            final Long teamId) {
+        return get(tokenResponseDto, "/api/v1/teams/" + teamId + "/me");
+    }
+
+    public static ExtractableResponse<Response> 모임_닉네임_변경(final TokenResponseDto tokenResponseDto,
+                                                          final Long teamId,
+                                                          final UpdateTeamMemberRequest updateTeamMemberRequest) {
+        return put(tokenResponseDto, updateTeamMemberRequest, "/api/v1/teams/" + teamId + "/me");
     }
 
     public static ExtractableResponse<Response> 회원_롤링페이퍼_생성(final TokenResponseDto tokenResponseDto,

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/TeamAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/TeamAcceptanceTest.java
@@ -4,7 +4,7 @@ import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.가입한_�
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모든_모임_조회;
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_가입;
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_가입_정보_조회;
-import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_닉네임_변경;
+import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_내_닉네임_변경;
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_단건_조회;
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_삭제;
 import static com.woowacourse.naepyeon.acceptance.AcceptanceFixture.모임_생성;
@@ -19,7 +19,7 @@ import com.woowacourse.naepyeon.controller.dto.CreateResponse;
 import com.woowacourse.naepyeon.controller.dto.JoinTeamMemberRequest;
 import com.woowacourse.naepyeon.controller.dto.MemberRegisterRequest;
 import com.woowacourse.naepyeon.controller.dto.TeamRequest;
-import com.woowacourse.naepyeon.controller.dto.UpdateTeamMemberRequest;
+import com.woowacourse.naepyeon.controller.dto.UpdateTeamParticipantRequest;
 import com.woowacourse.naepyeon.service.dto.JoinedMemberResponseDto;
 import com.woowacourse.naepyeon.service.dto.JoinedMembersResponseDto;
 import com.woowacourse.naepyeon.service.dto.TeamMemberResponseDto;
@@ -422,9 +422,10 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final TokenResponseDto tokenResponseDto = 회원가입_후_로그인(member);
         final Long teamId = 모임_생성(tokenResponseDto);
 
-        final TeamMemberResponseDto actual = 모임_가입_정보_조회(tokenResponseDto, teamId)
-                .as(TeamMemberResponseDto.class);
-        assertThat(actual.getNickname()).isEqualTo(expected);
+        final String actual = 모임_가입_정보_조회(tokenResponseDto, teamId)
+                .as(TeamMemberResponseDto.class)
+                .getNickname();
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -436,12 +437,13 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final TokenResponseDto tokenResponseDto = 회원가입_후_로그인(member);
         final Long teamId = 모임_생성(tokenResponseDto);
 
-        final UpdateTeamMemberRequest updateTeamMemberRequest = new UpdateTeamMemberRequest(expected);
-        모임_닉네임_변경(tokenResponseDto, teamId, updateTeamMemberRequest);
+        final UpdateTeamParticipantRequest updateTeamParticipantRequest = new UpdateTeamParticipantRequest(expected);
+        모임_내_닉네임_변경(tokenResponseDto, teamId, updateTeamParticipantRequest);
 
-        final TeamMemberResponseDto actual = 모임_가입_정보_조회(tokenResponseDto, teamId)
-                .as(TeamMemberResponseDto.class);
-        assertThat(actual.getNickname()).isEqualTo(expected);
+        final String actual = 모임_가입_정보_조회(tokenResponseDto, teamId)
+                .as(TeamMemberResponseDto.class)
+                .getNickname();
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -458,8 +460,9 @@ class TeamAcceptanceTest extends AcceptanceTest {
         final JoinTeamMemberRequest request = new JoinTeamMemberRequest("애플");
         모임_가입(tokenResponseDto2, teamId, request);
 
-        final UpdateTeamMemberRequest updateTeamMemberRequest = new UpdateTeamMemberRequest("나는야모임장");
-        final ExtractableResponse<Response> response = 모임_닉네임_변경(tokenResponseDto, teamId, updateTeamMemberRequest);
+        final UpdateTeamParticipantRequest updateTeamParticipantRequest = new UpdateTeamParticipantRequest("나는야모임장");
+        final ExtractableResponse<Response> response = 모임_내_닉네임_변경(tokenResponseDto, teamId,
+                updateTeamParticipantRequest);
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.woowacourse.naepyeon.domain.Member;
-import com.woowacourse.naepyeon.domain.Rollingpaper;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
 import com.woowacourse.naepyeon.exception.DuplicateTeamPaticipateException;
@@ -80,6 +79,16 @@ class TeamParticipationRepositoryTest {
     }
 
     @Test
+    @DisplayName("모임에 가입한 회원을 memberId와 teamId로 찾는다.")
+    void findMemberByMemberIdAndTeamId() {
+        final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member1, "닉네임1");
+        teamParticipationRepository.save(teamParticipation1);
+
+        assertThat(teamParticipationRepository.findMemberByMemberIdAndTeamId(member1.getId(), team1.getId()))
+                .isEqualTo(member1);
+    }
+
+    @Test
     @DisplayName("모임에 가입한 회원들을 team id로 조회한다.")
     void findByTeamId() {
         final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member1, "닉네임1");
@@ -127,6 +136,20 @@ class TeamParticipationRepositoryTest {
     }
 
     @Test
+    @DisplayName("특정 팀의 모든 닉네임들을 조회한다.")
+    void findAllNicknamesByTeamId() {
+        final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member1, "닉네임1");
+        final TeamParticipation teamParticipation2 = new TeamParticipation(team1, member2, "닉네임2");
+
+        teamParticipationRepository.save(teamParticipation1);
+        teamParticipationRepository.save(teamParticipation2);
+
+        final List<String> actual = teamParticipationRepository.findAllNicknames(team1.getId());
+
+        assertThat(actual).contains("닉네임1", "닉네임2");
+    }
+
+    @Test
     @DisplayName("특정 모임에 회원이 가입했는지 여부를 반환한다.")
     void isJoinedMember() {
         final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member1, "닉네임1");
@@ -151,5 +174,21 @@ class TeamParticipationRepositoryTest {
         final TeamParticipation actual = teamParticipationRepository.findById(teamParticipationId)
                 .orElseThrow();
         assertThat(actual.getCreatedDate()).isAfter(LocalDateTime.MIN);
+    }
+
+    @Test
+    @DisplayName("회원이 특정 팀의 닉네임을 변경한다.")
+    void updateNickname() {
+        final String expected = "닉네임2";
+        final TeamParticipation teamParticipation = new TeamParticipation(team1, member1, "닉네임1");
+        final Long teamParticipationId = teamParticipationRepository.save(teamParticipation);
+
+        teamParticipationRepository.updateNickname(expected, member1.getId(), team1.getId());
+        em.flush();
+
+        final String actual = teamParticipationRepository.findById(teamParticipationId)
+                .orElseThrow()
+                .getNickname();
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
@@ -130,7 +130,7 @@ class TeamParticipationRepositoryTest {
         teamParticipationRepository.save(teamParticipation1);
 
         final String actual =
-                teamParticipationRepository.findNicknameByMemberId(member1.getId(), team1.getId());
+                teamParticipationRepository.findNicknameByMemberIdAndTeamId(member1.getId(), team1.getId());
 
         assertThat(actual).isEqualTo(expected);
     }
@@ -144,7 +144,7 @@ class TeamParticipationRepositoryTest {
         teamParticipationRepository.save(teamParticipation1);
         teamParticipationRepository.save(teamParticipation2);
 
-        final List<String> actual = teamParticipationRepository.findAllNicknames(team1.getId());
+        final List<String> actual = teamParticipationRepository.findAllNicknamesByTeamId(team1.getId());
 
         assertThat(actual).contains("닉네임1", "닉네임2");
     }

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
@@ -84,8 +84,9 @@ class TeamParticipationRepositoryTest {
         final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member1, "닉네임1");
         teamParticipationRepository.save(teamParticipation1);
 
-        assertThat(teamParticipationRepository.findMemberByMemberIdAndTeamId(member1.getId(), team1.getId()))
-                .isEqualTo(member1);
+        final Member actual = teamParticipationRepository.findMemberByMemberIdAndTeamId(member1.getId(), team1.getId())
+                .orElseThrow();
+        assertThat(actual).isEqualTo(member1);
     }
 
     @Test

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
@@ -8,12 +8,15 @@ import com.woowacourse.naepyeon.controller.dto.TeamRequest;
 import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Team;
 import com.woowacourse.naepyeon.domain.TeamParticipation;
+import com.woowacourse.naepyeon.exception.DuplicateNicknameException;
 import com.woowacourse.naepyeon.exception.NotFoundMemberException;
 import com.woowacourse.naepyeon.exception.NotFoundTeamException;
+import com.woowacourse.naepyeon.exception.UncertificationTeamMemberException;
 import com.woowacourse.naepyeon.repository.MemberRepository;
 import com.woowacourse.naepyeon.repository.TeamParticipationRepository;
 import com.woowacourse.naepyeon.repository.TeamRepository;
 import com.woowacourse.naepyeon.service.dto.JoinedMemberResponseDto;
+import com.woowacourse.naepyeon.service.dto.TeamMemberResponseDto;
 import com.woowacourse.naepyeon.service.dto.TeamResponseDto;
 import com.woowacourse.naepyeon.service.dto.TeamsResponseDto;
 import java.util.List;
@@ -250,6 +253,80 @@ class TeamServiceTest {
     @DisplayName("모임에 회원 가입 여부를 확인할 때, 해당 모임이 존재하지 않으면 예외를 발생시킨다.")
     void isJoinedMemberWithNotFoundTeam() {
         assertThatThrownBy(() -> teamService.isJoinedMember(member.getId(), team1.getId() + 1000L))
+                .isInstanceOf(NotFoundTeamException.class);
+    }
+
+    @Test
+    @DisplayName("모임에서의 마이페이지를 조회한다.")
+    void findMyInfoInTeam() {
+        final String expected = "닉네임1";
+        final TeamParticipation teamParticipation = new TeamParticipation(team1, member, expected);
+        teamParticipationRepository.save(teamParticipation);
+
+        final TeamMemberResponseDto actual = teamService.findMyInfoInTeam(team1.getId(), member.getId());
+
+        assertThat(actual.getNickname()).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("모임 내 마이페이지 조회 창에서 가입한 모임이 아닐 경우 예외를 발생시킨다.")
+    void findMyInfoInOtherTeam() {
+        final TeamParticipation teamParticipation = new TeamParticipation(team1, member, "해커");
+        teamParticipationRepository.save(teamParticipation);
+
+        assertThatThrownBy(() -> teamService.findMyInfoInTeam(team2.getId(), member.getId()))
+                .isInstanceOf(UncertificationTeamMemberException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임에서 마이페이지를 조회할 경우 예외를 발생시킨다.")
+    void findMyInfoInNotExistTeam() {
+        assertThatThrownBy(() -> teamService.findMyInfoInTeam(team1.getId() + 10000L, member.getId()))
+                .isInstanceOf(NotFoundTeamException.class);
+    }
+
+    @Test
+    @DisplayName("모임에 가입된 닉네임을 수정한다. 다른 모임에 해당 닉네임이 존재해도 수정에 문제되지 않는다.")
+    void updateNickname() {
+        final String expected = "닉네임1";
+        final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member, "닉네임1");
+        final TeamParticipation teamParticipation2 = new TeamParticipation(team2, member2, "닉네임2");
+        teamParticipationRepository.save(teamParticipation1);
+        teamParticipationRepository.save(teamParticipation2);
+
+        teamService.updateNickname(team2.getId(), member2.getId(), expected);
+
+        final String actual = teamParticipationRepository.findNicknameByMemberId(member2.getId(), team2.getId());
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 닉네임으로 닉네임을 수정할 경우 예외를 발생시킨다.")
+    void updateDuplicateNickname() {
+        final String expected = "닉네임1";
+        final TeamParticipation teamParticipation1 = new TeamParticipation(team1, member, "닉네임1");
+        final TeamParticipation teamParticipation2 = new TeamParticipation(team1, member2, "닉네임2");
+        teamParticipationRepository.save(teamParticipation1);
+        teamParticipationRepository.save(teamParticipation2);
+
+        assertThatThrownBy(() -> teamService.updateNickname(team1.getId(), member2.getId(), expected))
+                .isInstanceOf(DuplicateNicknameException.class);
+    }
+
+    @Test
+    @DisplayName("내가 가입되지 않은 모임에서 닉네임 변경을 하려 할 경우 예외를 발생시킨다.")
+    void updateNicknameNotMyTeam() {
+        final TeamParticipation teamParticipation = new TeamParticipation(team1, member, "해커");
+        teamParticipationRepository.save(teamParticipation);
+
+        assertThatThrownBy(() -> teamService.updateNickname(team2.getId(), member.getId(), "선량한시민"))
+                .isInstanceOf(UncertificationTeamMemberException.class);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 모임에서 닉네임 변경을 하려 할 경우 예외를 발생시킨다.")
+    void updateNicknameNotExistTeam() {
+        assertThatThrownBy(() -> teamService.updateNickname(team1.getId() + 10000L, member.getId(), "해커"))
                 .isInstanceOf(NotFoundTeamException.class);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
@@ -296,7 +296,7 @@ class TeamServiceTest {
 
         teamService.updateNickname(team2.getId(), member2.getId(), expected);
 
-        final String actual = teamParticipationRepository.findNicknameByMemberId(member2.getId(), team2.getId());
+        final String actual = teamParticipationRepository.findNicknameByMemberIdAndTeamId(member2.getId(), team2.getId());
         assertThat(actual).isEqualTo(expected);
     }
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
@@ -294,9 +294,10 @@ class TeamServiceTest {
         teamParticipationRepository.save(teamParticipation1);
         teamParticipationRepository.save(teamParticipation2);
 
-        teamService.updateNickname(team2.getId(), member2.getId(), expected);
+        teamService.updateMyInfo(team2.getId(), member2.getId(), expected);
 
-        final String actual = teamParticipationRepository.findNicknameByMemberIdAndTeamId(member2.getId(), team2.getId());
+        final String actual = teamParticipationRepository.findNicknameByMemberIdAndTeamId(member2.getId(),
+                team2.getId());
         assertThat(actual).isEqualTo(expected);
     }
 
@@ -309,7 +310,7 @@ class TeamServiceTest {
         teamParticipationRepository.save(teamParticipation1);
         teamParticipationRepository.save(teamParticipation2);
 
-        assertThatThrownBy(() -> teamService.updateNickname(team1.getId(), member2.getId(), expected))
+        assertThatThrownBy(() -> teamService.updateMyInfo(team1.getId(), member2.getId(), expected))
                 .isInstanceOf(DuplicateNicknameException.class);
     }
 
@@ -319,14 +320,14 @@ class TeamServiceTest {
         final TeamParticipation teamParticipation = new TeamParticipation(team1, member, "해커");
         teamParticipationRepository.save(teamParticipation);
 
-        assertThatThrownBy(() -> teamService.updateNickname(team2.getId(), member.getId(), "선량한시민"))
+        assertThatThrownBy(() -> teamService.updateMyInfo(team2.getId(), member.getId(), "선량한시민"))
                 .isInstanceOf(UncertificationTeamMemberException.class);
     }
 
     @Test
     @DisplayName("존재하지 않는 모임에서 닉네임 변경을 하려 할 경우 예외를 발생시킨다.")
     void updateNicknameNotExistTeam() {
-        assertThatThrownBy(() -> teamService.updateNickname(team1.getId() + 10000L, member.getId(), "해커"))
+        assertThatThrownBy(() -> teamService.updateMyInfo(team1.getId() + 10000L, member.getId(), "해커"))
                 .isInstanceOf(NotFoundTeamException.class);
     }
 }


### PR DESCRIPTION
close #182 
## 구현한 내용
1. 모임 가입 정보 조회 API
2.모임 닉네임 수정 API 구현
 - 팀이 가입돼있지 않거나, 팀이 존재하지 않는 경우 예외 발생
 - 이미 존재하는 닉네임으로 수정할 경우 아래 예외 발생

<img width="638" alt="image" src="https://user-images.githubusercontent.com/57135043/181003098-55f27ac6-b77a-4c0a-a42e-c8cabc2975fb.png">
