### PR TITLE
feat: 유저 정보가 변경되면 변경된 정보를 refetch

### DIFF
--- a/frontend/src/pages/MyPage/components/UserProfile.tsx
+++ b/frontend/src/pages/MyPage/components/UserProfile.tsx
@@ -12,7 +12,7 @@ import UnderlineInput from "@/components/UnderlineInput";
 
 import { REGEX } from "@/constants";
 import { CustomError, ValueOf } from "@/types";
-import { appClient } from "@/api";
+import { appClient, queryClient } from "@/api";
 import Pencil from "@/assets/icons/bx-pencil.svg";
 
 const MODE = {
@@ -40,7 +40,8 @@ const UserProfile = ({ username, email }: UserProfileProp) => {
     },
     {
       onSuccess: () => {
-        openSnackbar(`username: ${username} 수정 완료`);
+        queryClient.refetchQueries(["user-profile"]);
+        openSnackbar(`이름 수정 완료`);
       },
       onError: (error) => {
         if (axios.isAxiosError(error) && error.response) {

--- a/frontend/src/pages/MyPage/components/UserProfile.tsx
+++ b/frontend/src/pages/MyPage/components/UserProfile.tsx
@@ -41,7 +41,7 @@ const UserProfile = ({ username, email }: UserProfileProp) => {
     {
       onSuccess: () => {
         queryClient.refetchQueries(["user-profile"]);
-        openSnackbar(`이름 수정 완료`);
+        openSnackbar("이름 수정 완료");
       },
       onError: (error) => {
         if (axios.isAxiosError(error) && error.response) {

--- a/frontend/src/pages/MyPage/components/UserProfile.tsx
+++ b/frontend/src/pages/MyPage/components/UserProfile.tsx
@@ -58,11 +58,7 @@ const UserProfile = ({ username, email }: UserProfileProp) => {
   };
 
   const handleEditCancelButtonClick = () => {
-    if (
-      mode === MODE.EDIT &&
-      confirm(`${editName}으로 이름을 변경하시겠습니까?`)
-    ) {
-      setEditName(username);
+    if (confirm("이름 변경을 취소하시겠습니까?")) {
       setMode(MODE.NORMAL);
     }
   };


### PR DESCRIPTION
## 구현 사항
- 이름 변경 취소 버튼 handler 수정
- 이름 변경시 유저 정보 refetch

### 고민
유저 정보만을 refetch해오고 있는데요, rollingpaper와 message정보도 refetch하는 것이 좋을지 고민입니다. 우선적으로 사용자의 이름과 두 정보는 연관이 없어 refetch하지 않도록 하였습니다.

closed #274 