### PR TITLE
feat: 마이페이지 API 요청 및 응답 로직 구현

### DIFF
--- a/frontend/src/components/MyPagePaginatedMessageList.tsx
+++ b/frontend/src/components/MyPagePaginatedMessageList.tsx
@@ -7,10 +7,10 @@ import WrittenMessageCard from "@/components/WrittenMessageCard";
 interface WrittenMessage {
   id: number;
   rollingpaperId: number;
-  teamId: number;
   rollingpaperTitle: string;
+  teamId: number;
+  teamName: string;
   to: string;
-  team: string;
   content: string;
   color: string;
 }
@@ -31,17 +31,19 @@ const MyPagePaginatedMessageList = ({
   return (
     <>
       <StyledMessageList>
-        {messages.map(({ id, rollingpaperTitle, to, team, content, color }) => (
-          <li key={id}>
-            <WrittenMessageCard
-              rollingpaperTitle={rollingpaperTitle}
-              to={to}
-              team={team}
-              content={content}
-              color={color}
-            />
-          </li>
-        ))}
+        {messages.map(
+          ({ id, rollingpaperTitle, to, teamName, content, color }) => (
+            <li key={id}>
+              <WrittenMessageCard
+                rollingpaperTitle={rollingpaperTitle}
+                to={to}
+                team={teamName}
+                content={content}
+                color={color}
+              />
+            </li>
+          )
+        )}
       </StyledMessageList>
       <StyledPaging>
         <Paging

--- a/frontend/src/components/MyPagePaginatedMessageList.tsx
+++ b/frontend/src/components/MyPagePaginatedMessageList.tsx
@@ -15,19 +15,19 @@ interface WrittenMessage {
   color: string;
 }
 
-interface MyPageWrittenMessageListPagingProp {
+interface MyPagePaginatedMessageListProp {
   messages: WrittenMessage[];
   currentPage: number;
   maxPage: number;
   setCurrentPage: Dispatch<SetStateAction<number>>;
 }
 
-const MyPageWrittenMessageListPaging = ({
+const MyPagePaginatedMessageList = ({
   messages,
   currentPage,
   maxPage,
   setCurrentPage,
-}: MyPageWrittenMessageListPagingProp) => {
+}: MyPagePaginatedMessageListProp) => {
   return (
     <>
       <StyledMessageList>
@@ -68,4 +68,4 @@ const StyledPaging = styled.div`
   justify-content: center;
 `;
 
-export default MyPageWrittenMessageListPaging;
+export default MyPagePaginatedMessageList;

--- a/frontend/src/components/MyPagePaginatedRollingpaperList.tsx
+++ b/frontend/src/components/MyPagePaginatedRollingpaperList.tsx
@@ -11,19 +11,19 @@ interface MyPageRollingpaper {
   teamName: string;
 }
 
-interface MyPageRollingpaperListPaging {
+interface MyPagePaginatedRollingpaperList {
   rollingpapers: MyPageRollingpaper[];
   currentPage: number;
   maxPage: number;
   setCurrentPage: Dispatch<SetStateAction<number>>;
 }
 
-const MyPageRollingpaperListPaging = ({
+const MyPagePaginatedRollingpaperList = ({
   rollingpapers,
   currentPage,
   maxPage,
   setCurrentPage,
-}: MyPageRollingpaperListPaging) => {
+}: MyPagePaginatedRollingpaperList) => {
   return (
     <>
       <StyledRollingpaperList>
@@ -58,4 +58,4 @@ const StyledPaging = styled.div`
   justify-content: center;
 `;
 
-export default MyPageRollingpaperListPaging;
+export default MyPagePaginatedRollingpaperList;

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import styled from "@emotion/styled";
 
 import { UserContext } from "@/context/UserContext";
+import { useSnackbar } from "@/context/SnackbarContext";
 
 import IconButton from "@/components/IconButton";
 import LineButton from "@/components/LineButton";
@@ -28,6 +29,7 @@ type UserProfileMode = ValueOf<typeof MODE>;
 const UserProfile = ({ username, email }: UserProfileProp) => {
   const [mode, setMode] = useState<UserProfileMode>(MODE.NORMAL);
   const [editName, setEditName] = useState(username);
+  const { openSnackbar } = useSnackbar();
 
   const { logout } = useContext(UserContext);
 
@@ -38,7 +40,7 @@ const UserProfile = ({ username, email }: UserProfileProp) => {
     },
     {
       onSuccess: () => {
-        alert(`username: ${username} 수정 완료`);
+        openSnackbar(`username: ${username} 수정 완료`);
       },
       onError: (error) => {
         if (axios.isAxiosError(error) && error.response) {

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -1,36 +1,74 @@
 import React, { useState, useContext } from "react";
+import { useMutation } from "react-query";
+import axios from "axios";
 import styled from "@emotion/styled";
 
-import IconButton from "@/components/IconButton";
+import { UserContext } from "@/context/UserContext";
 
-import Pencil from "@/assets/icons/bx-pencil.svg";
+import IconButton from "@/components/IconButton";
 import LineButton from "@/components/LineButton";
 import UnderlineInput from "@/components/UnderlineInput";
 
-import { UserContext } from "@/context/UserContext";
 import { REGEX } from "@/constants";
-import { ValueOf } from "@/types";
+import { CustomError, ValueOf } from "@/types";
+import appClient from "@/api";
+import Pencil from "@/assets/icons/bx-pencil.svg";
 
 const MODE = {
   NORMAL: "normal",
   EDIT: "edit",
 } as const;
 interface UserProfileProp {
-  name: string;
+  username: string;
   email: string;
 }
 
 type UserProfileMode = ValueOf<typeof MODE>;
 
-const UserProfile = ({ name, email }: UserProfileProp) => {
+const UserProfile = ({ username, email }: UserProfileProp) => {
   const [mode, setMode] = useState<UserProfileMode>(MODE.NORMAL);
-  const [editName, setEditName] = useState(name);
+  const [editName, setEditName] = useState(username);
 
   const { logout } = useContext(UserContext);
 
-  const handleButtonClick = () => {
+  const { mutate: updateUserProfile } = useMutation(
+    async ({ username }: Pick<UserProfileProp, "username">) => {
+      const response = await appClient.put("/members/me", { username });
+      return response.data;
+    },
+    {
+      onSuccess: () => {
+        alert(`username: ${username} 수정 완료`);
+      },
+      onError: (error) => {
+        if (axios.isAxiosError(error) && error.response) {
+          const customError = error.response.data as CustomError;
+          alert(customError.message);
+        }
+      },
+    }
+  );
+
+  const handleLogoutButtonClick = () => {
     if (mode === MODE.NORMAL) {
       logout();
+    }
+  };
+
+  const handleEditCancelButtonClick = () => {
+    if (
+      mode === MODE.EDIT &&
+      confirm(`${editName}으로 이름을 변경하시겠습니까?`)
+    ) {
+      setEditName(username);
+      setMode(MODE.NORMAL);
+    }
+  };
+
+  const handleEditSaveButtonClick = () => {
+    if (mode === MODE.EDIT) {
+      updateUserProfile({ username: editName });
+      setMode(MODE.NORMAL);
     }
   };
 
@@ -39,7 +77,7 @@ const UserProfile = ({ name, email }: UserProfileProp) => {
       {mode === MODE.NORMAL ? (
         <>
           <StyledNormal>
-            <StyledName>{name}</StyledName>
+            <StyledName>{username}</StyledName>
             <IconButton
               onClick={() => {
                 setMode(MODE.EDIT);
@@ -49,20 +87,22 @@ const UserProfile = ({ name, email }: UserProfileProp) => {
             </IconButton>
           </StyledNormal>
           <StyledEmail>{email}</StyledEmail>
+          <LineButton onClick={handleLogoutButtonClick}>로그아웃</LineButton>
         </>
       ) : (
-        <StyledEdit>
+        <StyledUserProfileEditForm>
           <UnderlineInput
             value={editName}
             setValue={setEditName}
             pattern={REGEX.USERNAME.source}
             errorMessage="2~20자 사이의 이름을 입력해주세요"
           />
-        </StyledEdit>
+          <StyledEditLineButtonContainer>
+            <LineButton onClick={handleEditCancelButtonClick}>취소</LineButton>
+            <LineButton onClick={handleEditSaveButtonClick}>완료</LineButton>
+          </StyledEditLineButtonContainer>
+        </StyledUserProfileEditForm>
       )}
-      <LineButton onClick={handleButtonClick}>
-        {mode === MODE.NORMAL ? "로그아웃" : "완료"}
-      </LineButton>
     </StyledProfile>
   );
 };
@@ -82,9 +122,9 @@ const StyledNormal = styled.div`
   }
 `;
 
-const StyledEdit = styled.div`
+const StyledUserProfileEditForm = styled.form`
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
 
   font-size: 14px;
 
@@ -102,6 +142,11 @@ const StyledName = styled.div`
 const StyledEmail = styled.div`
   color: ${({ theme }) => theme.colors.GRAY_700};
   margin-bottom: 12px;
+`;
+
+const StyledEditLineButtonContainer = styled.div`
+  display: flex;
+  gap: 10px;
 `;
 
 export default UserProfile;

--- a/frontend/src/mocks/dummy/receivedRollingpapers.json
+++ b/frontend/src/mocks/dummy/receivedRollingpapers.json
@@ -1,0 +1,64 @@
+{
+  "rollingpapers": [
+    {
+      "id": 1,
+      "title": "소피아 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기"
+    },
+    {
+      "id": 2,
+      "title": "소피아 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기"
+    },
+    {
+      "id": 3,
+      "title": "소피아 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기"
+    },
+    {
+      "id": 4,
+      "title": "소피아 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기"
+    },
+    {
+      "id": 5,
+      "title": "소피아 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기"
+    },
+    {
+      "id": 11,
+      "title": "도리야 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기 프로젝트 내편"
+    },
+    {
+      "id": 12,
+      "title": "도리야 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기 프로젝트 내편"
+    },
+    {
+      "id": 13,
+      "title": "도리야 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기 프로젝트 내편"
+    },
+    {
+      "id": 14,
+      "title": "도리야 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기 프로젝트 내편"
+    },
+    {
+      "id": 15,
+      "title": "도리야 생일 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기 프로젝트 내편"
+    }
+  ]
+}

--- a/frontend/src/mocks/dummy/sentMessages.json
+++ b/frontend/src/mocks/dummy/sentMessages.json
@@ -1,0 +1,104 @@
+{
+  "messages": [
+    {
+      "id": 1,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#FFF598"
+    },
+    {
+      "id": 2,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#C5FF98"
+    },
+    {
+      "id": 3,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 FE",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#FFF598"
+    },
+    {
+      "id": 4,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#FF8181"
+    },
+    {
+      "id": 5,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#FFF598"
+    },
+    {
+      "id": 6,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#98DAFF"
+    },
+    {
+      "id": 7,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#98A2FF"
+    },
+    {
+      "id": 8,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#FF98D0"
+    },
+    {
+      "id": 9,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#FFF598"
+    },
+    {
+      "id": 10,
+      "rollingpaperId": 1,
+      "rollingpaperTitle": "소피아의 생일을 축하해",
+      "teamId": 1,
+      "teamName": "우테코 4기",
+      "to": "소피아",
+      "content": "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
+      "color": "#FFF598"
+    }
+  ]
+}

--- a/frontend/src/mocks/handlers/memberHandlers.js
+++ b/frontend/src/mocks/handlers/memberHandlers.js
@@ -1,4 +1,5 @@
 import { rest } from "msw";
+import receivedRollinpapersDummy from "../dummy/receivedRollingpapers.json";
 
 const memberHandlers = [
   // 회원 가입 요쳥
@@ -43,6 +44,23 @@ const memberHandlers = [
     }
 
     return res(ctx.status(204));
+  }),
+
+  // 내가 받은 롤링페이퍼 목록 조회
+  rest.get("/api/v1/members/me/rollingpapers/received", (req, res, ctx) => {
+    const page = req.url.searchParams.get("page");
+    const count = req.url.searchParams.get("count");
+
+    const begin = page % 2 === 1 ? 0 : 5;
+    const end = page % 2 === 1 ? 5 : 10;
+
+    const result = {
+      totalCount: 160, // 전체 컨텐츠 개수
+      currentPage: Number(page), // 현재 페이지 번호 - 확인차?
+      rollingpapers: receivedRollinpapersDummy.rollingpapers.slice(begin, end),
+    };
+
+    return res(ctx.json(result));
   }),
 ];
 

--- a/frontend/src/mocks/handlers/memberHandlers.js
+++ b/frontend/src/mocks/handlers/memberHandlers.js
@@ -33,6 +33,17 @@ const memberHandlers = [
 
     return res(ctx.json(result));
   }),
+
+  // 내 정보 수정
+  rest.put("/api/v1/members/me", (req, res, ctx) => {
+    const accessToken = req.headers.headers.authorization.split(" ")[1];
+
+    if (!accessToken) {
+      return res(ctx.status(400));
+    }
+
+    return res(ctx.status(204));
+  }),
 ];
 
 export default memberHandlers;

--- a/frontend/src/mocks/handlers/memberHandlers.js
+++ b/frontend/src/mocks/handlers/memberHandlers.js
@@ -1,5 +1,6 @@
 import { rest } from "msw";
 import receivedRollinpapersDummy from "../dummy/receivedRollingpapers.json";
+import sentMessagesDummy from "../dummy/sentMessages.json";
 
 const memberHandlers = [
   // 회원 가입 요쳥
@@ -55,9 +56,26 @@ const memberHandlers = [
     const end = page % 2 === 1 ? 5 : 10;
 
     const result = {
-      totalCount: 160, // 전체 컨텐츠 개수
-      currentPage: Number(page), // 현재 페이지 번호 - 확인차?
+      totalCount: 160,
+      currentPage: Number(page),
       rollingpapers: receivedRollinpapersDummy.rollingpapers.slice(begin, end),
+    };
+
+    return res(ctx.json(result));
+  }),
+
+  // 내가 쓴 메시지 목록 조회
+  rest.get("/api/v1/members/me/messages/written", (req, res, ctx) => {
+    const page = req.url.searchParams.get("page");
+    const count = req.url.searchParams.get("count");
+
+    const begin = page % 2 === 1 ? 0 : 5;
+    const end = page % 2 === 1 ? 5 : 10;
+
+    const result = {
+      totalCount: 160,
+      currentPage: Number(page),
+      messages: sentMessagesDummy.messages.slice(begin, end),
     };
 
     return res(ctx.json(result));

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -3,8 +3,8 @@ import styled from "@emotion/styled";
 
 import MyPageTab from "@/components/MyPageTab";
 import UserProfile from "@/components/UserProfile";
-import MyPageRollingpaperListPaging from "@/components/MyPageRollingpaperListPaging";
-import MyPageWrittenMessageListPaging from "@/components/MyPageWrittenMessageListPaging";
+import MyPagePaginatedRollingpaperList from "@/components/MyPagePaginatedRollingpaperList";
+import MyPagePaginatedMessageList from "@/components/MyPagePaginatedMessageList";
 
 import { ValueOf } from "@/types";
 
@@ -108,14 +108,14 @@ const MyPage = () => {
         />
       </StyledTabs>
       {tab === TAB.RECEIVED_PAPER ? (
-        <MyPageRollingpaperListPaging
+        <MyPagePaginatedRollingpaperList
           rollingpapers={rollingpapers}
           currentPage={receivedCurrentPage}
           maxPage={10}
           setCurrentPage={setReceivedCurrentPage}
         />
       ) : (
-        <MyPageWrittenMessageListPaging
+        <MyPagePaginatedMessageList
           messages={messages}
           currentPage={writtenCurrentPage}
           maxPage={10}

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -12,78 +12,12 @@ import appClient from "@/api";
 
 import { CustomError, ValueOf } from "@/types";
 
-const rollingpapers = [
-  { id: 1, title: "소피아 생일 축하해", teamId: 1, teamName: "우테코 4기" },
-  { id: 2, title: "소피아 생일 축하해", teamId: 1, teamName: "우테코 4기" },
-  { id: 3, title: "소피아 생일 축하해", teamId: 1, teamName: "우테코 4기" },
-  { id: 4, title: "소피아 생일 축하해", teamId: 1, teamName: "우테코 4기" },
-  { id: 5, title: "소피아 생일 축하해", teamId: 1, teamName: "우테코 4기" },
-];
-
-const messages = [
-  {
-    id: 1,
-    rollingpaperId: 1,
-    teamId: 1,
-    rollingpaperTitle: "소피아의 생일을 축하해",
-    to: "소피아",
-    team: "우테코 4기",
-    content:
-      "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
-    color: "#C5FF98",
-  },
-  {
-    id: 2,
-    rollingpaperId: 1,
-    teamId: 1,
-    rollingpaperTitle: "소피아의 생일을 축하해",
-    to: "소피아",
-    team: "우테코 4기",
-    content:
-      "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
-    color: "#C5FF98",
-  },
-  {
-    id: 3,
-    rollingpaperId: 1,
-    teamId: 1,
-    rollingpaperTitle: "소피아의 생일을 축하해",
-    to: "소피아",
-    team: "우테코 4기",
-    content:
-      "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
-    color: "#FF8181",
-  },
-  {
-    id: 4,
-    rollingpaperId: 1,
-    teamId: 1,
-    rollingpaperTitle: "소피아의 생일을 축하해",
-    to: "소피아",
-    team: "우테코 4기",
-    content:
-      "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
-    color: "#C5FF98",
-  },
-  {
-    id: 5,
-    rollingpaperId: 1,
-    teamId: 1,
-    rollingpaperTitle: "소피아의 생일을 축하해",
-    to: "소피아",
-    team: "우테코 4기",
-    content:
-      "소피아야 생일 축하해~ 축카추카추 소피아야 생일 축하해~ 축카추카추",
-    color: "#C5FF98",
-  },
-];
+type TabMode = ValueOf<typeof TAB>;
 
 const TAB = {
   RECEIVED_PAPER: "received_paper",
   SENT_MESSAGE: "sent_message",
 } as const;
-
-type TabMode = ValueOf<typeof TAB>;
 
 interface UserProfile {
   id: number;

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -196,14 +196,18 @@ const MyPage = () => {
         <MyPagePaginatedRollingpaperList
           rollingpapers={responseReceivedRollingpapers.rollingpapers}
           currentPage={receivedRollingpapersPage}
-          maxPage={10}
+          maxPage={Math.ceil(
+            responseReceivedRollingpapers.totalCount / contentCountPerPage
+          )}
           setCurrentPage={setReceivedRollingpapersPage}
         />
       ) : (
         <MyPagePaginatedMessageList
           messages={responseSentMessages.messages}
           currentPage={sentMessagesCurrentPage}
-          maxPage={10}
+          maxPage={Math.ceil(
+            responseSentMessages.totalCount / contentCountPerPage
+          )}
           setCurrentPage={setSentMessagesCurrentPage}
         />
       )}

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -80,7 +80,7 @@ const MyPage = () => {
     error: getUserProfileError,
     data: userProfile,
   } = useQuery<UserInfo>(["user-profile"], () => fetchUserInfo(), {
-    initialData: INITIAL_DATA.USER_INFO,
+    placeholderData: INITIAL_DATA.USER_INFO,
   });
 
   const {
@@ -97,7 +97,7 @@ const MyPage = () => {
       ),
     {
       keepPreviousData: true,
-      initialData: INITIAL_DATA.RECEIVED_ROLLINGPAPERS,
+      placeholderData: INITIAL_DATA.RECEIVED_ROLLINGPAPERS,
     }
   );
 
@@ -111,7 +111,7 @@ const MyPage = () => {
     () => fetchSentMessage(sentMessagesCurrentPage, contentCountPerPage),
     {
       keepPreviousData: true,
-      initialData: INITIAL_DATA.SENT_MESSAGES,
+      placeholderData: INITIAL_DATA.SENT_MESSAGES,
     }
   );
 

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -126,7 +126,7 @@ const MyPage = () => {
 
   return (
     <>
-      <UserProfile name={userProfile.username} email={userProfile.email} />
+      <UserProfile username={userProfile.username} email={userProfile.email} />
       <StyledTabs>
         <MyPageTab
           number={rollingpapers.length}

--- a/frontend/src/pages/MyPage.tsx
+++ b/frontend/src/pages/MyPage.tsx
@@ -63,24 +63,14 @@ const MyPage = () => {
   };
 
   const fetchReceivedRollingpapers = (page = 1, count = 5) => {
-    const searchParams = new URLSearchParams({
-      page: page.toString(),
-      count: count.toString(),
-    });
-
     return appClient
-      .get(`/members/me/rollingpapers/received?${searchParams.toString()}`)
+      .get(`/members/me/rollingpapers/received?page=${page}&count=${count}`)
       .then((response) => response.data);
   };
 
   const fetchSentMessage = (page = 1, count = 5) => {
-    const searchParams = new URLSearchParams({
-      page: page.toString(),
-      count: count.toString(),
-    });
-
     return appClient
-      .get(`/members/me/messages/written?${searchParams.toString()}`)
+      .get(`/members/me/messages/written?page=${page}&count=${count}`)
       .then((response) => response.data);
   };
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,6 +12,30 @@ export interface Rollingpaper {
   messages: Message[];
 }
 
+export interface UserInfo {
+  id: number;
+  username: string;
+  email: string;
+}
+
+export interface ReceivedRollingpaper {
+  id: number;
+  title: string;
+  teamId: number;
+  teamName: string;
+}
+
+export interface SentMessage {
+  id: number;
+  rollingpaperId: number;
+  rollingpaperTitle: string;
+  teamId: number;
+  teamName: string;
+  to: string;
+  content: string;
+  color: string;
+}
+
 export type CustomError = {
   errorCode: number;
   message: string;


### PR DESCRIPTION
## 구현 사항
- 내 정보 조회, 내 정보 수정, 내가 받은 롤링페이퍼 목록 조회, 내가 작성한 메시지 목록 조회 API 로직 MyPage 컴포넌트 내에서 동작하도록 구현
- 받은 롤링페이퍼 목록, 작성한 메시지 목록 페이지네이션 가능하도록 구현
- 내 정보 조회, 내 정보 수정, 내가 받은 롤링페이퍼 목록 조회, 내가 작성한 메시지 목록 조회 API mocking

## 논의하고 싶은 부분
1. MyPage 페이지 컴포넌트에서 너무 많은 API 요청 로직을 가지고 있어서 자식 컴포넌트에게 분배하면 어떨까 싶어요. 당장 생각해본 방식들은 다음과 같습니다.
- API 변경 없이 자식 컴포넌트로 API 요청 로직을 옮기려면? 페이지 컴포넌트 탭에서 전체 컨텐츠 개수가 필요함, 페이지 컴포넌트에서 Count 상태만 가지고, 자식 컴포넌트(리스트 컴포넌트)에서 setCount만 내려 받아 요청 응답이 돌아왔을 때 해당 상태만 업데이트하는 방법
- 컨텐츠 개수만 돌려주는 API 새로 추가, 마이페이지에서 개수만 가져오고 리스트 컴포넌트 각각에서 목록 조회 API 요청 -> 백엔드 논의 필요

  도리 생각은 어떤가요? 의견이나 다른 아이디어 있다면 공유 부탁해요!

2. Axios 에러 처리 로직이 반복되는데, util 함수나 useQuery 또는 useMutation을 커스텀 훅으로 감싸서 분리해보면 좋을 것 같아요.  방법은 조금 더 고민해볼게요.

close #203 