### PR TITLE
feat: 비밀글(비밀 메시지) UI 구현

### DIFF
--- a/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
@@ -245,6 +245,8 @@ const StyledMessageList = styled.div`
   flex-direction: column;
   gap: 20px;
 
+  width: 100%;
+
   a {
     display: inline-block;
   }

--- a/frontend/src/pages/RollingpaperPage/components/RollingpaperMessage.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/RollingpaperMessage.tsx
@@ -96,7 +96,6 @@ const StyledMessage = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  white-space: pre-line;
 
   width: 100%;
   aspect-ratio: 1;

--- a/frontend/src/pages/RollingpaperPage/components/SecretMessage.stories.jsx
+++ b/frontend/src/pages/RollingpaperPage/components/SecretMessage.stories.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import SecretMessage from "@/pages/RollingpaperPage/components/SecretMessage";
+
+export default {
+  component: SecretMessage,
+  title: "components/RollingpaperPage/SecretMessage",
+};
+
+const Template = (args) => <SecretMessage {...args}></SecretMessage>;
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/frontend/src/pages/RollingpaperPage/components/SecretMessage.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/SecretMessage.tsx
@@ -28,7 +28,7 @@ const StyledSecretMessageContainer = styled.div`
 `;
 
 const StyledGuideText = styled.div`
-  font-size: 15px;
+  font-size: 14px;
 `;
 
 const StyledGuideTextTitle = styled.h3`

--- a/frontend/src/pages/RollingpaperPage/components/SecretMessage.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/SecretMessage.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+const SecretMessage = () => {
+  return (
+    <StyledSecretMessageContainer>
+      <StyledGuideTextTitle>🔒 비밀글입니다.</StyledGuideTextTitle>
+      <StyledGuideText>작성자와 받은 사람만 확인할 수 있어요.</StyledGuideText>
+    </StyledSecretMessageContainer>
+  );
+};
+
+const StyledSecretMessageContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  white-space: pre-line;
+
+  text-align: center;
+
+  width: 100%;
+  aspect-ratio: 1;
+  min-width: 180px;
+  padding: 20px 20px 12px;
+
+  color: ${({ theme }) => theme.colors.GRAY_700};
+  background-color: ${({ theme }) => theme.colors.GRAY_300};
+`;
+
+const StyledGuideText = styled.div`
+  font-size: 15px;
+`;
+
+const StyledGuideTextTitle = styled.h3`
+  margin-bottom: 10px;
+`;
+
+export default SecretMessage;

--- a/frontend/src/pages/RollingpaperPage/components/SecretMessage.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/SecretMessage.tsx
@@ -14,7 +14,6 @@ const StyledSecretMessageContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  white-space: pre-line;
 
   text-align: center;
 


### PR DESCRIPTION
## 작업 내용
- SecretMessage 컴포넌트 구현
- LetterPaper의 StyledMessageList에 스타일 추가

<br >

## 이미지
<img src="https://user-images.githubusercontent.com/71116429/184291575-a0fdb9b6-3aa5-4a2c-8189-1f2632879391.png" width="300px" />

<br >

## 구현하면서 한 생각
명세 논의 때 각 메시지마다 현재 사용자가 확인 가능한 메시지인가에 대한 정보(visible)를 받기로 했기 때문에, 
지금 RollingpaperMessage 컴포넌트가 해당 정보를 받으면 조건에 따라 SecrectMessage를 반환하는 방식으로 구현하면 좋겠다고 생각했습니다.