### PR TITLE
feat: 메시지 폼 관련 오류를 해결한다. 

### DIFF
--- a/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
@@ -89,6 +89,7 @@ const StyledMessage = styled.div`
 `;
 
 const StyledMessageContent = styled.div`
+  white-space: pre-wrap;
   overflow: hidden;
 
   font-size: 16px;

--- a/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
@@ -90,7 +90,7 @@ const StyledMessage = styled.div`
 
 const StyledMessageContent = styled.div`
   white-space: pre-wrap;
-  overflow: hidden;
+  word-break: break-all;
 
   font-size: 16px;
   line-height: 22px;

--- a/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
@@ -89,7 +89,7 @@ const StyledMessage = styled.div`
 `;
 
 const StyledMessageContent = styled.div`
-  white-space: pre-wrap;
+  white-space: break-spaces;
   word-break: break-all;
 
   font-size: 16px;

--- a/frontend/src/pages/RollingpaperPage/components/MessageTextArea.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageTextArea.tsx
@@ -62,6 +62,7 @@ const StyledTextArea = styled.textarea`
   background-color: transparent;
 
   resize: none;
+  white-space: break-spaces;
 
   font-size: inherit;
   line-height: inherit;


### PR DESCRIPTION
## 추가 발견 오류 사항
- 메시지 입력 시 줄의 마지막에서 스페이스를 눌러도 줄바꿈이 일어나지 않고 글자수만 늘어나게 됨
<img width="382" alt="스크린샷 2022-09-09 오후 4 52 28" src="https://user-images.githubusercontent.com/67692759/189300286-d33406f9-2aba-4163-8b23-994d1d392e44.png">



## 구현 사항
- 메시지 줄바꿈이 적용되지 않는 문제
  - white-space: break-spaces;
  - 연속 공백을 유지 및 문장의 끝부분 space 처리를 위해 break-spaces 사용
- 영어로 작성 시 화면 사이즈에 맞춰 줄바꿈이 되지 않는 문제
  - word-break: break-all;
- 메시지 입력 시 줄의 마지막에서 스페이스를 눌러도 줄바꿈이 일어나지 않고 글자수만 늘어나게  되는 문제
  - white-space: break-spaces;

closed #418 