### PR TITLE
fix: UserContext의 내 정보 조회 요청 URL 수정

### DIFF
--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -34,7 +34,7 @@ const UserProvider = ({ children }: PropsWithChildren) => {
   useQuery<UserInfo>(
     ["memberId"],
     () =>
-      axios
+      appClient
         .get("/api/v1/members/me", {
           headers: {
             Authorization: `Bearer ${accessTokenCookie || ""}`,

--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -1,10 +1,8 @@
 import { useState, createContext, PropsWithChildren } from "react";
 import { useQuery } from "@tanstack/react-query";
-import axios from "axios";
-
-import { deleteCookie, getCookie, setCookie } from "@/util/cookie";
 
 import { appClient } from "@/api";
+import { deleteCookie, getCookie, setCookie } from "@/util/cookie";
 
 const COOKIE_KEY = {
   ACCESS_TOKEN: "accessToken",

--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -35,7 +35,7 @@ const UserProvider = ({ children }: PropsWithChildren) => {
     ["memberId"],
     () =>
       appClient
-        .get("/api/v1/members/me", {
+        .get("/members/me", {
           headers: {
             Authorization: `Bearer ${accessTokenCookie || ""}`,
           },


### PR DESCRIPTION
## 문제 상황
UserContext의 내 정보 조회 시 잘못된 Url로 요청을 보내는 문제 발견
- UserContext의 내 정보 조회 API에서 사용하는 axios의 baseUrl 설정이 안 되어있다.
- UserContext의 내 정보 조회 요청 Url이 잘못 설정되어있다.

## 해결
- UserContext에서 내 정보 조회 시,  baseUrl이 설정되어 있는 axios instance를 사용하도록 변경
- UserContext의 내 정보 조회 요청 Url을 변경