### PR TITLE
feat: 모임/개인에게 롤링페이퍼 작성을 위한 UI를 구현

### DIFF
--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -37,6 +37,11 @@ const KAKAO_OAUTH_URL = {
     'https://kapi.kakao.com/v2/user/me?secure_resource=true&property_keys=["kakao_account.profile","kakao_account.email"]',
 };
 
+const RECIPIENT = {
+  TEAM: "team",
+  MEMBER: "member",
+} as const;
+
 export {
   REGEX,
   COLORS,
@@ -45,4 +50,5 @@ export {
   MYPAGE_MESSAGE_PAGING_COUNT,
   SOCIAL_LOGIN_PLATFORM,
   KAKAO_OAUTH_URL,
+  RECIPIENT,
 };

--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import styled from "@emotion/styled";
+import { useQuery } from "@tanstack/react-query";
+
+import LabeledInput from "@/components/LabeledInput";
+import Button from "@/components/Button";
+import AutoCompleteInput from "@/components/AutoCompleteInput";
+
+import { REGEX } from "@/constants";
+import useParamValidate from "@/hooks/useParamValidate";
+import useAutoCompleteInput from "@/hooks/useAutoCompleteInput";
+
+import { getTeamMembers } from "@/api/team";
+
+interface TeamMemberResponse {
+  members: TeamMember[];
+}
+
+interface TeamMember {
+  id: number;
+  nickname: string;
+}
+
+const MemberRollingpaperCreateForm = () => {
+  const { teamId } = useParamValidate(["teamId"]);
+  const {
+    value: rollingpaperTo,
+    autoCompleteList,
+    isOpen,
+    ref,
+    handleAutoInputChange,
+    handleAutoInputFocus,
+    handleListItemClick,
+    setKeywordList,
+  } = useAutoCompleteInput();
+
+  const {
+    isLoading,
+    isError,
+    data: teamMemberResponse,
+  } = useQuery<TeamMemberResponse>(
+    ["team-member", teamId],
+    () => getTeamMembers(+teamId),
+    {
+      onSuccess: (data) => {
+        const keywordList = data.members.map((item) => item.nickname);
+        setKeywordList(keywordList);
+      },
+    }
+  );
+
+  const findReceiverWithNickName = (nickName: string) => {
+    return teamMemberResponse?.members.find(
+      (member) => member.nickname === nickName
+    );
+  };
+
+  const isValidReceiverNickName = (nickName: string) => {
+    const receiver = findReceiverWithNickName(nickName);
+    return !!receiver;
+  };
+
+  const handleRollingpaperCreateSubmit: React.FormEventHandler<
+    HTMLFormElement
+  > = () => {
+    console.log("생성되었음");
+  };
+
+  return (
+    <StyledForm onSubmit={handleRollingpaperCreateSubmit}>
+      <LabeledInput
+        labelText="롤링페이퍼 제목"
+        pattern={REGEX.ROLLINGPAPER_TITLE.source}
+      />
+      <AutoCompleteInput
+        labelText="받는 사람"
+        value={rollingpaperTo}
+        autoCompleteList={autoCompleteList}
+        isOpen={isOpen}
+        ref={ref}
+        onChange={handleAutoInputChange}
+        onFocus={handleAutoInputFocus}
+        onClickListItem={handleListItemClick}
+      />
+      <Button>완료</Button>
+    </StyledForm>
+  );
+};
+
+const StyledForm = styled.form`
+  width: 100%;
+  button {
+    margin-top: 60px;
+  }
+`;
+
+export default MemberRollingpaperCreateForm;

--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -47,25 +47,43 @@ const MemberRollingpaperCreateForm = () => {
   };
 
   return (
-    <StyledForm onSubmit={handleRollingpaperCreateSubmit}>
-      <LabeledInput
-        labelText="롤링페이퍼 제목"
-        pattern={REGEX.ROLLINGPAPER_TITLE.source}
-      />
-      <AutoCompleteInput
-        labelText="받는 사람"
-        value={rollingpaperTo}
-        autoCompleteList={autoCompleteList}
-        isOpen={isOpen}
-        ref={ref}
-        onChange={handleAutoInputChange}
-        onFocus={handleAutoInputFocus}
-        onClickListItem={handleListItemClick}
-      />
-      <Button>완료</Button>
-    </StyledForm>
+    <StyledMain>
+      <StyledHeader>맴버에게 롤링페이퍼 작성</StyledHeader>
+      <StyledForm onSubmit={handleRollingpaperCreateSubmit}>
+        <LabeledInput
+          labelText="롤링페이퍼 제목"
+          pattern={REGEX.ROLLINGPAPER_TITLE.source}
+        />
+        <AutoCompleteInput
+          labelText="받는 사람"
+          value={rollingpaperTo}
+          autoCompleteList={autoCompleteList}
+          isOpen={isOpen}
+          ref={ref}
+          onChange={handleAutoInputChange}
+          onFocus={handleAutoInputFocus}
+          onClickListItem={handleListItemClick}
+        />
+        <Button>완료</Button>
+      </StyledForm>
+    </StyledMain>
   );
 };
+
+const StyledMain = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: 80px;
+
+  width: 100%;
+`;
+
+const StyledHeader = styled.h1`
+  font-size: 28px;
+  font-weight: 600;
+
+  align-self: center;
+`;
 
 const StyledForm = styled.form`
   width: 100%;

--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -24,10 +24,10 @@ const MemberRollingpaperCreateForm = () => {
     setKeywordList,
   } = useAutoCompleteInput();
 
-  const { data: teamMemberResponse, isSuccess } = useReadTeamMembers(+teamId);
-  if (isSuccess) {
-    setKeywordList(teamMemberResponse.members.map((member) => member.nickname));
-  }
+  const { data: teamMemberResponse } = useReadTeamMembers(
+    +teamId,
+    setKeywordList
+  );
 
   const findReceiverWithNickName = (nickName: string) => {
     return teamMemberResponse?.members.find(

--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -24,10 +24,11 @@ const MemberRollingpaperCreateForm = () => {
     setKeywordList,
   } = useAutoCompleteInput();
 
-  const { data: teamMemberResponse } = useReadTeamMembers(
-    +teamId,
-    setKeywordList
-  );
+  const { data: teamMemberResponse } = useReadTeamMembers({
+    teamId: +teamId,
+    onSuccess: (data) =>
+      setKeywordList(data.members.map((member) => member.nickname)),
+  });
 
   const findReceiverWithNickName = (nickName: string) => {
     return teamMemberResponse?.members.find(

--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import styled from "@emotion/styled";
-import { useQuery } from "@tanstack/react-query";
 
 import LabeledInput from "@/components/LabeledInput";
 import Button from "@/components/Button";
@@ -10,16 +9,7 @@ import { REGEX } from "@/constants";
 import useParamValidate from "@/hooks/useParamValidate";
 import useAutoCompleteInput from "@/hooks/useAutoCompleteInput";
 
-import { getTeamMembers } from "@/api/team";
-
-interface TeamMemberResponse {
-  members: TeamMember[];
-}
-
-interface TeamMember {
-  id: number;
-  nickname: string;
-}
+import { useReadTeamMembers } from "@/pages/RollingpaperCreationPage/hooks/useReadTeamMembers";
 
 const MemberRollingpaperCreateForm = () => {
   const { teamId } = useParamValidate(["teamId"]);
@@ -34,20 +24,10 @@ const MemberRollingpaperCreateForm = () => {
     setKeywordList,
   } = useAutoCompleteInput();
 
-  const {
-    isLoading,
-    isError,
-    data: teamMemberResponse,
-  } = useQuery<TeamMemberResponse>(
-    ["team-member", teamId],
-    () => getTeamMembers(+teamId),
-    {
-      onSuccess: (data) => {
-        const keywordList = data.members.map((item) => item.nickname);
-        setKeywordList(keywordList);
-      },
-    }
-  );
+  const { data: teamMemberResponse, isSuccess } = useReadTeamMembers(+teamId);
+  if (isSuccess) {
+    setKeywordList(teamMemberResponse.members.map((member) => member.nickname));
+  }
 
   const findReceiverWithNickName = (nickName: string) => {
     return teamMemberResponse?.members.find(

--- a/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
@@ -1,22 +1,25 @@
 import React from "react";
 import styled from "@emotion/styled";
 
+import { RECIPIENT } from "@/constants";
 import { Recipient } from "@/types";
 
 const boxInput = {
   team: {
+    recipient: RECIPIENT.TEAM,
     to: "모임",
     description: "모임을 대상으로 한 롤링페이퍼 작성하기",
   },
   member: {
-    to: "개인",
+    recipient: RECIPIENT.MEMBER,
+    to: "멤버",
     description: "모임 내의 멤버에게 롤링페이퍼 작성하기",
   },
 };
 
 interface RecipientBoxProps {
   type: Recipient;
-  onClick: VoidFunction;
+  onClick: (type: Recipient) => React.MouseEventHandler<HTMLDivElement>;
 }
 
 interface StyledRecipientBoxProps {
@@ -24,10 +27,10 @@ interface StyledRecipientBoxProps {
 }
 
 export const RecipientBox = ({ type, onClick }: RecipientBoxProps) => {
-  const { to, description } = boxInput[type];
+  const { recipient, to, description } = boxInput[type];
 
   return (
-    <StyledRecipientBox type={type} onClick={onClick}>
+    <StyledRecipientBox type={type} onClick={onClick(recipient)}>
       <StyledTo>{to}</StyledTo>
       <StyledDescription>{description}</StyledDescription>
     </StyledRecipientBox>

--- a/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import styled from "@emotion/styled";
 
+import { RecipientType } from "@/pages/RollingpaperCreationPage/index";
+
 const boxInput = {
   team: {
     to: "모임",
@@ -11,8 +13,6 @@ const boxInput = {
     description: "모임 내의 멤버에게 롤링페이퍼 작성하기",
   },
 };
-
-type RecipientType = "team" | "member";
 
 interface RecipientBoxProps {
   type: RecipientType;

--- a/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styled from "@emotion/styled";
 
-import { RecipientType } from "@/pages/RollingpaperCreationPage/index";
+import { Recipient } from "@/types";
 
 const boxInput = {
   team: {
@@ -15,12 +15,12 @@ const boxInput = {
 };
 
 interface RecipientBoxProps {
-  type: RecipientType;
+  type: Recipient;
   onClick: VoidFunction;
 }
 
 interface StyledRecipientBoxProps {
-  type: RecipientType;
+  type: Recipient;
 }
 
 export const RecipientBox = ({ type, onClick }: RecipientBoxProps) => {

--- a/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+const boxInput = {
+  team: {
+    to: "모임",
+    description: "모임을 대상으로 한 롤링페이퍼 작성하기",
+  },
+  member: {
+    to: "개인",
+    description: "모임 내의 멤버에게 롤링페이퍼 작성하기",
+  },
+};
+
+type RecipientType = "team" | "member";
+
+interface RecipientBoxProps {
+  type: RecipientType;
+  onClick: VoidFunction;
+}
+
+interface StyledRecipientBoxProps {
+  type: RecipientType;
+}
+
+export const RecipientBox = ({ type, onClick }: RecipientBoxProps) => {
+  const { to, description } = boxInput[type];
+
+  return (
+    <StyledRecipientBox type={type} onClick={onClick}>
+      <StyledTo>{to}</StyledTo>
+      <StyledDescription>{description}</StyledDescription>
+    </StyledRecipientBox>
+  );
+};
+
+const StyledRecipientBox = styled.div<StyledRecipientBoxProps>`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-evenly;
+
+  width: 160px;
+  height: 190px;
+
+  padding: 10px;
+
+  background-color: ${({ theme, type }) =>
+    type === "team" ? theme.colors.YELLOW_200 : theme.colors.LIGHT_GREEN_200};
+
+  border-radius: 8px;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme, type }) =>
+      type === "team" ? theme.colors.YELLOW_300 : theme.colors.LIGHT_GREEN_300};
+  }
+`;
+
+const StyledTo = styled.div`
+  font-size: 32px;
+  font-weight: 600;
+`;
+
+const StyledDescription = styled.div`
+  font-size: 16px;
+  text-align: center;
+`;

--- a/frontend/src/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import styled from "@emotion/styled";
+
+import LabeledInput from "@/components/LabeledInput";
+import Button from "@/components/Button";
+
+import { REGEX } from "@/constants";
+
+const TeamRollingpaperCreateForm = () => {
+  const handleRollingpaperCreateSubmit: React.FormEventHandler<
+    HTMLFormElement
+  > = () => {
+    console.log("생성되었음");
+  };
+
+  return (
+    <StyledForm onSubmit={handleRollingpaperCreateSubmit}>
+      <LabeledInput
+        labelText="롤링페이퍼 제목"
+        pattern={REGEX.ROLLINGPAPER_TITLE.source}
+      />
+      <Button>완료</Button>
+    </StyledForm>
+  );
+};
+
+const StyledForm = styled.form`
+  width: 100%;
+  button {
+    margin-top: 60px;
+  }
+`;
+
+export default TeamRollingpaperCreateForm;

--- a/frontend/src/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm.tsx
@@ -14,15 +14,33 @@ const TeamRollingpaperCreateForm = () => {
   };
 
   return (
-    <StyledForm onSubmit={handleRollingpaperCreateSubmit}>
-      <LabeledInput
-        labelText="롤링페이퍼 제목"
-        pattern={REGEX.ROLLINGPAPER_TITLE.source}
-      />
-      <Button>완료</Button>
-    </StyledForm>
+    <StyledMain>
+      <StyledHeader>모임에게 롤링페이퍼 작성</StyledHeader>
+      <StyledForm onSubmit={handleRollingpaperCreateSubmit}>
+        <LabeledInput
+          labelText="롤링페이퍼 제목"
+          pattern={REGEX.ROLLINGPAPER_TITLE.source}
+        />
+        <Button>완료</Button>
+      </StyledForm>
+    </StyledMain>
   );
 };
+
+const StyledMain = styled.main`
+  display: flex;
+  flex-direction: column;
+  gap: 80px;
+
+  width: 100%;
+`;
+
+const StyledHeader = styled.h1`
+  font-size: 28px;
+  font-weight: 600;
+
+  align-self: center;
+`;
 
 const StyledForm = styled.form`
   width: 100%;

--- a/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
@@ -12,8 +12,17 @@ interface TeamMemberResponse {
   members: TeamMember[];
 }
 
-export const useReadTeamMembers = (teamId: number) => {
-  return useQuery<TeamMemberResponse>(["team-member", teamId], () =>
-    getTeamMembers(+teamId)
+export const useReadTeamMembers = (
+  teamId: number,
+  setKeywordList: React.Dispatch<React.SetStateAction<string[]>>
+) => {
+  return useQuery<TeamMemberResponse>(
+    ["team-member", teamId],
+    () => getTeamMembers(+teamId),
+    {
+      onSuccess: (data) => {
+        setKeywordList(data.members.map((member) => member.nickname));
+      },
+    }
   );
 };

--- a/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
@@ -3,6 +3,10 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getTeamMembers } from "@/api/team";
 
+interface UseReadTeamMembersArgs {
+  teamId: number;
+  onSuccess: (data: ResponseTeamMember) => void;
+}
 interface TeamMember {
   id: number;
   nickname: string;
@@ -12,17 +16,15 @@ interface ResponseTeamMember {
   members: TeamMember[];
 }
 
-export const useReadTeamMembers = (
-  teamId: number,
-  setKeywordList: React.Dispatch<React.SetStateAction<string[]>>
-) => {
+export const useReadTeamMembers = ({
+  teamId,
+  onSuccess,
+}: UseReadTeamMembersArgs) => {
   return useQuery<ResponseTeamMember>(
     ["team-member", teamId],
     () => getTeamMembers(+teamId),
     {
-      onSuccess: (data) => {
-        setKeywordList(data.members.map((member) => member.nickname));
-      },
+      onSuccess,
     }
   );
 };

--- a/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
@@ -8,7 +8,7 @@ interface TeamMember {
   nickname: string;
 }
 
-interface TeamMemberResponse {
+interface ResponseTeamMember {
   members: TeamMember[];
 }
 
@@ -16,7 +16,7 @@ export const useReadTeamMembers = (
   teamId: number,
   setKeywordList: React.Dispatch<React.SetStateAction<string[]>>
 ) => {
-  return useQuery<TeamMemberResponse>(
+  return useQuery<ResponseTeamMember>(
     ["team-member", teamId],
     () => getTeamMembers(+teamId),
     {

--- a/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getTeamMembers } from "@/api/team";
+
+interface TeamMember {
+  id: number;
+  nickname: string;
+}
+
+interface TeamMemberResponse {
+  members: TeamMember[];
+}
+
+export const useReadTeamMembers = (teamId: number) => {
+  return useQuery<TeamMemberResponse>(["team-member", teamId], () =>
+    getTeamMembers(+teamId)
+  );
+};

--- a/frontend/src/pages/RollingpaperCreationPage/index.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/index.tsx
@@ -1,162 +1,56 @@
-import React from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
-import { useNavigate } from "react-router-dom";
+import React, { useState } from "react";
 import styled from "@emotion/styled";
-import axios from "axios";
 
-import PageTitleWithBackButton from "@/components/PageTitleWithBackButton";
-import LabeledInput from "@/components/LabeledInput";
-import AutoCompleteInput from "@/components/AutoCompleteInput";
-import Button from "@/components/Button";
+import { RecipientBox } from "@/pages/RollingpaperCreationPage/components/RecipientBox";
+import TeamRollingpaperCreateForm from "@/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm";
+import MemberRollingpaperCreateForm from "@/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm";
 
-import { Rollingpaper, CustomError } from "@/types";
-import { REGEX } from "@/constants";
-
-import useAutoCompleteInput from "@/hooks/useAutoCompleteInput";
-import useInput from "@/hooks/useInput";
-
-import { getTeamMembers } from "@/api/team";
-import { postRollingpaper } from "@/api/rollingpaper";
-import useParamValidate from "@/hooks/useParamValidate";
-
-interface TeamMemberResponse {
-  members: TeamMember[];
-}
-
-interface TeamMember {
-  id: number;
-  nickname: string;
-}
+type RecipientType = "team" | "member";
 
 const RollingpaperCreationPage = () => {
-  const navigate = useNavigate();
-  const { teamId } = useParamValidate(["teamId"]);
-  const {
-    value: rollingpaperTitle,
-    handleInputChange: handleRollingpaperTitleChange,
-  } = useInput("");
-  const {
-    value: rollingpaperTo,
-    autoCompleteList,
-    isOpen,
-    ref,
-    handleAutoInputChange,
-    handleAutoInputFocus,
-    handleListItemClick,
-    setKeywordList,
-  } = useAutoCompleteInput();
+  const [recipient, setRecipient] = useState<RecipientType | null>(null);
 
-  const {
-    isLoading,
-    isError,
-    data: teamMemberResponse,
-  } = useQuery<TeamMemberResponse>(["team-member", teamId], () =>
-    getTeamMembers(+teamId)
-  );
+  const handleTeamRollingpaperCreateClick = () => {
+    setRecipient("team");
+  };
 
-  const { mutate: postNewRollingpaper } = useMutation(
-    ({
-      title,
-      addresseeId,
-    }: Pick<Rollingpaper, "title"> & { addresseeId: number }) =>
-      postRollingpaper({ teamId: +teamId, title, addresseeId }),
-    {
-      onSuccess: (data) => {
-        const { id: newRollingpaperId } = data;
-        navigate(`/team/${teamId}/rollingpaper/${newRollingpaperId}`, {
-          replace: true,
-        });
-      },
-      onError: (error) => {
-        if (axios.isAxiosError(error) && error.response) {
-          const customError = error.response.data as CustomError;
-          alert(customError.message);
-        }
-      },
-    }
-  );
+  const handleMemberRollingpaperCreateClick = () => {
+    setRecipient("member");
+  };
 
-  const findReceiverWithNickName = (nickName: string) => {
-    return teamMemberResponse?.members.find(
-      (member) => member.nickname === nickName
+  if (recipient === "team") {
+    return (
+      <StyledMain>
+        <TeamRollingpaperCreateForm />
+      </StyledMain>
     );
-  };
-
-  const isValidRollingpaperTitle = (title: string) => {
-    return REGEX.ROLLINGPAPER_TITLE.test(title);
-  };
-
-  const isValidReceiverNickName = (nickName: string) => {
-    const receiver = findReceiverWithNickName(nickName);
-    return !!receiver;
-  };
-
-  const handleRollingpaperFormSubmit = (
-    e: React.FormEvent<HTMLFormElement>
-  ) => {
-    e.preventDefault();
-
-    if (!isValidRollingpaperTitle(rollingpaperTitle)) {
-      return alert("롤링페이퍼 제목은 1 ~ 20자여야 합니다.");
-    }
-
-    const receiver = findReceiverWithNickName(rollingpaperTo);
-    if (!receiver) {
-      return alert("받는 사람은 모임원 중 한 명이어야 합니다.");
-    }
-
-    postNewRollingpaper({ title: rollingpaperTitle, addresseeId: receiver.id });
-  };
-
-  if (isLoading) {
-    return <div>로딩 중</div>;
   }
-  if (isError || !teamMemberResponse) {
-    return <div>에러</div>;
+
+  if (recipient === "member") {
+    return (
+      <StyledMain>
+        <MemberRollingpaperCreateForm />
+      </StyledMain>
+    );
   }
 
   return (
-    <>
-      <PageTitleWithBackButton>롤링페이퍼 만들기</PageTitleWithBackButton>
-      <StyledForm onSubmit={handleRollingpaperFormSubmit}>
-        <LabeledInput
-          labelText="롤링페이퍼 제목"
-          value={rollingpaperTitle}
-          pattern={REGEX.ROLLINGPAPER_TITLE.source}
-          onChange={handleRollingpaperTitleChange}
-        />
-        <AutoCompleteInput
-          labelText="받는 사람"
-          value={rollingpaperTo}
-          autoCompleteList={autoCompleteList}
-          isOpen={isOpen}
-          ref={ref}
-          onChange={handleAutoInputChange}
-          onFocus={handleAutoInputFocus}
-          onClickListItem={handleListItemClick}
-        />
-        <Button
-          type="submit"
-          disabled={
-            !isValidRollingpaperTitle(rollingpaperTitle) ||
-            !isValidReceiverNickName(rollingpaperTo)
-          }
-        >
-          완료
-        </Button>
-      </StyledForm>
-    </>
+    <StyledMain>
+      <RecipientBox type="team" onClick={handleTeamRollingpaperCreateClick} />
+      <RecipientBox
+        type="member"
+        onClick={handleMemberRollingpaperCreateClick}
+      />
+    </StyledMain>
   );
 };
 
-const StyledForm = styled.form`
+const StyledMain = styled.div`
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 40px;
-  button {
-    align-self: flex-end;
-  }
+  justify-content: center;
+  gap: 12px;
+  height: 100vh;
 `;
 
 export default RollingpaperCreationPage;

--- a/frontend/src/pages/RollingpaperCreationPage/index.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/index.tsx
@@ -4,17 +4,12 @@ import styled from "@emotion/styled";
 import { RecipientBox } from "@/pages/RollingpaperCreationPage/components/RecipientBox";
 import TeamRollingpaperCreateForm from "@/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm";
 import MemberRollingpaperCreateForm from "@/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm";
-import { ValueOf } from "@/types";
 
-const RECIPIENT = {
-  TEAM: "team",
-  MEMBER: "member",
-} as const;
-
-export type RecipientType = ValueOf<typeof RECIPIENT>;
+import { RECIPIENT } from "@/constants";
+import { Recipient } from "@/types";
 
 const RollingpaperCreationPage = () => {
-  const [recipient, setRecipient] = useState<RecipientType | null>(null);
+  const [recipient, setRecipient] = useState<Recipient | null>(null);
 
   const handleTeamRollingpaperCreateClick = () => {
     setRecipient(RECIPIENT.TEAM);

--- a/frontend/src/pages/RollingpaperCreationPage/index.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/index.tsx
@@ -11,12 +11,8 @@ import { Recipient } from "@/types";
 const RollingpaperCreationPage = () => {
   const [recipient, setRecipient] = useState<Recipient | null>(null);
 
-  const handleTeamRollingpaperCreateClick = () => {
-    setRecipient(RECIPIENT.TEAM);
-  };
-
-  const handleMemberRollingpaperCreateClick = () => {
-    setRecipient(RECIPIENT.MEMBER);
+  const handleRollingpaperCreateClick = (recipient: Recipient) => () => {
+    setRecipient(recipient);
   };
 
   if (recipient === RECIPIENT.TEAM) {
@@ -39,11 +35,11 @@ const RollingpaperCreationPage = () => {
     <StyledMain>
       <RecipientBox
         type={RECIPIENT.TEAM}
-        onClick={handleTeamRollingpaperCreateClick}
+        onClick={handleRollingpaperCreateClick}
       />
       <RecipientBox
         type={RECIPIENT.MEMBER}
-        onClick={handleMemberRollingpaperCreateClick}
+        onClick={handleRollingpaperCreateClick}
       />
     </StyledMain>
   );

--- a/frontend/src/pages/RollingpaperCreationPage/index.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/index.tsx
@@ -4,21 +4,27 @@ import styled from "@emotion/styled";
 import { RecipientBox } from "@/pages/RollingpaperCreationPage/components/RecipientBox";
 import TeamRollingpaperCreateForm from "@/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm";
 import MemberRollingpaperCreateForm from "@/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm";
+import { ValueOf } from "@/types";
 
-type RecipientType = "team" | "member";
+const RECIPIENT = {
+  TEAM: "team",
+  MEMBER: "member",
+} as const;
+
+export type RecipientType = ValueOf<typeof RECIPIENT>;
 
 const RollingpaperCreationPage = () => {
   const [recipient, setRecipient] = useState<RecipientType | null>(null);
 
   const handleTeamRollingpaperCreateClick = () => {
-    setRecipient("team");
+    setRecipient(RECIPIENT.TEAM);
   };
 
   const handleMemberRollingpaperCreateClick = () => {
-    setRecipient("member");
+    setRecipient(RECIPIENT.MEMBER);
   };
 
-  if (recipient === "team") {
+  if (recipient === RECIPIENT.TEAM) {
     return (
       <StyledMain>
         <TeamRollingpaperCreateForm />
@@ -26,7 +32,7 @@ const RollingpaperCreationPage = () => {
     );
   }
 
-  if (recipient === "member") {
+  if (recipient === RECIPIENT.MEMBER) {
     return (
       <StyledMain>
         <MemberRollingpaperCreateForm />
@@ -36,9 +42,12 @@ const RollingpaperCreationPage = () => {
 
   return (
     <StyledMain>
-      <RecipientBox type="team" onClick={handleTeamRollingpaperCreateClick} />
       <RecipientBox
-        type="member"
+        type={RECIPIENT.TEAM}
+        onClick={handleTeamRollingpaperCreateClick}
+      />
+      <RecipientBox
+        type={RECIPIENT.MEMBER}
         onClick={handleMemberRollingpaperCreateClick}
       />
     </StyledMain>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,5 @@
+import { RECIPIENT } from "@/constants";
+
 export interface Team {
   id: number;
   name: string;
@@ -66,3 +68,5 @@ export type CustomError = {
 };
 
 export type ValueOf<T> = T[keyof T];
+
+export type Recipient = ValueOf<typeof RECIPIENT>;


### PR DESCRIPTION
## 구현 사항
- 모임, 개인을 선택해서 롤링페이퍼를 작성할 수 있도록 함
<img width="374" alt="스크린샷 2022-08-13 오후 10 01 07" src="https://user-images.githubusercontent.com/67692759/184495336-b66358ca-7cc8-4b31-8e57-e3715348d497.png">

![스크린샷 2022-08-13 오후 10 02 01](https://user-images.githubusercontent.com/67692759/184495358-fc24ff9b-3cec-443e-b251-0065bce97840.png)

![스크린샷 2022-08-13 오후 10 02 16](https://user-images.githubusercontent.com/67692759/184495364-d581db76-582e-4fbb-b77a-ec49afaaac31.png)

### 고민 거리
- RecipientType의 위치. 페이지 내에서만 사용되는 타입이라 이를 type폴더에 빼는 것이 맞을지 고민입니다. 오히려 RECIPIENT 상수와 같이 있는게 보기 더 편한 것 같기도 하고...??
- 모바일 위주로 구현하다보니 데스크탑 버전에서는 조금 공허함(단 이점은 기존에도 그랬어서 괜찮은 것 같기도 하구)
- 모임을 선택했다가 앗차 하고 뒤로 돌아갈 수 없음. 사용자가 뒤로가기를 눌렀을때 바로 팀 상세페이지로 가게 해도 괜찮을까에 대한 고민. 혹은 모임에 대한 롤링페이퍼를 작성중인지, 팀에 대한 롤링페이퍼를 작성중인지를 바로 알기 어려움. `회원가입`처럼 제목을 위에 써주는 것이 좋을까?

closed #345 