### PR TITLE
fea: 마이페이지의 paging 위치를 고정

### DIFF
--- a/frontend/src/pages/MyPage/components/MessageList.tsx
+++ b/frontend/src/pages/MyPage/components/MessageList.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import styled from "@emotion/styled";
 
@@ -36,7 +36,7 @@ const MessageList = ({ lastPage }: MessageListProp) => {
   }
 
   return (
-    <>
+    <StyledListWithPaging>
       <StyledMessageList>
         {data.messages.map((message) => (
           <MessageListItem {...message} />
@@ -51,7 +51,7 @@ const MessageList = ({ lastPage }: MessageListProp) => {
           handlePrevClick={handlePrevClick}
         />
       </StyledPaging>
-    </>
+    </StyledListWithPaging>
   );
 };
 
@@ -63,6 +63,14 @@ const EmptyState = () => {
     </StyledEmpty>
   );
 };
+
+const StyledListWithPaging = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  justify-content: space-between;
+  height: 580px;
+`;
 
 const StyledEmpty = styled.div`
   display: flex;

--- a/frontend/src/pages/MyPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperList.tsx
@@ -41,7 +41,7 @@ const RollingpaperList = ({ lastPage }: RollingpaperListProp) => {
   }
 
   return (
-    <>
+    <StyledListWithPaging>
       <StyledRollingpaperList>
         {data.rollingpapers.map((rollingpaper) => (
           <RollingpaperListItem {...rollingpaper} />
@@ -56,7 +56,7 @@ const RollingpaperList = ({ lastPage }: RollingpaperListProp) => {
           handlePrevClick={handlePrevClick}
         />
       </StyledPaging>
-    </>
+    </StyledListWithPaging>
   );
 };
 
@@ -68,6 +68,14 @@ const EmptyState = () => {
     </StyledEmpty>
   );
 };
+
+const StyledListWithPaging = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  justify-content: space-between;
+  height: 580px;
+`;
 
 const StyledEmpty = styled.div`
   display: flex;


### PR DESCRIPTION
## 구현 사항
- 받은 롤링페이퍼 리스트와 페이징의 높이를 고정
- 작성한 메시지 리스트와 페이징의 높이를 고정
<img width="300" alt="스크린샷 2022-08-17 오후 5 40 02" src="https://user-images.githubusercontent.com/67692759/185074546-ec0511a4-c072-4b67-be9c-3be587e80e84.png">
<img width="300" alt="스크린샷 2022-08-17 오후 5 40 29" src="https://user-images.githubusercontent.com/67692759/185074649-612d4817-edbc-495b-b1d0-2d3a6c19c4e7.png">


closed #375 
