### PR TITLE
feat: 카카오 로그인 API 명세 변경에 따라 관련 로직 변경

### DIFF
--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -1,40 +1,16 @@
-import axios from "axios";
+import { appClient } from "@/api";
 
-import { KAKAO_OAUTH_URL } from "@/constants";
-import { OAuthUserInfo } from "@/types/oauth";
+import { RequestKakaoOauthBody } from "@/types/oauth";
 
-const requestKakaoToken = (authorizeCode: string) =>
-  axios
-    .post(
-      KAKAO_OAUTH_URL.TOKEN(authorizeCode),
-      {},
-      {
-        headers: {
-          "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
-        },
-      }
-    )
-    .then((response) => {
-      const { access_token } = response.data;
-      return access_token;
-    });
+const postKakaoOauth = async ({
+  authorizationCode,
+  redirectUri,
+}: RequestKakaoOauthBody) => {
+  const response = await appClient.post("/oauth/kakao", {
+    authorizationCode,
+    redirectUri,
+  });
+  return response.data;
+};
 
-const requestKakaoUserInfo = (accessToken: string) =>
-  axios
-    .get(KAKAO_OAUTH_URL.USER_INFO, {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
-      },
-    })
-    .then(({ data }) => {
-      const userInfo: OAuthUserInfo = {
-        platformId: data.id,
-        email: data.kakao_account.email,
-        username: data.kakao_account.profile.nickname,
-        profileImageUrl: data.kakao_account.profile.profile_image_url,
-      };
-      return userInfo;
-    });
-
-export { requestKakaoToken, requestKakaoUserInfo };
+export { postKakaoOauth };

--- a/frontend/src/mocks/handlers/memberHandlers.js
+++ b/frontend/src/mocks/handlers/memberHandlers.js
@@ -13,6 +13,15 @@ const memberHandlers = [
     return res(ctx.status(200), ctx.json(result));
   }),
 
+  // 카카오 OAuth
+  rest.post("/api/v1/oauth/kakao", (req, res, ctx) => {
+    const { authorizationCode, redirectUri } = req.body;
+
+    const result = { accessToken: "accessToken2", id: 1 };
+
+    return res(ctx.status(200), ctx.json(result));
+  }),
+
   // 내 정보 조회
   rest.get("/api/v1/members/me", (req, res, ctx) => {
     const accessToken = req.headers.headers.authorization.split(" ")[1];

--- a/frontend/src/types/oauth.ts
+++ b/frontend/src/types/oauth.ts
@@ -1,10 +1,4 @@
-export type OAuthUserInfo = {
-  platformId: number;
-  email: string;
-  username: string;
-  profileImageUrl: string;
-};
-
-export type RequestOauthLoginBody = OAuthUserInfo & {
-  platformType: "KAKAO" | "NAVER" | "GOOGLE";
+export type RequestKakaoOauthBody = {
+  authorizationCode: string;
+  redirectUri: string;
 };


### PR DESCRIPTION
## 구현 사항
- kakao oauth API 명세 추가에 따라 mocking handler 추가
- kakao oauth api 로직 및 KakaoRedirectPage 내부 로직 전반 수정

<br >

## 논의하고 싶은 사항
- authorizationCode나 redirectUri를 못 찾아왔을 때 예외 처리를 어떻게 하면 좋을지 고민이에요. 
  [해당 부분 코멘트](https://github.com/woowacourse-teams/2022-nae-pyeon/pull/263#discussion_r935529312)로 남기겠습니다.

<br >

closed #259 