### PR TITLE
feat: api 호출 순서 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -39,74 +39,28 @@ const App = () => {
         <PageContainer>
           <UserProvider>
             <Routes>
-              <Route path="/" element={<HeaderLayoutPage />}>
+              <Route element={<RequireLogin />}>
+                <Route element={<HeaderLayoutPage />}>
+                  <Route path="/" element={<MainPage />} />
+                  <Route path="team/:teamId" element={<TeamDetailPage />} />
+                  <Route path="search" element={<TeamSearch />} />
+                  <Route path="mypage" element={<MyPage />} />
+                  <Route path="*" element={<ErrorPage />} />
+                </Route>
+                <Route path="team/new" element={<TeamCreationPage />} />
                 <Route
-                  path="/"
-                  element={
-                    <RequireLogin>
-                      <MainPage />
-                    </RequireLogin>
-                  }
+                  path="team/:teamId/rollingpaper/new"
+                  element={<RollingpaperCreationPage />}
                 />
                 <Route
-                  path="team/:teamId"
-                  element={
-                    <RequireLogin>
-                      <TeamDetailPage />
-                    </RequireLogin>
-                  }
+                  path="team/:teamId/rollingpaper/:rollingpaperId"
+                  element={<RollingpaperPage />}
                 />
-                <Route
-                  path="search"
-                  element={
-                    <RequireLogin>
-                      <TeamSearch />
-                    </RequireLogin>
-                  }
-                />
-                <Route
-                  path="mypage"
-                  element={
-                    <RequireLogin>
-                      <MyPage />
-                    </RequireLogin>
-                  }
-                />
-                <Route path="*" element={<ErrorPage />} />
               </Route>
-              <Route
-                path="login"
-                element={
-                  <RequireLogout>
-                    <LoginPage />
-                  </RequireLogout>
-                }
-              />
-              <Route
-                path="team/new"
-                element={
-                  <RequireLogin>
-                    <TeamCreationPage />
-                  </RequireLogin>
-                }
-              />
-              <Route
-                path="team/:teamId/rollingpaper/new"
-                element={
-                  <RequireLogin>
-                    <RollingpaperCreationPage />
-                  </RequireLogin>
-                }
-              />
-              <Route
-                path="team/:teamId/rollingpaper/:rollingpaperId"
-                element={
-                  <RequireLogin>
-                    <RollingpaperPage />
-                  </RequireLogin>
-                }
-              />
-              <Route path="oauth/kakao" element={<KakaoRedirectPage />} />
+              <Route element={<RequireLogout />}>
+                <Route path="login" element={<LoginPage />} />
+                <Route path="oauth/kakao" element={<KakaoRedirectPage />} />
+              </Route>
             </Routes>
             {isOpened && <Snackbar />}
           </UserProvider>

--- a/frontend/src/components/RequireLogin.tsx
+++ b/frontend/src/components/RequireLogin.tsx
@@ -1,16 +1,56 @@
 import { useContext } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, Outlet } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 
 import { UserContext } from "@/context/UserContext";
+import { appClient } from "@/api";
+import { getCookie } from "@/util/cookie";
 
-const RequireLogin = ({ children }: { children: JSX.Element }) => {
-  const { isLoggedIn } = useContext(UserContext);
+interface UserInfo {
+  id: number;
+  username: string;
+  email: string;
+}
+
+const COOKIE_KEY = {
+  ACCESS_TOKEN: "accessToken",
+};
+
+const RequireLogin = () => {
+  const { isLoggedIn, login } = useContext(UserContext);
 
   if (!isLoggedIn) {
     return <Navigate to="/login" replace />;
   }
 
-  return children;
+  const accessTokenCookie = getCookie(COOKIE_KEY.ACCESS_TOKEN);
+
+  const { isSuccess, error } = useQuery<UserInfo>(
+    ["memberId"],
+    () =>
+      appClient
+        .get("/members/me", {
+          headers: {
+            Authorization: `Bearer ${accessTokenCookie || ""}`,
+          },
+        })
+        .then((response) => response.data),
+    {
+      enabled: !!accessTokenCookie,
+      onSuccess: (data) => {
+        login(accessTokenCookie!, data.id);
+
+        appClient.defaults.headers.common[
+          "Authorization"
+        ] = `Bearer ${accessTokenCookie}`;
+      },
+    }
+  );
+
+  if (isSuccess) {
+    return <Outlet />;
+  }
+  return <>{error}</>;
 };
 
 export default RequireLogin;

--- a/frontend/src/components/RequireLogin.tsx
+++ b/frontend/src/components/RequireLogin.tsx
@@ -17,9 +17,10 @@ const COOKIE_KEY = {
 };
 
 const RequireLogin = () => {
-  const { isLoggedIn, login } = useContext(UserContext);
+  const isLogged = getCookie(COOKIE_KEY.ACCESS_TOKEN);
+  const { login } = useContext(UserContext);
 
-  if (!isLoggedIn) {
+  if (!isLogged) {
     return <Navigate to="/login" replace />;
   }
 

--- a/frontend/src/components/RequireLogout.tsx
+++ b/frontend/src/components/RequireLogout.tsx
@@ -1,16 +1,16 @@
 import { useContext } from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, Outlet } from "react-router-dom";
 
 import { UserContext } from "@/context/UserContext";
 
-const RequireLogout = ({ children }: { children: JSX.Element }) => {
+const RequireLogout = () => {
   const { isLoggedIn } = useContext(UserContext);
 
   if (isLoggedIn) {
     return <Navigate to="/" replace />;
   }
 
-  return children;
+  return <Outlet />;
 };
 
 export default RequireLogout;

--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -1,5 +1,4 @@
 import { useState, createContext, PropsWithChildren } from "react";
-import { useQuery } from "@tanstack/react-query";
 
 import { appClient } from "@/api";
 import { deleteCookie, getCookie, setCookie } from "@/util/cookie";
@@ -15,12 +14,6 @@ interface UserContextType {
   memberId: number | null;
 }
 
-interface UserInfo {
-  id: number;
-  username: string;
-  email: string;
-}
-
 const UserContext = createContext<UserContextType>(null!);
 
 const UserProvider = ({ children }: PropsWithChildren) => {
@@ -28,29 +21,6 @@ const UserProvider = ({ children }: PropsWithChildren) => {
 
   const [isLoggedIn, setIsLoggedIn] = useState(!!accessTokenCookie);
   const [memberId, setMemberId] = useState<number | null>(null);
-
-  useQuery<UserInfo>(
-    ["memberId"],
-    () =>
-      appClient
-        .get("/members/me", {
-          headers: {
-            Authorization: `Bearer ${accessTokenCookie || ""}`,
-          },
-        })
-        .then((response) => response.data),
-    {
-      enabled: !!accessTokenCookie,
-      onSuccess: (data) => {
-        setMemberId(data.id);
-        setIsLoggedIn(true);
-
-        appClient.defaults.headers.common[
-          "Authorization"
-        ] = `Bearer ${accessTokenCookie}`;
-      },
-    }
-  );
 
   const login = (accessToken: string, memberId: number) => {
     appClient.defaults.headers.common[

--- a/frontend/src/context/UserContext.tsx
+++ b/frontend/src/context/UserContext.tsx
@@ -17,9 +17,7 @@ interface UserContextType {
 const UserContext = createContext<UserContextType>(null!);
 
 const UserProvider = ({ children }: PropsWithChildren) => {
-  const accessTokenCookie = getCookie(COOKIE_KEY.ACCESS_TOKEN);
-
-  const [isLoggedIn, setIsLoggedIn] = useState(!!accessTokenCookie);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [memberId, setMemberId] = useState<number | null>(null);
 
   const login = (accessToken: string, memberId: number) => {


### PR DESCRIPTION
## 구현 사항
- RequireLogin에서 나의 정보를 가져오도록 수정

## 고민
- 기존에는 UserContext에서 cookie를 가져와 이를 통해 isLoggedIn을 결정하는 로직을 가지고 있었습니다. RequireLogin으로 나의 정보 조회 로직을 옮기고 난 후 나의 정보 조회가 성공하면 로그인을 다시 하도록 하는 로직을 실행시키다보니 isLoggedIn이 이미 true인데 다시 login을 해서 또 true로 만드는 반복되는 로직이 생겼습니다. 이 과정에서 오히려 requireLogin에서 cookie가 있는지를 확인하고, 있다면 isLoggedIn을 true로 변경하는 것이 맞지 않을까 라는 생각이 들어 cookie를 get해오는 로직을 RequireLoggedIn으로 옮기게 되었습니다. 어떻게 보면 RequireLogin에서 자동 로그인을 시켜주고 있다고 보면 될 것 같습니다. cookie를 get해오는 위치에 대한 소피아의 생각이 궁금합니다!
- 두번째로 기존과 동일하게 하고, isLoggedIn의 초기 state를 false로 두면, 새로 고침시 로그인이 풀리게 되는 문제가 있습니다....!

글로 쓰려고 하니 어렵네요...


closed #314 