### PR TITLE
feat: 마이페이지의 롤링페이퍼/메시지 목록 아이템 클릭 시 페이지 이동 기능 구현

### DIFF
--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -1,0 +1,12 @@
+import { appClient } from "@/api";
+
+const getMyTeams =
+  (teamPageCount = 5) =>
+  async ({ pageParam = 1 }) => {
+    const data = appClient
+      .get(`teams/me?page=${pageParam}&count=${teamPageCount}`)
+      .then((response) => response.data);
+    return data;
+  };
+
+export { getMyTeams };

--- a/frontend/src/mocks/dummy/myTeams.json
+++ b/frontend/src/mocks/dummy/myTeams.json
@@ -127,6 +127,30 @@
       "emoji": "😎",
       "color": "#98DAFF",
       "joined": true
+    },
+    {
+      "id": 17,
+      "name": "우테코 4기",
+      "description": "우테코 4기 설명입니다",
+      "emoji": "😎",
+      "color": "#C5FF98",
+      "joined": true
+    },
+    {
+      "id": 18,
+      "name": "우테코 4기",
+      "description": "우테코 4기 설명입니다",
+      "emoji": "😎",
+      "color": "#FFF598",
+      "joined": true
+    },
+    {
+      "id": 19,
+      "name": "우테코 4기",
+      "description": "우테코 4기 설명입니다",
+      "emoji": "😎",
+      "color": "#98DAFF",
+      "joined": true
     }
   ]
 }

--- a/frontend/src/mocks/handlers/teamHandlers.js
+++ b/frontend/src/mocks/handlers/teamHandlers.js
@@ -21,9 +21,13 @@ const teamHandlers = [
   // 내가 가입한 모임 조회
   rest.get("/api/v1/teams/me", (req, res, ctx) => {
     const accessToken = req.headers.headers.authorization;
+    const page = +req.url.searchParams.get("page");
+    const count = +req.url.searchParams.get("count");
 
     const result = {
-      teams: myTeams,
+      totalCount: myTeams.length,
+      currentPage: Number(page),
+      teams: myTeams.slice((page - 1) * count, (page - 1) * count + count),
     };
 
     return res(ctx.json(result));

--- a/frontend/src/pages/MyPage/components/MessageCard.tsx
+++ b/frontend/src/pages/MyPage/components/MessageCard.tsx
@@ -16,16 +16,18 @@ const MessageCard = ({
   color,
 }: SentMessage) => {
   return (
-    <Link to={`/team/${teamId}/rollingpaper/${rollingpaperId}`}>
-      <StyledMessage color={color}>
-        <StyledTitle>{rollingpaperTitle}</StyledTitle>
-        <StyledTo>
-          To. <span>{to}</span>
-          <span>({teamName})</span>
-        </StyledTo>
-        <StyledContent>{content}</StyledContent>
-      </StyledMessage>
-    </Link>
+    <li>
+      <Link to={`/team/${teamId}/rollingpaper/${rollingpaperId}`}>
+        <StyledMessage color={color}>
+          <StyledTitle>{rollingpaperTitle}</StyledTitle>
+          <StyledTo>
+            To. <span>{to}</span>
+            <span>({teamName})</span>
+          </StyledTo>
+          <StyledContent>{content}</StyledContent>
+        </StyledMessage>
+      </Link>
+    </li>
   );
 };
 

--- a/frontend/src/pages/MyPage/components/MessageCard.tsx
+++ b/frontend/src/pages/MyPage/components/MessageCard.tsx
@@ -1,29 +1,23 @@
 import React from "react";
 import styled from "@emotion/styled";
 
-interface MessageCardProp {
-  rollingpaperTitle: string;
-  to: string;
-  team: string;
-  content: string;
-  color: string;
-}
+import { SentMessage } from "@/types";
 
-type StyledMessageProp = Pick<MessageCardProp, "color">;
+type StyledMessageProp = Pick<SentMessage, "color">;
 
 const MessageCard = ({
   rollingpaperTitle,
   to,
-  team,
+  teamName,
   content,
   color,
-}: MessageCardProp) => {
+}: SentMessage) => {
   return (
     <StyledMessage color={color}>
       <StyledTitle>{rollingpaperTitle}</StyledTitle>
       <StyledTo>
         To. <span>{to}</span>
-        <span>({team})</span>
+        <span>({teamName})</span>
       </StyledTo>
       <StyledContent>{content}</StyledContent>
     </StyledMessage>

--- a/frontend/src/pages/MyPage/components/MessageCard.tsx
+++ b/frontend/src/pages/MyPage/components/MessageCard.tsx
@@ -2,25 +2,30 @@ import React from "react";
 import styled from "@emotion/styled";
 
 import { SentMessage } from "@/types";
+import { Link } from "react-router-dom";
 
 type StyledMessageProp = Pick<SentMessage, "color">;
 
 const MessageCard = ({
+  rollingpaperId,
   rollingpaperTitle,
   to,
+  teamId,
   teamName,
   content,
   color,
 }: SentMessage) => {
   return (
-    <StyledMessage color={color}>
-      <StyledTitle>{rollingpaperTitle}</StyledTitle>
-      <StyledTo>
-        To. <span>{to}</span>
-        <span>({teamName})</span>
-      </StyledTo>
-      <StyledContent>{content}</StyledContent>
-    </StyledMessage>
+    <Link to={`/team/${teamId}/rollingpaper/${rollingpaperId}`}>
+      <StyledMessage color={color}>
+        <StyledTitle>{rollingpaperTitle}</StyledTitle>
+        <StyledTo>
+          To. <span>{to}</span>
+          <span>({teamName})</span>
+        </StyledTo>
+        <StyledContent>{content}</StyledContent>
+      </StyledMessage>
+    </Link>
   );
 };
 

--- a/frontend/src/pages/MyPage/components/MessageList.tsx
+++ b/frontend/src/pages/MyPage/components/MessageList.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction } from "react";
 import styled from "@emotion/styled";
 
-import MessageCard from "@/pages/MyPage/components/MessageCard";
+import MessageListItem from "@/pages/MyPage/components/MessageListItem";
 import Paging from "@/components/Paging";
 
 import { SentMessage } from "@/types";
@@ -23,7 +23,7 @@ const MessageList = ({
     <>
       <StyledMessageList>
         {messages.map((message) => (
-          <MessageCard {...message} />
+          <MessageListItem {...message} />
         ))}
       </StyledMessageList>
       <StyledPaging>

--- a/frontend/src/pages/MyPage/components/MessageList.tsx
+++ b/frontend/src/pages/MyPage/components/MessageList.tsx
@@ -1,22 +1,13 @@
 import React, { Dispatch, SetStateAction } from "react";
 import styled from "@emotion/styled";
 
-import Paging from "@/components/Paging";
 import MessageCard from "@/pages/MyPage/components/MessageCard";
+import Paging from "@/components/Paging";
 
-interface WrittenMessage {
-  id: number;
-  rollingpaperId: number;
-  rollingpaperTitle: string;
-  teamId: number;
-  teamName: string;
-  to: string;
-  content: string;
-  color: string;
-}
+import { SentMessage } from "@/types";
 
 interface MessageListProp {
-  messages: WrittenMessage[];
+  messages: SentMessage[];
   currentPage: number;
   maxPage: number;
   setCurrentPage: Dispatch<SetStateAction<number>>;
@@ -31,19 +22,11 @@ const MessageList = ({
   return (
     <>
       <StyledMessageList>
-        {messages.map(
-          ({ id, rollingpaperTitle, to, teamName, content, color }) => (
-            <li key={id}>
-              <MessageCard
-                rollingpaperTitle={rollingpaperTitle}
-                to={to}
-                team={teamName}
-                content={content}
-                color={color}
-              />
-            </li>
-          )
-        )}
+        {messages.map((message) => (
+          <li key={message.id}>
+            <MessageCard {...message} />
+          </li>
+        ))}
       </StyledMessageList>
       <StyledPaging>
         <Paging

--- a/frontend/src/pages/MyPage/components/MessageList.tsx
+++ b/frontend/src/pages/MyPage/components/MessageList.tsx
@@ -23,9 +23,7 @@ const MessageList = ({
     <>
       <StyledMessageList>
         {messages.map((message) => (
-          <li key={message.id}>
-            <MessageCard {...message} />
-          </li>
+          <MessageCard {...message} />
         ))}
       </StyledMessageList>
       <StyledPaging>

--- a/frontend/src/pages/MyPage/components/MessageListItem.tsx
+++ b/frontend/src/pages/MyPage/components/MessageListItem.tsx
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 
 type StyledMessageProp = Pick<SentMessage, "color">;
 
-const MessageCard = ({
+const MessageListItem = ({
   rollingpaperId,
   rollingpaperTitle,
   to,
@@ -70,4 +70,4 @@ const StyledContent = styled.div`
   -webkit-line-clamp: 2;
 `;
 
-export default MessageCard;
+export default MessageListItem;

--- a/frontend/src/pages/MyPage/components/RollingpaperCard.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperCard.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import styled from "@emotion/styled";
 
-interface RollingpaperCardProps {
-  title: string;
-  teamName: string;
-}
+import { ReceivedRollingpaper } from "@/types";
 
-const RollingpaperCard = ({ title, teamName }: RollingpaperCardProps) => {
+const RollingpaperCard = ({ title, teamName }: ReceivedRollingpaper) => {
   return (
     <StyledRollingpaperCard>
       <StyledTitle>{title}</StyledTitle>

--- a/frontend/src/pages/MyPage/components/RollingpaperCard.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperCard.tsx
@@ -11,12 +11,14 @@ const RollingpaperCard = ({
   teamName,
 }: ReceivedRollingpaper) => {
   return (
-    <Link to={`/team/${teamId}/rollingpaper/${id}`}>
-      <StyledRollingpaperCard>
-        <StyledTitle>{title}</StyledTitle>
-        <StyledTeamName>{teamName}</StyledTeamName>
-      </StyledRollingpaperCard>
-    </Link>
+    <li>
+      <Link to={`/team/${teamId}/rollingpaper/${id}`}>
+        <StyledRollingpaperCard>
+          <StyledTitle>{title}</StyledTitle>
+          <StyledTeamName>{teamName}</StyledTeamName>
+        </StyledRollingpaperCard>
+      </Link>
+    </li>
   );
 };
 

--- a/frontend/src/pages/MyPage/components/RollingpaperCard.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperCard.tsx
@@ -1,14 +1,22 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import styled from "@emotion/styled";
 
 import { ReceivedRollingpaper } from "@/types";
 
-const RollingpaperCard = ({ title, teamName }: ReceivedRollingpaper) => {
+const RollingpaperCard = ({
+  id,
+  title,
+  teamId,
+  teamName,
+}: ReceivedRollingpaper) => {
   return (
-    <StyledRollingpaperCard>
-      <StyledTitle>{title}</StyledTitle>
-      <StyledTeamName>{teamName}</StyledTeamName>
-    </StyledRollingpaperCard>
+    <Link to={`/team/${teamId}/rollingpaper/${id}`}>
+      <StyledRollingpaperCard>
+        <StyledTitle>{title}</StyledTitle>
+        <StyledTeamName>{teamName}</StyledTeamName>
+      </StyledRollingpaperCard>
+    </Link>
   );
 };
 

--- a/frontend/src/pages/MyPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperList.tsx
@@ -23,9 +23,7 @@ const RollingpaperList = ({
     <>
       <StyledRollingpaperList>
         {rollingpapers.map((rollingpaper) => (
-          <li key={rollingpaper.id}>
-            <RollingpaperCard {...rollingpaper} />
-          </li>
+          <RollingpaperCard {...rollingpaper} />
         ))}
       </StyledRollingpaperList>
       <StyledPaging>

--- a/frontend/src/pages/MyPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperList.tsx
@@ -4,12 +4,7 @@ import styled from "@emotion/styled";
 import RollingpaperCard from "@/pages/MyPage/components/RollingpaperCard";
 import Paging from "@/components/Paging";
 
-interface ReceivedRollingpaper {
-  id: number;
-  title: string;
-  teamId: number;
-  teamName: string;
-}
+import { ReceivedRollingpaper } from "@/types";
 
 interface RollingpaperList {
   rollingpapers: ReceivedRollingpaper[];
@@ -27,9 +22,9 @@ const RollingpaperList = ({
   return (
     <>
       <StyledRollingpaperList>
-        {rollingpapers.map(({ title, teamName, id }) => (
-          <li key={id}>
-            <RollingpaperCard title={title} teamName={teamName} />
+        {rollingpapers.map((rollingpaper) => (
+          <li key={rollingpaper.id}>
+            <RollingpaperCard {...rollingpaper} />
           </li>
         ))}
       </StyledRollingpaperList>

--- a/frontend/src/pages/MyPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperList.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction } from "react";
 import styled from "@emotion/styled";
 
-import RollingpaperCard from "@/pages/MyPage/components/RollingpaperCard";
+import RollingpaperListItem from "@/pages/MyPage/components/RollingpaperListItem";
 import Paging from "@/components/Paging";
 
 import { ReceivedRollingpaper } from "@/types";
@@ -23,7 +23,7 @@ const RollingpaperList = ({
     <>
       <StyledRollingpaperList>
         {rollingpapers.map((rollingpaper) => (
-          <RollingpaperCard {...rollingpaper} />
+          <RollingpaperListItem {...rollingpaper} />
         ))}
       </StyledRollingpaperList>
       <StyledPaging>

--- a/frontend/src/pages/MyPage/components/RollingpaperListItem.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperListItem.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 
 import { ReceivedRollingpaper } from "@/types";
 
-const RollingpaperCard = ({
+const RollingpaperListItem = ({
   id,
   title,
   teamId,
@@ -13,16 +13,16 @@ const RollingpaperCard = ({
   return (
     <li>
       <Link to={`/team/${teamId}/rollingpaper/${id}`}>
-        <StyledRollingpaperCard>
+        <StyledRollingpaperListItem>
           <StyledTitle>{title}</StyledTitle>
           <StyledTeamName>{teamName}</StyledTeamName>
-        </StyledRollingpaperCard>
+        </StyledRollingpaperListItem>
       </Link>
     </li>
   );
 };
 
-const StyledRollingpaperCard = styled.div`
+const StyledRollingpaperListItem = styled.div`
   display: flex;
   justify-content: space-between;
 
@@ -49,4 +49,4 @@ const StyledTeamName = styled.div`
   font-size: 14px;
 `;
 
-export default RollingpaperCard;
+export default RollingpaperListItem;

--- a/frontend/src/pages/TeamSearchPage/index.tsx
+++ b/frontend/src/pages/TeamSearchPage/index.tsx
@@ -34,7 +34,7 @@ const TeamSearch = () => {
     { rootMargin: "10px", threshold: 1.0 }
   );
 
-  const fetchTeams =
+  const getTeams =
     (keyword: string) =>
     async ({ pageParam = 0 }) => {
       const data = appClient
@@ -54,7 +54,7 @@ const TeamSearch = () => {
     isError,
     isLoading,
     refetch,
-  } = useInfiniteQuery(["projects"], fetchTeams(searchKeyword), {
+  } = useInfiniteQuery(["projects"], getTeams(searchKeyword), {
     getNextPageParam: (lastPage) => {
       if (
         lastPage.currentPage * TOTAL_TEAMS_PAGING_COUNT <


### PR DESCRIPTION
## 추가된 기능
- 마이페이지의 내가 받은 롤링페이퍼 목록에서 아이템 클릭 시, 해당 롤링페이퍼 페이지로 이동한다.
- 마이페이지의 내가 작성한 메세지 목록에서 아이템 클릭 시, 해당 메세지가 작성된 롤링페이퍼 페이지로 이동한다.

<br >

## 작업 내용
- MyPage 내부 컴포넌트에서, types 폴더에 정의해둔 ReceivedRollingpaper, SentMessage 타입을 사용하도록 수정
- RollingpaperCard, MessageCard 내부에 Link 추가

<br >

## 논의하고 싶은 내용
- RollingpaperList - RollingpaperCard, MessageList - MessageCard 형식인데 Card 대신 ListItem으로 이름을 바꾸는 건 어떨까요? 모양이 기존에 사용하던 Card와는 다르기도 하고, list 태그 내에 있어서 li 태그로 감싸줬더라고요. ([코멘트](https://github.com/woowacourse-teams/2022-nae-pyeon/pull/266#discussion_r935796817) 참고해주세요!)그래서 ListItem으로 네이밍해도 좋을 것 같습니다. 이 부분 도리 의견 들어보고 리팩토링 진행하겠습니다~

<br >

closed #249 