### PR TITLE
test: `AfterPropertiesSet`을 이용한 DB cleaner 클래스를 만들어 `@DirtiesContext` 제거

### DIFF
--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/AcceptanceTest.java
@@ -10,6 +10,7 @@ import com.woowacourse.naepyeon.service.MemberService;
 import com.woowacourse.naepyeon.service.dto.PlatformUserDto;
 import com.woowacourse.naepyeon.service.dto.TokenRequestDto;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
+import com.woowacourse.naepyeon.acceptance.support.DatabaseCleaner;
 import com.woowacourse.naepyeon.support.JwtTokenProvider;
 import com.woowacourse.naepyeon.support.invitetoken.InviteTokenProvider;
 import com.woowacourse.naepyeon.support.invitetoken.aes.Aes256InviteTokenProvider;
@@ -23,11 +24,8 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.ClassMode;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
 @AutoConfigureTestDatabase
 public class AcceptanceTest {
 
@@ -44,6 +42,8 @@ public class AcceptanceTest {
     protected Aes256Supporter aes256Supporter;
     @Autowired
     protected ObjectMapper objectMapper;
+    @Autowired
+    protected DatabaseCleaner databaseCleaner;
 
     @LocalServerPort
     int port;
@@ -61,6 +61,7 @@ public class AcceptanceTest {
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
+        databaseCleaner.execute();
         authService = new AuthService(memberService, jwtTokenProvider, kakaoPlatformUserProvider);
 
         final String alexName = "alex";

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/support/DatabaseCleaner.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/support/DatabaseCleaner.java
@@ -1,0 +1,44 @@
+package com.woowacourse.naepyeon.acceptance.support;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import javax.persistence.Table;
+import javax.persistence.metamodel.Type;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class DatabaseCleaner {
+
+    private static final String FOREIGN_KEY_RULE_UPDATE_FORMAT = "SET REFERENTIAL_INTEGRITY %s";
+    private static final String TRUNCATE_FORMAT = "TRUNCATE TABLE %s";
+    private static final String ID_RESET_FORMAT = "ALTER TABLE %s ALTER COLUMN %s_id RESTART WITH 1";
+
+    private final EntityManager entityManager;
+    private final List<String> tableNames;
+
+    public DatabaseCleaner(final EntityManager entityManager) {
+        this.entityManager = entityManager;
+        this.tableNames = entityManager.getMetamodel()
+                .getEntities()
+                .stream()
+                .map(Type::getJavaType)
+                .map(javaType -> javaType.getAnnotation(Table.class))
+                .map(Table::name)
+                .collect(Collectors.toUnmodifiableList());
+    }
+
+    @Transactional
+    public void execute() {
+        entityManager.flush();
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_RULE_UPDATE_FORMAT, "FALSE"))
+                .executeUpdate();
+        for (final String tableName : tableNames) {
+            entityManager.createNativeQuery(String.format(TRUNCATE_FORMAT, tableName)).executeUpdate();
+            entityManager.createNativeQuery(String.format(ID_RESET_FORMAT, tableName, tableName)).executeUpdate();
+        }
+        entityManager.createNativeQuery(String.format(FOREIGN_KEY_RULE_UPDATE_FORMAT, "TRUE"))
+                .executeUpdate();
+    }
+}

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/MemberRepositoryTest.java
@@ -13,7 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class MemberRepositoryTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
@@ -24,7 +24,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class MessageRepositoryTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/RollingpaperRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/RollingpaperRepositoryTest.java
@@ -23,7 +23,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class RollingpaperRepositoryTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamParticipationRepositoryTest.java
@@ -22,7 +22,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class TeamParticipationRepositoryTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/TeamRepositoryTest.java
@@ -18,7 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class TeamRepositoryTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/AuthServiceTest.java
@@ -21,7 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class AuthServiceTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/MemberServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/MemberServiceTest.java
@@ -11,7 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class MemberServiceTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/MessageServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/MessageServiceTest.java
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class MessageServiceTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/RollingpaperServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/RollingpaperServiceTest.java
@@ -22,7 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class RollingpaperServiceTest {
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/TeamServiceTest.java
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @Transactional
 class TeamServiceTest {
 


### PR DESCRIPTION
close #410 
이제 acceptanceTest, 전체 테스트의 성능이 매우 빨라졌을 겁니다.