### PR TITLE
feat: 초대 링크 관련 기능 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -65,8 +65,8 @@ const App = () => {
           <Route element={<RequireLogout />}>
             <Route path="login" element={<LoginPage />} />
             <Route path="oauth/kakao" element={<KakaoRedirectPage />} />
-            <Route path="invite" element={<InvitePage />} />
           </Route>
+          <Route path="invite/:inviteToken" element={<InvitePage />} />
         </Routes>
         {isOpened && <Snackbar />}
       </UserProvider>

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -1,5 +1,6 @@
 import { appClient } from "@/api";
 import { Team } from "@/types";
+
 interface SearchRequest {
   keyword: string;
   count: number;
@@ -34,6 +35,11 @@ const getTeamRollingpapers = (id: number) =>
     return response.data;
   });
 
+const getTeamWithInviteToken = (inviteToken: string) =>
+  appClient
+    .get(`/teams/invite/inviteToken=${inviteToken}`)
+    .then((response) => response.data);
+
 const postTeam = ({
   name,
   description,
@@ -53,14 +59,25 @@ const postTeam = ({
     })
     .then((response) => response.data);
 
-const postTeamNickname = ({ id, nickname }: Pick<Team, "id" | "nickname">) =>
-  appClient
-    .post(`/teams/${id}`, { nickname })
-    .then((response) => response.data);
+const postTeamInviteToken = ({ id }: Pick<Team, "id">) =>
+  appClient.post(`/teams/${id}/invite`).then((response) => response.data);
 
 const putTeamNickname = ({ id, nickname }: Pick<Team, "id" | "nickname">) =>
   appClient
     .put(`/teams/${id}/me`, { nickname })
+    .then((response) => response.data);
+
+const postTeamMember = ({ id, nickname }: Pick<Team, "id" | "nickname">) =>
+  appClient
+    .post(`/teams/${id}`, { nickname })
+    .then((response) => response.data);
+
+const postTeamMemberWithInviteToken = ({
+  inviteToken,
+  nickname,
+}: Pick<Team, "nickname"> & { inviteToken: string }) =>
+  appClient
+    .post(`/teams/invite/join`, { inviteToken, nickname })
     .then((response) => response.data);
 
 export {
@@ -69,7 +86,10 @@ export {
   getTeam,
   getTeamMembers,
   getTeamRollingpapers,
+  getTeamWithInviteToken,
   postTeam,
-  postTeamNickname,
+  postTeamMember,
+  postTeamMemberWithInviteToken,
+  postTeamInviteToken,
   putTeamNickname,
 };

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -37,7 +37,7 @@ const getTeamRollingpapers = (id: number) =>
 
 const getTeamWithInviteToken = (inviteToken: string) =>
   appClient
-    .get(`/teams/invite/inviteToken=${inviteToken}`)
+    .get(`/teams/invite?inviteToken=${inviteToken}`)
     .then((response) => response.data);
 
 const postTeam = ({

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -30,7 +30,8 @@ const SOCIAL_LOGIN_PLATFORM = {
 } as const;
 
 const KAKAO_OAUTH_URL = {
-  AUTHORIZE_CODE: `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=${process.env.KAKAO_REDIRECT_URL}&response_type=code`,
+  AUTHORIZE_CODE: (inviteToken = "") =>
+    `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=${process.env.KAKAO_REDIRECT_URL}&response_type=code&state=${inviteToken}`,
   TOKEN: (authorize_code: string) =>
     `https://kauth.kakao.com/oauth/token?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=${process.env.KAKAO_REDIRECT_URL}&grant_type=authorization_code&client_secret=${process.env.KAKAO_CLIENT_SECRET}&code=${authorize_code}`,
   USER_INFO:

--- a/frontend/src/mocks/handlers/teamHandlers.js
+++ b/frontend/src/mocks/handlers/teamHandlers.js
@@ -1,4 +1,3 @@
-import { raw } from "@storybook/react";
 import { rest } from "msw";
 
 import totalTeamsDummy from "../dummy/totalTeams.json";
@@ -72,7 +71,7 @@ const teamHandlers = [
     return res(ctx.status(200), ctx.json(result));
   }),
 
-  // 모임 가입
+  // 모임 가입 (일반)
   rest.post("/api/v1/teams/:teamId", (req, res, ctx) => {
     const { teamId } = req.params;
     const { nickname } = req.body;
@@ -117,6 +116,36 @@ const teamHandlers = [
     };
 
     return res(ctx.json(result));
+  }),
+
+  // 모임 초대토큰 생성하기
+  rest.post("/api/v1/teams/:teamId/invite", (req, res, ctx) => {
+    const { teamId } = req.params;
+
+    const result = {
+      inviteToken: "testInviteToken",
+    };
+
+    return res(ctx.json(result));
+  }),
+
+  // 초대토큰으로 모임 정보 조회
+  rest.get("/api/v1/teams/invite", (req, res, ctx) => {
+    const inviteToken = +req.url.searchParams.get("inviteToken");
+
+    const team = totalTeams.find((team) => team.secret);
+    const result = {
+      ...team,
+    };
+
+    return res(ctx.json(result));
+  }),
+
+  // 모임 가입 (초대토큰)
+  rest.post("/api/v1/teams/invite/join", (req, res, ctx) => {
+    const { inviteToken, nickname } = req.body;
+
+    return res(ctx.status(204));
   }),
 ];
 

--- a/frontend/src/mocks/handlers/teamHandlers.js
+++ b/frontend/src/mocks/handlers/teamHandlers.js
@@ -58,6 +58,18 @@ const teamHandlers = [
     return res(ctx.json(result));
   }),
 
+  // 초대토큰으로 모임 정보 조회
+  rest.get("/api/v1/teams/invite", (req, res, ctx) => {
+    const inviteToken = req.url.searchParams.get("inviteToken");
+
+    const team = totalTeams.find((team) => team.secret);
+    const result = {
+      ...team,
+    };
+
+    return res(ctx.json(result));
+  }),
+
   // 모임 상세정보 조회
   rest.get("/api/v1/teams/:teamId", (req, res, ctx) => {
     const { teamId } = req.params;
@@ -124,18 +136,6 @@ const teamHandlers = [
 
     const result = {
       inviteToken: "testInviteToken",
-    };
-
-    return res(ctx.json(result));
-  }),
-
-  // 초대토큰으로 모임 정보 조회
-  rest.get("/api/v1/teams/invite", (req, res, ctx) => {
-    const inviteToken = +req.url.searchParams.get("inviteToken");
-
-    const team = totalTeams.find((team) => team.secret);
-    const result = {
-      ...team,
     };
 
     return res(ctx.json(result));

--- a/frontend/src/pages/InvitePage/hooks/useCheckInviteLinkAccessibility.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useCheckInviteLinkAccessibility.tsx
@@ -1,6 +1,7 @@
 import React, { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { useSnackbar } from "@/context/SnackbarContext";
 import { UserContext } from "@/context/UserContext";
 
 import { Team } from "@/types";
@@ -14,10 +15,12 @@ const useCheckInviteLinkAccessibility = ({
 }: useCheckInviteLinkAccessibilityArgs) => {
   const navigate = useNavigate();
 
+  const { openSnackbar } = useSnackbar();
   const { isLoggedIn } = useContext(UserContext);
 
   const checkAccessibility = (teamDetail: Team | undefined) => {
     if (!isLoggedIn) {
+      openSnackbar("로그인이 필요한 서비스입니다.");
       navigate("/login", {
         replace: true,
         state: { inviteToken },
@@ -25,7 +28,7 @@ const useCheckInviteLinkAccessibility = ({
     }
 
     if (teamDetail && teamDetail.joined) {
-      alert("이미 가입한 모임입니다.");
+      openSnackbar("이미 가입한 모임입니다.");
       navigate(`/team/${teamDetail.id}`, {
         replace: true,
       });

--- a/frontend/src/pages/InvitePage/hooks/useCheckInviteLinkAccessibility.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useCheckInviteLinkAccessibility.tsx
@@ -1,0 +1,37 @@
+import React, { useContext } from "react";
+import { useNavigate } from "react-router-dom";
+
+import { UserContext } from "@/context/UserContext";
+
+import { Team } from "@/types";
+
+type useCheckInviteLinkAccessibilityArgs = {
+  inviteToken: string;
+};
+
+const useCheckInviteLinkAccessibility = ({
+  inviteToken,
+}: useCheckInviteLinkAccessibilityArgs) => {
+  const navigate = useNavigate();
+
+  const { isLoggedIn } = useContext(UserContext);
+
+  const checkAccessibility = (teamDetail: Team | undefined) => {
+    if (!isLoggedIn) {
+      navigate("/login", {
+        replace: true,
+        state: { inviteToken },
+      });
+    }
+
+    if (teamDetail && teamDetail.joined) {
+      navigate(`/team/${teamDetail.id}`, {
+        replace: true,
+      });
+    }
+  };
+
+  return checkAccessibility;
+};
+
+export default useCheckInviteLinkAccessibility;

--- a/frontend/src/pages/InvitePage/hooks/useCheckInviteLinkAccessibility.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useCheckInviteLinkAccessibility.tsx
@@ -25,6 +25,7 @@ const useCheckInviteLinkAccessibility = ({
     }
 
     if (teamDetail && teamDetail.joined) {
+      alert("이미 가입한 모임입니다.");
       navigate(`/team/${teamDetail.id}`, {
         replace: true,
       });

--- a/frontend/src/pages/InvitePage/hooks/useCheckLogin.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useCheckLogin.tsx
@@ -4,21 +4,17 @@ import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "@/context/SnackbarContext";
 import { UserContext } from "@/context/UserContext";
 
-import { Team } from "@/types";
-
-type useCheckInviteLinkAccessibilityArgs = {
+type useCheckLoginArgs = {
   inviteToken: string;
 };
 
-const useCheckInviteLinkAccessibility = ({
-  inviteToken,
-}: useCheckInviteLinkAccessibilityArgs) => {
+const useCheckLogin = ({ inviteToken }: useCheckLoginArgs) => {
   const navigate = useNavigate();
 
   const { openSnackbar } = useSnackbar();
   const { isLoggedIn } = useContext(UserContext);
 
-  const checkAccessibility = (teamDetail: Team | undefined) => {
+  const checkLogin = () => {
     if (!isLoggedIn) {
       openSnackbar("로그인이 필요한 서비스입니다.");
       navigate("/login", {
@@ -26,16 +22,9 @@ const useCheckInviteLinkAccessibility = ({
         state: { inviteToken },
       });
     }
-
-    if (teamDetail && teamDetail.joined) {
-      openSnackbar("이미 가입한 모임입니다.");
-      navigate(`/team/${teamDetail.id}`, {
-        replace: true,
-      });
-    }
   };
 
-  return checkAccessibility;
+  return checkLogin;
 };
 
-export default useCheckInviteLinkAccessibility;
+export default useCheckLogin;

--- a/frontend/src/pages/InvitePage/hooks/useCheckLogin.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useCheckLogin.tsx
@@ -4,11 +4,8 @@ import { useNavigate } from "react-router-dom";
 import { useSnackbar } from "@/context/SnackbarContext";
 import { UserContext } from "@/context/UserContext";
 
-type useCheckLoginArgs = {
-  inviteToken: string;
-};
 
-const useCheckLogin = ({ inviteToken }: useCheckLoginArgs) => {
+const useCheckLogin = (inviteToken: string) => {
   const navigate = useNavigate();
 
   const { openSnackbar } = useSnackbar();

--- a/frontend/src/pages/InvitePage/hooks/useCheckTeamJoined.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useCheckTeamJoined.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+
+import { useSnackbar } from "@/context/SnackbarContext";
+import { Team } from "@/types";
+
+const useCheckTeamJoined = () => {
+  const navigate = useNavigate();
+  const { openSnackbar } = useSnackbar();
+
+  const checkTeamJoined = (teamDetail: Team) => {
+    if (teamDetail.joined) {
+      openSnackbar("이미 가입한 모임입니다.");
+      navigate(`/team/${teamDetail.id}`, {
+        replace: true,
+      });
+    }
+  };
+
+  return checkTeamJoined;
+};
+
+export default useCheckTeamJoined;

--- a/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { useMutation } from "@tanstack/react-query";
+import axios from "axios";
+
+import { postTeamMemberWithInviteToken } from "@/api/team";
+
+import { CustomError, Team } from "@/types";
+import { useSnackbar } from "@/context/SnackbarContext";
+
+type RequestJoinTeamWithInviteToken = Pick<Team, "nickname"> & {
+  inviteToken: string;
+};
+
+const useJoinTeamWithInviteToken = () => {
+  const { openSnackbar } = useSnackbar();
+
+  const { mutate: joinTeamWithInviteToken } = useMutation(
+    ({ inviteToken, nickname }: RequestJoinTeamWithInviteToken) => {
+      return postTeamMemberWithInviteToken({
+        inviteToken,
+        nickname,
+      });
+    },
+    {
+      onSuccess: () => {
+        openSnackbar("회원가입 성공!");
+      },
+      onError: (error) => {
+        if (axios.isAxiosError(error) && error.response) {
+          const customError = error.response.data as CustomError;
+          alert(customError.message);
+        }
+      },
+    }
+  );
+
+  return joinTeamWithInviteToken;
+};
+
+export default useJoinTeamWithInviteToken;

--- a/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import axios from "axios";
 
@@ -11,7 +12,8 @@ type RequestJoinTeamWithInviteToken = Pick<Team, "nickname"> & {
   inviteToken: string;
 };
 
-const useJoinTeamWithInviteToken = () => {
+const useJoinTeamWithInviteToken = (teamId: number | undefined) => {
+  const navigate = useNavigate();
   const { openSnackbar } = useSnackbar();
 
   const { mutate: joinTeamWithInviteToken } = useMutation(
@@ -23,7 +25,14 @@ const useJoinTeamWithInviteToken = () => {
     },
     {
       onSuccess: () => {
-        openSnackbar("회원가입 성공!");
+        openSnackbar("모임 가입 성공!");
+
+        if (teamId) {
+          navigate(`/team/${teamId}`, { replace: true });
+          return;
+        }
+
+        navigate("/", { replace: true });
       },
       onError: (error) => {
         if (axios.isAxiosError(error) && error.response) {

--- a/frontend/src/pages/InvitePage/hooks/useTeamDetailWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useTeamDetailWithInviteToken.tsx
@@ -5,19 +5,21 @@ import { getTeamWithInviteToken } from "@/api/team";
 
 import { Team } from "@/types";
 
-type RequestTeamDetailWithInviteToken = {
+type UseTeamDetailWithInviteTokenArgs = {
   inviteToken: string;
+  onSuccess?: ((data: Team) => void) | undefined;
+  onError?: ((err: unknown) => void) | undefined;
 };
 
 const useTeamDetailWithInviteToken = ({
   inviteToken,
-}: RequestTeamDetailWithInviteToken) => {
+  onSuccess,
+  onError,
+}: UseTeamDetailWithInviteTokenArgs) => {
   return useQuery<Team>(
     ["teamDetailWithInviteToken", inviteToken],
     () => getTeamWithInviteToken(inviteToken),
-    {
-      enabled: !!inviteToken,
-    }
+    { onSuccess, onError }
   );
 };
 

--- a/frontend/src/pages/InvitePage/hooks/useTeamDetailWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useTeamDetailWithInviteToken.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import { getTeamWithInviteToken } from "@/api/team";
+
+import { Team } from "@/types";
+
+type RequestTeamDetailWithInviteToken = {
+  inviteToken: string;
+};
+
+const useTeamDetailWithInviteToken = ({
+  inviteToken,
+}: RequestTeamDetailWithInviteToken) => {
+  return useQuery<Team>(
+    ["teamDetailWithInviteToken", inviteToken],
+    () => getTeamWithInviteToken(inviteToken),
+    {
+      enabled: !!inviteToken,
+    }
+  );
+};
+
+export default useTeamDetailWithInviteToken;

--- a/frontend/src/pages/InvitePage/index.tsx
+++ b/frontend/src/pages/InvitePage/index.tsx
@@ -18,10 +18,10 @@ const InvitePage = () => {
   const { inviteToken } = useParamValidate(["inviteToken"]);
   const checkAccessibility = useCheckInviteLinkAccessibility({ inviteToken });
 
-  const joinTeamWithInviteToken = useJoinTeamWithInviteToken();
   const { data: teamDetail } = useTeamDetailWithInviteToken({
     inviteToken,
   });
+  const joinTeamWithInviteToken = useJoinTeamWithInviteToken(teamDetail?.id);
 
   const { value: nickname, handleInputChange } = useInput("");
 

--- a/frontend/src/pages/InvitePage/index.tsx
+++ b/frontend/src/pages/InvitePage/index.tsx
@@ -23,7 +23,7 @@ const InvitePage = () => {
   const checkLogin = useCheckLogin({ inviteToken });
   const handleTeamDetailWithInviteTokenSuccess = useCheckTeamJoined();
 
-  const { data: teamDetail } = useTeamDetailWithInviteToken({
+  const { data: teamDetail, isLoading } = useTeamDetailWithInviteToken({
     inviteToken,
     onSuccess: handleTeamDetailWithInviteTokenSuccess,
   });
@@ -43,7 +43,7 @@ const InvitePage = () => {
     checkLogin();
   }, []);
 
-  if (!teamDetail) {
+  if (isLoading || !teamDetail) {
     return <div>로딩 중</div>;
   }
 

--- a/frontend/src/pages/InvitePage/index.tsx
+++ b/frontend/src/pages/InvitePage/index.tsx
@@ -20,7 +20,7 @@ const InvitePage = () => {
   const { inviteToken } = useParamValidate(["inviteToken"]);
 
   const { value: nickname, handleInputChange } = useInput("");
-  const checkLogin = useCheckLogin({ inviteToken });
+  const checkLogin = useCheckLogin(inviteToken);
   const handleTeamDetailWithInviteTokenSuccess = useCheckTeamJoined();
 
   const { data: teamDetail, isLoading } = useTeamDetailWithInviteToken({

--- a/frontend/src/pages/InvitePage/index.tsx
+++ b/frontend/src/pages/InvitePage/index.tsx
@@ -1,19 +1,29 @@
 import React from "react";
 import styled from "@emotion/styled";
 
+import useParamValidate from "@/hooks/useParamValidate";
+import useInput from "@/hooks/useInput";
+import useJoinTeamWithInviteToken from "@/pages/InvitePage/hooks/useJoinTeamWithInviteToken";
+
 import UnderlineInput from "@/components/UnderlineInput";
 import LineButton from "@/components/LineButton";
 
-import { REGEX } from "@/constants";
 import TeamDescriptionBox from "@/pages/InvitePage/components/TeamDescriptionBox";
 
-import useInput from "@/hooks/useInput";
+import { REGEX } from "@/constants";
 
 const InvitePage = () => {
+  const { inviteToken } = useParamValidate(["inviteToken"]);
   const { value: nickname, handleInputChange } = useInput("");
+  const joinTeamWithInviteToken = useJoinTeamWithInviteToken();
 
-  const handleTeamJoinSubmit = () => {
-    console.log("team join logic");
+  const handleTeamJoinSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
+    e.preventDefault();
+
+    joinTeamWithInviteToken({
+      nickname,
+      inviteToken,
+    });
   };
 
   return (

--- a/frontend/src/pages/InvitePage/index.tsx
+++ b/frontend/src/pages/InvitePage/index.tsx
@@ -3,9 +3,11 @@ import styled from "@emotion/styled";
 
 import useParamValidate from "@/hooks/useParamValidate";
 import useInput from "@/hooks/useInput";
-import useCheckInviteLinkAccessibility from "@/pages/InvitePage/hooks/useCheckInviteLinkAccessibility";
-import useJoinTeamWithInviteToken from "@/pages/InvitePage/hooks/useJoinTeamWithInviteToken";
+import useCheckLogin from "@/pages/InvitePage/hooks/useCheckLogin";
+import useCheckTeamJoined from "@/pages/InvitePage/hooks/useCheckTeamJoined";
+
 import useTeamDetailWithInviteToken from "@/pages/InvitePage/hooks/useTeamDetailWithInviteToken";
+import useJoinTeamWithInviteToken from "@/pages/InvitePage/hooks/useJoinTeamWithInviteToken";
 
 import UnderlineInput from "@/components/UnderlineInput";
 import LineButton from "@/components/LineButton";
@@ -16,14 +18,17 @@ import { REGEX } from "@/constants";
 
 const InvitePage = () => {
   const { inviteToken } = useParamValidate(["inviteToken"]);
-  const checkAccessibility = useCheckInviteLinkAccessibility({ inviteToken });
+
+  const { value: nickname, handleInputChange } = useInput("");
+  const checkLogin = useCheckLogin({ inviteToken });
+  const handleTeamDetailWithInviteTokenSuccess = useCheckTeamJoined();
 
   const { data: teamDetail } = useTeamDetailWithInviteToken({
     inviteToken,
+    onSuccess: handleTeamDetailWithInviteTokenSuccess,
   });
-  const joinTeamWithInviteToken = useJoinTeamWithInviteToken(teamDetail?.id);
 
-  const { value: nickname, handleInputChange } = useInput("");
+  const joinTeamWithInviteToken = useJoinTeamWithInviteToken(teamDetail?.id);
 
   const handleTeamJoinSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
@@ -35,8 +40,8 @@ const InvitePage = () => {
   };
 
   useEffect(() => {
-    checkAccessibility(teamDetail);
-  }, [teamDetail]);
+    checkLogin();
+  }, []);
 
   if (!teamDetail) {
     return <div>로딩 중</div>;

--- a/frontend/src/pages/InvitePage/index.tsx
+++ b/frontend/src/pages/InvitePage/index.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "@emotion/styled";
 
 import useParamValidate from "@/hooks/useParamValidate";
 import useInput from "@/hooks/useInput";
+import useCheckInviteLinkAccessibility from "@/pages/InvitePage/hooks/useCheckInviteLinkAccessibility";
 import useJoinTeamWithInviteToken from "@/pages/InvitePage/hooks/useJoinTeamWithInviteToken";
+import useTeamDetailWithInviteToken from "@/pages/InvitePage/hooks/useTeamDetailWithInviteToken";
 
 import UnderlineInput from "@/components/UnderlineInput";
 import LineButton from "@/components/LineButton";
@@ -14,8 +16,14 @@ import { REGEX } from "@/constants";
 
 const InvitePage = () => {
   const { inviteToken } = useParamValidate(["inviteToken"]);
-  const { value: nickname, handleInputChange } = useInput("");
+  const checkAccessibility = useCheckInviteLinkAccessibility({ inviteToken });
+
   const joinTeamWithInviteToken = useJoinTeamWithInviteToken();
+  const { data: teamDetail } = useTeamDetailWithInviteToken({
+    inviteToken,
+  });
+
+  const { value: nickname, handleInputChange } = useInput("");
 
   const handleTeamJoinSubmit: React.FormEventHandler<HTMLFormElement> = (e) => {
     e.preventDefault();
@@ -26,13 +34,21 @@ const InvitePage = () => {
     });
   };
 
+  useEffect(() => {
+    checkAccessibility(teamDetail);
+  }, [teamDetail]);
+
+  if (!teamDetail) {
+    return <div>로딩 중</div>;
+  }
+
   return (
     <StyledPage>
       <TeamDescriptionBox
-        color="#98DAFF"
-        emoji="❤️"
-        name="우테코 4기"
-        description="설명입니다 설명입니다"
+        color={teamDetail.color}
+        emoji={teamDetail.emoji}
+        name={teamDetail.name}
+        description={teamDetail.description}
       />
       <StyledJoinForm onSubmit={handleTeamJoinSubmit}>
         <p>모임에서 사용할 닉네임을 입력해주세요. (1 ~ 20자)</p>

--- a/frontend/src/pages/KakaoRedirectPage/index.tsx
+++ b/frontend/src/pages/KakaoRedirectPage/index.tsx
@@ -15,6 +15,7 @@ const KakaoRedirectPage = () => {
   const { login } = useContext(UserContext);
   const params = new URLSearchParams(useLocation().search);
   const authorizationCode = params.get("code");
+  const inviteToken = params.get("state");
 
   const { mutate: kakaoOauthLogin } = useMutation(
     ({ authorizationCode, redirectUri }: RequestKakaoOauthBody) =>
@@ -25,7 +26,13 @@ const KakaoRedirectPage = () => {
     {
       onSuccess: (data) => {
         login(data.accessToken, data.id);
-        navigate(`/`, { replace: true });
+
+        if (inviteToken) {
+          navigate(`/invite/${inviteToken}`, { replace: true });
+          return;
+        }
+
+        navigate("/", { replace: true });
       },
       onError: (error) => {
         if (axios.isAxiosError(error) && error.response) {

--- a/frontend/src/pages/LoginPage/index.tsx
+++ b/frontend/src/pages/LoginPage/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useLocation } from "react-router-dom";
 import styled from "@emotion/styled";
 
 import { useSnackbar } from "@/context/SnackbarContext";
@@ -10,11 +11,15 @@ import { KAKAO_OAUTH_URL, SOCIAL_LOGIN_PLATFORM } from "@/constants";
 
 const LoginPage = () => {
   const { openSnackbar } = useSnackbar();
+  const { state: locationState } = useLocation();
 
   const handleKakaoLoginButtonClick: React.MouseEventHandler<
     HTMLButtonElement
   > = () => {
-    location.href = KAKAO_OAUTH_URL.AUTHORIZE_CODE;
+    const inviteToken =
+      (locationState as { inviteToken?: string })?.inviteToken || "";
+
+    location.href = KAKAO_OAUTH_URL.AUTHORIZE_CODE(inviteToken);
   };
 
   const handleNaverLoginButtonClick: React.MouseEventHandler<

--- a/frontend/src/pages/LoginPage/index.tsx
+++ b/frontend/src/pages/LoginPage/index.tsx
@@ -9,15 +9,19 @@ import SocialLoginButton from "@/pages/LoginPage/components/SocialLoginButton";
 
 import { KAKAO_OAUTH_URL, SOCIAL_LOGIN_PLATFORM } from "@/constants";
 
+type LoginPageLocationState = {
+  inviteToken?: string;
+};
+
 const LoginPage = () => {
   const { openSnackbar } = useSnackbar();
-  const { state: locationState } = useLocation();
+  const { state } = useLocation();
 
   const handleKakaoLoginButtonClick: React.MouseEventHandler<
     HTMLButtonElement
   > = () => {
-    const inviteToken =
-      (locationState as { inviteToken?: string })?.inviteToken || "";
+    const locationState = state as LoginPageLocationState;
+    const inviteToken = locationState?.inviteToken || "";
 
     location.href = KAKAO_OAUTH_URL.AUTHORIZE_CODE(inviteToken);
   };

--- a/frontend/src/pages/TeamDetailPage/components/InviteModal.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/InviteModal.tsx
@@ -1,13 +1,16 @@
-import React from "react";
+import React, { useEffect } from "react";
 import styled from "@emotion/styled";
 
-import Modal from "@/components/Modal";
+import { useSnackbar } from "@/context/SnackbarContext";
 
-import CopyIcon from "@/assets/icons/bx-copy.svg";
+import useParamValidate from "@/hooks/useParamValidate";
+import useCreateInviteLink from "@/pages/TeamDetailPage/hooks/useCreateInviteLink";
+
+import Modal from "@/components/Modal";
 import IconButton from "@/components/IconButton";
 
 import copyClipboard from "@/util/copyClipboard";
-import { useSnackbar } from "@/context/SnackbarContext";
+import CopyIcon from "@/assets/icons/bx-copy.svg";
 
 interface InviteModalProp {
   onClickClose: () => void;
@@ -15,7 +18,8 @@ interface InviteModalProp {
 
 const InviteModal = ({ onClickClose }: InviteModalProp) => {
   const { openSnackbar } = useSnackbar();
-  const link = "http://djslfjslfjsdlkfjsldkf";
+  const { teamId } = useParamValidate(["teamId"]);
+  const { createInviteLink, isError, data } = useCreateInviteLink();
 
   const handleCopyButton =
     (link: string): React.MouseEventHandler =>
@@ -25,9 +29,25 @@ const InviteModal = ({ onClickClose }: InviteModalProp) => {
       copyClipboard(
         link,
         () => openSnackbar("초대 링크가 복사되었습니다"),
-        () => openSnackbar("초대 링크가 복사에 실패했습니다")
+        () => openSnackbar("초대 링크 복사에 실패했습니다")
       );
     };
+
+  useEffect(() => {
+    const typedTeamId = Number(teamId);
+    createInviteLink({ id: typedTeamId });
+  }, []);
+
+  if (isError) {
+    return (
+      <Modal onClickCloseButton={onClickClose}>
+        <StyledInvite>
+          <StyledHeader>모임 초대하기</StyledHeader>
+          <div>초대링크 생성에 실패했습니다. 다시 시도하세요. 😥</div>
+        </StyledInvite>
+      </Modal>
+    );
+  }
 
   return (
     <Modal onClickCloseButton={onClickClose}>
@@ -35,8 +55,13 @@ const InviteModal = ({ onClickClose }: InviteModalProp) => {
         <StyledHeader>모임 초대하기</StyledHeader>
         <div>모임에 초대하려면 아래 링크를 공유하세요</div>
         <StyledLinkCopy>
-          <StyledLink>{link}</StyledLink>
-          <IconButton size="small" onClick={handleCopyButton(link)}>
+          <StyledLink>{`https://naepyeon.site/${data?.inviteToken}`}</StyledLink>
+          <IconButton
+            size="small"
+            onClick={handleCopyButton(
+              `https://naepyeon.site/${data?.inviteToken}`
+            )}
+          >
             <CopyIcon />
           </IconButton>
         </StyledLinkCopy>
@@ -70,6 +95,8 @@ const StyledLinkCopy = styled.div`
 `;
 
 const StyledLink = styled.a`
+  word-break: break-all;
+
   color: ${({ theme }) => theme.colors.SKY_BLUE_400};
 `;
 

--- a/frontend/src/pages/TeamDetailPage/components/NicknameCreateModalForm.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/NicknameCreateModalForm.tsx
@@ -13,7 +13,7 @@ import { useSnackbar } from "@/context/SnackbarContext";
 
 import useInput from "@/hooks/useInput";
 
-import { postTeamNickname } from "@/api/team";
+import { postTeamMember } from "@/api/team";
 import useParamValidate from "@/hooks/useParamValidate";
 
 interface NicknameCreateModalFormProp {
@@ -30,7 +30,7 @@ const NicknameCreateModalForm = ({
 
   const { mutate: joinTeam } = useMutation(
     async (nickname: string) => {
-      postTeamNickname({ id: +teamId, nickname });
+      postTeamMember({ id: +teamId, nickname });
     },
     {
       onSuccess: () => {

--- a/frontend/src/pages/TeamDetailPage/hooks/useCreateInviteLink.tsx
+++ b/frontend/src/pages/TeamDetailPage/hooks/useCreateInviteLink.tsx
@@ -1,11 +1,9 @@
 import React from "react";
 import { useMutation } from "@tanstack/react-query";
 
-import axios from "axios";
-
 import { postTeamInviteToken } from "@/api/team";
 
-import { CustomError, Team } from "@/types";
+import { Team } from "@/types";
 
 const useCreateInviteLink = () => {
   const {
@@ -14,19 +12,9 @@ const useCreateInviteLink = () => {
     isSuccess,
     isError,
     data,
-  } = useMutation(
-    ({ id }: Pick<Team, "id">) => {
-      return postTeamInviteToken({ id });
-    },
-    {
-      onError: (error) => {
-        if (axios.isAxiosError(error) && error.response) {
-          const customError = error.response.data as CustomError;
-          alert(customError.message);
-        }
-      },
-    }
-  );
+  } = useMutation(({ id }: Pick<Team, "id">) => {
+    return postTeamInviteToken({ id });
+  });
 
   return { createInviteLink, isLoading, isSuccess, isError, data };
 };

--- a/frontend/src/pages/TeamDetailPage/hooks/useCreateInviteLink.tsx
+++ b/frontend/src/pages/TeamDetailPage/hooks/useCreateInviteLink.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import { useMutation } from "@tanstack/react-query";
+
+import axios from "axios";
+
+import { postTeamInviteToken } from "@/api/team";
+
+import { CustomError, Team } from "@/types";
+
+const useCreateInviteLink = () => {
+  const {
+    mutate: createInviteLink,
+    isLoading,
+    isSuccess,
+    isError,
+    data,
+  } = useMutation(
+    ({ id }: Pick<Team, "id">) => {
+      return postTeamInviteToken({ id });
+    },
+    {
+      onError: (error) => {
+        if (axios.isAxiosError(error) && error.response) {
+          const customError = error.response.data as CustomError;
+          alert(customError.message);
+        }
+      },
+    }
+  );
+
+  return { createInviteLink, isLoading, isSuccess, isError, data };
+};
+
+export default useCreateInviteLink;


### PR DESCRIPTION
## 작업 내용
- TeamDetail 페이지에서 초대링크 생성하기 기능 구현(inviteToken 생성)
- InvitePage에서 inviteToken을 이용한 모임 가입하기 기능 구현
- 사용자 로그인 여부, 해당 모임 가입 여부에 따라 페이지 접근 제한 기능 구현

#### 초대링크 접근 시 페이지 라우팅 방식
- 이미 로그인한 사람
    - 모임에 가입이 안 된 사람 → 초대링크 페이지를 바로 보여준다.
    - 모임에 가입이 이미 된 사람 → alert(이미 가입한 모임입니다). → 해당 모임 페이지로 이동
- 로그인 안 한 사람
    - 로그인 페이지로 redirect. → 로그인을 한다. (로그인 성공) → 초대링크 페이지로
        → 모임에 가입이 안 된 사람이면 초대링크 페이지를 보여준다.
        → 모임에 가입이 이미 된 사람이면 alert(이미 가입한 모임입니다.)하고 해당 모임 페이지로 이동

<br >

## 참고 사항 및 논의하고 싶은 내용
- 코멘트 남겨두겠습니다!
- 이번에 뭔가 작업 범위가 여기저기라,,, 정신없는 코드들이 좀 있는데 꼼꼼한 확인과 테스트 잘 부탁해요! 🥰

closed #340 