### PR TITLE
feat: 전체 모임 검색에서 검색 결과가 없을 시 보여줄 empty state UI를 구현

### DIFF
--- a/frontend/src/mocks/handlers/teamHandlers.js
+++ b/frontend/src/mocks/handlers/teamHandlers.js
@@ -47,7 +47,7 @@ const teamHandlers = [
     const result = {
       totalCount: keywordTeam.length,
       currentPage: Number(page),
-      teams: keywordTeam.slice((page - 1) * count, (page - 1) * count + count),
+      teams: keywordTeam.slice(page * count, page * count + count),
     };
 
     return res(ctx.json(result));

--- a/frontend/src/pages/TeamSearchPage/index.tsx
+++ b/frontend/src/pages/TeamSearchPage/index.tsx
@@ -10,6 +10,7 @@ import { getTeamSearchResult } from "@/api/team";
 import SearchInput from "@/components/SearchInput";
 import SearchResultItem from "@/pages/TeamSearchPage/components/SearchResultItem";
 
+import EmptyStateImg from "@/assets/images/empty-state.svg";
 import { TOTAL_TEAMS_PAGING_COUNT } from "@/constants";
 
 import { CustomError } from "@/types";
@@ -93,6 +94,23 @@ const TeamSearch = () => {
     return <div>에러</div>;
   }
 
+  if (totalTeamResponse.pages[0].teams.length === 0) {
+    return (
+      <>
+        <StyledSearch>
+          <SearchInput
+            onClick={handleSearchClick}
+            onChange={handleSearchChange}
+          />
+        </StyledSearch>
+        <StyledEmptySearch>
+          <EmptyStateImg />
+          <div>검색 결과가 없어요!</div>
+        </StyledEmptySearch>
+      </>
+    );
+  }
+
   return (
     <>
       <StyledSearch>
@@ -119,6 +137,28 @@ const TeamSearch = () => {
     </>
   );
 };
+
+const StyledEmptySearch = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  margin-top: 10px;
+  height: 75vh;
+
+  svg {
+    font-size: 200px;
+  }
+
+  div {
+    font-size: 24px;
+    font-weight: 600;
+    color: ${({ theme }) => theme.colors.GRAY_400};
+
+    margin-bottom: 20px;
+  }
+`;
 
 const StyledSearch = styled.div`
   padding: 20px;


### PR DESCRIPTION
## 구현 사항
- 전체 팀 조회 handler page 계산 수정
- 전체 모임 검색에서 결과가 없을 시 보여줄 empty state UI 구현

소피아가 이전 pr에서 전체 팀 조회 handler를 수정해주었던 것 같은데 반영이 안되어 있어서 다시 수정했습니다
현재 전체 모임 검색 시 결과가 없으면 early return을 해주고 있습니다. 검색 결과가 없을때도 search input이 보여야해서 이를 넣어주었습니다. 그래서 early return이 좋은 방법인가 라는 궁금증이 생기네요. 이에 대한 소피아의 의견이 궁금합니다( early return이 나을지 삼항 연산자가 나을지)

closed #306 