### PR TITLE
feat: 누락된 refetch 해결

### DIFF
--- a/frontend/src/hooks/useParamValidate.tsx
+++ b/frontend/src/hooks/useParamValidate.tsx
@@ -1,19 +1,14 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 
-const useParamValidate = (requireParams: string[]) => {
-  const params = useParams();
-  const result: { [key: string]: string } = {};
+const useParamValidate = <T,>(requireParams: string): T => {
+  const param = useParams();
 
-  for (const requireParam of requireParams) {
-    const param = params[requireParam];
-    if (!param) {
-      throw new Error("올바르지 않은 파라미터 값");
-    }
-    result[requireParam] = param;
+  if (!param) {
+    throw new Error("올바르지 않은 파라미터 값");
   }
 
-  return result;
+  return param[requireParams] as unknown as T;
 };
 
 export default useParamValidate;

--- a/frontend/src/hooks/useValidatedParam.tsx
+++ b/frontend/src/hooks/useValidatedParam.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 
-const useParamValidate = <T,>(requireParams: string): T => {
+const useValidatedParam = <T,>(requireParams: string): T => {
   const param = useParams();
 
   if (!param) {
@@ -11,4 +11,4 @@ const useParamValidate = <T,>(requireParams: string): T => {
   return param[requireParams] as unknown as T;
 };
 
-export default useParamValidate;
+export default useValidatedParam;

--- a/frontend/src/pages/InvitePage/index.tsx
+++ b/frontend/src/pages/InvitePage/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 import styled from "@emotion/styled";
 
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 import useInput from "@/hooks/useInput";
 import useCheckLogin from "@/pages/InvitePage/hooks/useCheckLogin";
 import useCheckTeamJoined from "@/pages/InvitePage/hooks/useCheckTeamJoined";
@@ -17,7 +17,7 @@ import TeamDescriptionBox from "@/pages/InvitePage/components/TeamDescriptionBox
 import { REGEX } from "@/constants";
 
 const InvitePage = () => {
-  const inviteToken = useParamValidate<string>("inviteToken");
+  const inviteToken = useValidatedParam<string>("inviteToken");
 
   const { value: nickname, handleInputChange } = useInput("");
   const checkLogin = useCheckLogin(inviteToken);

--- a/frontend/src/pages/InvitePage/index.tsx
+++ b/frontend/src/pages/InvitePage/index.tsx
@@ -17,7 +17,7 @@ import TeamDescriptionBox from "@/pages/InvitePage/components/TeamDescriptionBox
 import { REGEX } from "@/constants";
 
 const InvitePage = () => {
-  const { inviteToken } = useParamValidate(["inviteToken"]);
+  const inviteToken = useParamValidate<string>("inviteToken");
 
   const { value: nickname, handleInputChange } = useInput("");
   const checkLogin = useCheckLogin(inviteToken);

--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -6,7 +6,7 @@ import Button from "@/components/Button";
 import AutoCompleteInput from "@/components/AutoCompleteInput";
 
 import { REGEX } from "@/constants";
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 import useAutoCompleteInput from "@/hooks/useAutoCompleteInput";
 import useInput from "@/hooks/useInput";
 
@@ -14,7 +14,7 @@ import useReadTeamMembers from "@/pages/RollingpaperCreationPage/hooks/useReadTe
 import useCreateMemberRollingpaper from "@/pages/RollingpaperCreationPage/hooks/useCreateMemberRolliingpaper";
 
 const MemberRollingpaperCreateForm = () => {
-  const teamId = useParamValidate<number>("teamId");
+  const teamId = useValidatedParam<number>("teamId");
   const { value: title, handleInputChange } = useInput("");
   const {
     value: rollingpaperTo,

--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -14,7 +14,7 @@ import useReadTeamMembers from "@/pages/RollingpaperCreationPage/hooks/useReadTe
 import useCreateMemberRollingpaper from "@/pages/RollingpaperCreationPage/hooks/useCreateMemberRolliingpaper";
 
 const MemberRollingpaperCreateForm = () => {
-  const { teamId } = useParamValidate(["teamId"]);
+  const teamId = useParamValidate<number>("teamId");
   const { value: title, handleInputChange } = useInput("");
   const {
     value: rollingpaperTo,
@@ -27,10 +27,10 @@ const MemberRollingpaperCreateForm = () => {
     setKeywordList,
   } = useAutoCompleteInput();
 
-  const createMemberRollingpaper = useCreateMemberRollingpaper(+teamId);
+  const createMemberRollingpaper = useCreateMemberRollingpaper(teamId);
 
   const { data: teamMemberResponse } = useReadTeamMembers({
-    teamId: +teamId,
+    teamId: teamId,
     onSuccess: (data) =>
       setKeywordList(data.members.map((member) => member.nickname)),
   });

--- a/frontend/src/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import LabeledInput from "@/components/LabeledInput";
 import Button from "@/components/Button";
 
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 import useInput from "@/hooks/useInput";
 
 import useCreateTeamRollingpaper from "@/pages/RollingpaperCreationPage/hooks/useCreateTeamRollingpaper";
@@ -13,7 +13,7 @@ import { REGEX } from "@/constants";
 
 const TeamRollingpaperCreateForm = () => {
   const { value: title, handleInputChange } = useInput("");
-  const teamId = useParamValidate<number>("teamId");
+  const teamId = useValidatedParam<number>("teamId");
 
   const createTeamRollingpaper = useCreateTeamRollingpaper(teamId);
 

--- a/frontend/src/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/TeamRollingpaperCreateForm.tsx
@@ -13,9 +13,9 @@ import { REGEX } from "@/constants";
 
 const TeamRollingpaperCreateForm = () => {
   const { value: title, handleInputChange } = useInput("");
-  const { teamId } = useParamValidate(["teamId"]);
+  const teamId = useParamValidate<number>("teamId");
 
-  const createTeamRollingpaper = useCreateTeamRollingpaper(+teamId);
+  const createTeamRollingpaper = useCreateTeamRollingpaper(teamId);
 
   const handleRollingpaperCreateSubmit: React.FormEventHandler<
     HTMLFormElement

--- a/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
@@ -7,7 +7,7 @@ import TrashIcon from "@/assets/icons/bx-trash.svg";
 import Pencil from "@/assets/icons/bx-pencil.svg";
 import LockIcon from "@/assets/icons/bx-lock-alt.svg";
 
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 import MessageUpdateForm from "@/pages/RollingpaperPage/components/MessageUpdateForm";
 import useMessageBox from "@/pages/RollingpaperPage/hooks/useMessageBox";
 import SecretMessage from "@/pages/RollingpaperPage/components/SecretMessage";
@@ -24,7 +24,7 @@ const MessageBox = ({
   secret,
   visible,
 }: Message) => {
-  const rollingpaperId = useParamValidate<number>("rollingpaperId");
+  const rollingpaperId = useValidatedParam<number>("rollingpaperId");
   const {
     isEdit,
     handleWriteButtonClick,

--- a/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
@@ -24,13 +24,13 @@ const MessageBox = ({
   secret,
   visible,
 }: Message) => {
-  const { rollingpaperId } = useParamValidate(["rollingpaperId"]);
+  const rollingpaperId = useParamValidate<number>("rollingpaperId");
   const {
     isEdit,
     handleWriteButtonClick,
     handleDeleteButtonClick,
     handleEditEnd,
-  } = useMessageBox({ id, rollingpaperId: +rollingpaperId });
+  } = useMessageBox({ id, rollingpaperId: rollingpaperId });
 
   if (!visible) {
     return <SecretMessage from={from} />;

--- a/frontend/src/pages/RollingpaperPage/components/MessageCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageCreateForm.tsx
@@ -49,8 +49,8 @@ export const MessageCreateForm = ({ onEditEnd }: MessageCreateFormProps) => {
     initMessage,
   } = useMessageForm({});
 
-  const { rollingpaperId } = useParamValidate(["rollingpaperId"]);
-  const { createMessage } = useCreateMessage(+rollingpaperId);
+  const rollingpaperId = useParamValidate<number>("rollingpaperId");
+  const { createMessage } = useCreateMessage(rollingpaperId);
 
   const handleMessageSubmit = () => {
     createMessage({ content, color, anonymous, secret });

--- a/frontend/src/pages/RollingpaperPage/components/MessageCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageCreateForm.tsx
@@ -10,7 +10,7 @@ import XIcon from "@/assets/icons/bx-x.svg";
 
 import useMessageForm from "@/pages/RollingpaperPage/hooks/useMessageForm";
 import useCreateMessage from "@/pages/RollingpaperPage/hooks/useCreateMessage";
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 
 type MessageCreateFormProps = {
   onEditEnd: () => void;
@@ -49,7 +49,7 @@ export const MessageCreateForm = ({ onEditEnd }: MessageCreateFormProps) => {
     initMessage,
   } = useMessageForm({});
 
-  const rollingpaperId = useParamValidate<number>("rollingpaperId");
+  const rollingpaperId = useValidatedParam<number>("rollingpaperId");
   const { createMessage } = useCreateMessage(rollingpaperId);
 
   const handleMessageSubmit = () => {

--- a/frontend/src/pages/RollingpaperPage/hooks/useUpdateMessage.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useUpdateMessage.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useMutation } from "@tanstack/react-query";
 import axios from "axios";
 
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 import { useSnackbar } from "@/context/SnackbarContext";
 
 import { queryClient } from "@/api";
@@ -11,7 +11,7 @@ import { Message, CustomError } from "@/types";
 
 const useUpdateMessage = (id: number) => {
   const { openSnackbar } = useSnackbar();
-  const rollingpaperId = useParamValidate<number>("rollingpaperId");
+  const rollingpaperId = useValidatedParam<number>("rollingpaperId");
 
   const { mutate: updateMessage } = useMutation(
     ({

--- a/frontend/src/pages/RollingpaperPage/hooks/useUpdateMessage.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useUpdateMessage.tsx
@@ -11,7 +11,7 @@ import { Message, CustomError } from "@/types";
 
 const useUpdateMessage = (id: number) => {
   const { openSnackbar } = useSnackbar();
-  const { rollingpaperId } = useParamValidate(["rollingpaperId"]);
+  const rollingpaperId = useParamValidate<number>("rollingpaperId");
 
   const { mutate: updateMessage } = useMutation(
     ({
@@ -21,7 +21,7 @@ const useUpdateMessage = (id: number) => {
       secret,
     }: Pick<Message, "content" | "color" | "anonymous" | "secret">) => {
       return putMessage({
-        rollingpaperId: +rollingpaperId,
+        rollingpaperId: rollingpaperId,
         id,
         content,
         color,

--- a/frontend/src/pages/RollingpaperPage/index.tsx
+++ b/frontend/src/pages/RollingpaperPage/index.tsx
@@ -10,10 +10,8 @@ import { getRollingpaper } from "@/api/rollingpaper";
 import useParamValidate from "@/hooks/useParamValidate";
 
 const RollingpaperPage = () => {
-  const { teamId, rollingpaperId } = useParamValidate([
-    "teamId",
-    "rollingpaperId",
-  ]);
+  const teamId = useParamValidate<number>("teamId");
+  const rollingpaperId = useParamValidate<number>("rollingpaperId");
 
   const {
     isLoading,
@@ -21,7 +19,7 @@ const RollingpaperPage = () => {
     error: rollingpaperError,
     data: rollingpaper,
   } = useQuery<Rollingpaper>(["rollingpaper", rollingpaperId], () =>
-    getRollingpaper(+teamId, +rollingpaperId)
+    getRollingpaper(teamId, rollingpaperId)
   );
 
   if (isLoading) {

--- a/frontend/src/pages/RollingpaperPage/index.tsx
+++ b/frontend/src/pages/RollingpaperPage/index.tsx
@@ -7,11 +7,11 @@ import LetterPaper from "@/pages/RollingpaperPage/components/LetterPaper";
 
 import { Rollingpaper, CustomError } from "@/types";
 import { getRollingpaper } from "@/api/rollingpaper";
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 
 const RollingpaperPage = () => {
-  const teamId = useParamValidate<number>("teamId");
-  const rollingpaperId = useParamValidate<number>("rollingpaperId");
+  const teamId = useValidatedParam<number>("teamId");
+  const rollingpaperId = useValidatedParam<number>("rollingpaperId");
 
   const {
     isLoading,

--- a/frontend/src/pages/TeamDetailPage/components/InviteModal.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/InviteModal.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 
 import { useSnackbar } from "@/context/SnackbarContext";
 
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 import useCreateInviteLink from "@/pages/TeamDetailPage/hooks/useCreateInviteLink";
 
 import Modal from "@/components/Modal";
@@ -18,7 +18,7 @@ interface InviteModalProp {
 
 const InviteModal = ({ onClickClose }: InviteModalProp) => {
   const { openSnackbar } = useSnackbar();
-  const teamId = useParamValidate<number>("teamId");
+  const teamId = useValidatedParam<number>("teamId");
   const { createInviteLink, isError, data } = useCreateInviteLink();
 
   const handleCopyButton =

--- a/frontend/src/pages/TeamDetailPage/components/InviteModal.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/InviteModal.tsx
@@ -18,7 +18,7 @@ interface InviteModalProp {
 
 const InviteModal = ({ onClickClose }: InviteModalProp) => {
   const { openSnackbar } = useSnackbar();
-  const { teamId } = useParamValidate(["teamId"]);
+  const teamId = useParamValidate<number>("teamId");
   const { createInviteLink, isError, data } = useCreateInviteLink();
 
   const handleCopyButton =
@@ -34,8 +34,7 @@ const InviteModal = ({ onClickClose }: InviteModalProp) => {
     };
 
   useEffect(() => {
-    const typedTeamId = Number(teamId);
-    createInviteLink({ id: typedTeamId });
+    createInviteLink({ id: teamId });
   }, []);
 
   if (isError) {

--- a/frontend/src/pages/TeamDetailPage/components/NicknameCreateModalForm.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/NicknameCreateModalForm.tsx
@@ -14,7 +14,7 @@ import { useSnackbar } from "@/context/SnackbarContext";
 import useInput from "@/hooks/useInput";
 
 import { postTeamMember } from "@/api/team";
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 
 interface NicknameCreateModalFormProp {
   onClickCloseButton: () => void;
@@ -26,7 +26,7 @@ const NicknameCreateModalForm = ({
   const { openSnackbar } = useSnackbar();
   const { value: nickname, handleInputChange: handleNicknameChange } =
     useInput("");
-  const teamId = useParamValidate<number>("teamId");
+  const teamId = useValidatedParam<number>("teamId");
 
   const { mutate: joinTeam } = useMutation(
     async (nickname: string) => {

--- a/frontend/src/pages/TeamDetailPage/components/NicknameCreateModalForm.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/NicknameCreateModalForm.tsx
@@ -26,11 +26,11 @@ const NicknameCreateModalForm = ({
   const { openSnackbar } = useSnackbar();
   const { value: nickname, handleInputChange: handleNicknameChange } =
     useInput("");
-  const { teamId } = useParamValidate(["teamId"]);
+  const teamId = useParamValidate<number>("teamId");
 
   const { mutate: joinTeam } = useMutation(
     async (nickname: string) => {
-      postTeamMember({ id: +teamId, nickname });
+      postTeamMember({ id: teamId, nickname });
     },
     {
       onSuccess: () => {

--- a/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
@@ -24,12 +24,12 @@ const NicknameEditModalForm = ({
   onClickCloseButton,
 }: NicknameEditModalForm) => {
   const { openSnackbar } = useSnackbar();
-  const { teamId } = useParamValidate(["teamId"]);
+  const teamId = useParamValidate<number>("teamId");
   const { value: nickname, handleInputChange: handleNicknameChange } =
     useInput("");
 
   const { mutate: editTeamNickname } = useMutation(
-    async (nickname: string) => putTeamNickname({ id: +teamId, nickname }),
+    async (nickname: string) => putTeamNickname({ id: teamId, nickname }),
     {
       onSuccess: () => {
         onClickCloseButton();

--- a/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
@@ -8,7 +8,7 @@ import LineButton from "@/components/LineButton";
 import Modal from "@/components/Modal";
 import UnderlineInput from "@/components/UnderlineInput";
 
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 import useInput from "@/hooks/useInput";
 
 import { REGEX } from "@/constants";
@@ -24,7 +24,7 @@ const NicknameEditModalForm = ({
   onClickCloseButton,
 }: NicknameEditModalForm) => {
   const { openSnackbar } = useSnackbar();
-  const teamId = useParamValidate<number>("teamId");
+  const teamId = useValidatedParam<number>("teamId");
   const { value: nickname, handleInputChange: handleNicknameChange } =
     useInput("");
 

--- a/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
@@ -11,7 +11,7 @@ import { Rollingpaper, CustomError } from "@/types";
 
 import PlusIcon from "@/assets/icons/bx-plus.svg";
 import { getTeamRollingpapers } from "@/api/team";
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 
 interface RollingpaperListResponse {
   rollingpapers: Omit<Rollingpaper, "messages">[];
@@ -19,7 +19,7 @@ interface RollingpaperListResponse {
 
 const RollingpaperList = () => {
   const navigate = useNavigate();
-  const teamId = useParamValidate<number>("teamId");
+  const teamId = useValidatedParam<number>("teamId");
 
   const {
     isLoading: isLoadingGetTeamRollingpaperList,

--- a/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
@@ -19,7 +19,7 @@ interface RollingpaperListResponse {
 
 const RollingpaperList = () => {
   const navigate = useNavigate();
-  const { teamId } = useParamValidate(["teamId"]);
+  const teamId = useParamValidate<number>("teamId");
 
   const {
     isLoading: isLoadingGetTeamRollingpaperList,
@@ -27,7 +27,7 @@ const RollingpaperList = () => {
     error: getTeamRollingpaperListError,
     data: teamRollinpaperListResponse,
   } = useQuery<RollingpaperListResponse>(["rollingpaperList", teamId], () =>
-    getTeamRollingpapers(+teamId)
+    getTeamRollingpapers(teamId)
   );
 
   if (isLoadingGetTeamRollingpaperList) {

--- a/frontend/src/pages/TeamDetailPage/index.tsx
+++ b/frontend/src/pages/TeamDetailPage/index.tsx
@@ -12,14 +12,14 @@ import { getTeam } from "@/api/team";
 import useParamValidate from "@/hooks/useParamValidate";
 
 const TeamDetailPage = () => {
-  const { teamId } = useParamValidate(["teamId"]);
+  const teamId = useParamValidate<number>("teamId");
 
   const {
     isLoading: isLoadingTeamDetail,
     isError: isErrorTeamDetail,
     error: TeamDetailError,
     data: teamDetail,
-  } = useQuery<Team>(["team", teamId], () => getTeam(+teamId));
+  } = useQuery<Team>(["team", teamId], () => getTeam(teamId));
 
   if (isLoadingTeamDetail) {
     return <div>로딩중</div>;

--- a/frontend/src/pages/TeamDetailPage/index.tsx
+++ b/frontend/src/pages/TeamDetailPage/index.tsx
@@ -9,10 +9,10 @@ import TeamJoinSection from "@/pages/TeamDetailPage/components/TeamJoinSection";
 
 import { Team, CustomError } from "@/types";
 import { getTeam } from "@/api/team";
-import useParamValidate from "@/hooks/useParamValidate";
+import useValidatedParam from "@/hooks/useValidatedParam";
 
 const TeamDetailPage = () => {
-  const teamId = useParamValidate<number>("teamId");
+  const teamId = useValidatedParam<number>("teamId");
 
   const {
     isLoading: isLoadingTeamDetail,


### PR DESCRIPTION
## 구현 사항
- 메시지 작성 시 refetch
- 메시지 삭제 시 refetch
- 모임 참가 시 refetch

### refetch가 안되던 이유,  useParamValidate에 관하여
- rollingpaperId, teamId등을 query key로 사용하고 있습니다. 이때 초기에 사용하던 key 값은 타입이 string, refetch 시 사용하는 key 값은 타입이 number라 refetch가 일어나지 않았습니다.
- useParamValidate를 사용하면 useParams(react-router-dom)의 결과 값인 string이 반환됩니다. api hook에서 때로는 이 값을 number로 변환하여 받고, 이를 재사용하다보니 타입이 일치하지 않아 문제가 발생합니다. 따라서 이 값을 사용 할 때마다 type을 변환하는 것이 아닌, 값을 가져다쓸 때 타입을 지정할 수 있도록 수정하였습니다.
- useParamValidate는 type을 지정하여 받고, 이 타입으로 param을 return하도록 합니다. 이를 구현하며 생긴 고민은 이 T을 좁혀주어야 하는가입니다. 지금 생각했을 때는 number, string 타입만 사용할 것 같은데 이를 좁혀 주는 것이 좋을까요??(최근에 들었던 타입스크립트 강의가 신경쓰인달까요...?)

closed #369 