### PR TITLE
feat: 모임 프로필 설정 시 기존 모임 닉네임을 보여준다

### DIFF
--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -61,11 +61,6 @@ const postTeam = ({
 const postTeamInviteToken = ({ id }: Pick<Team, "id">) =>
   appClient.post(`/teams/${id}/invite`).then((response) => response.data);
 
-const putTeamNickname = ({ id, nickname }: Pick<Team, "id" | "nickname">) =>
-  appClient
-    .put(`/teams/${id}/me`, { nickname })
-    .then((response) => response.data);
-
 const postTeamMember = ({ id, nickname }: Pick<Team, "id" | "nickname">) =>
   appClient
     .post(`/teams/${id}`, { nickname })
@@ -79,6 +74,11 @@ const postTeamMemberWithInviteToken = ({
     .post(`/teams/invite/join`, { inviteToken, nickname })
     .then((response) => response.data);
 
+const putTeamNickname = ({ id, nickname }: Pick<Team, "id" | "nickname">) =>
+  appClient
+    .put(`/teams/${id}/me`, { nickname })
+    .then((response) => response.data);
+
 export {
   getMyTeams,
   getTeamSearchResult,
@@ -86,8 +86,8 @@ export {
   getTeamMembers,
   getTeamRollingpapers,
   getTeamWithInviteToken,
-  postTeam,
   getTeamMyNickname,
+  postTeam,
   postTeamMember,
   postTeamMemberWithInviteToken,
   postTeamInviteToken,

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -36,6 +36,9 @@ const getTeamWithInviteToken = (inviteToken: string) =>
     .get(`/teams/invite?inviteToken=${inviteToken}`)
     .then((response) => response.data);
 
+const getTeamMyNickname = (id: number) =>
+  appClient.get(`/teams/${id}/me`).then((response) => response.data);
+
 const postTeam = ({
   name,
   description,
@@ -84,6 +87,7 @@ export {
   getTeamRollingpapers,
   getTeamWithInviteToken,
   postTeam,
+  getTeamMyNickname,
   postTeamMember,
   postTeamMemberWithInviteToken,
   postTeamInviteToken,

--- a/frontend/src/hooks/useInput.tsx
+++ b/frontend/src/hooks/useInput.tsx
@@ -1,4 +1,4 @@
-import { useState, ChangeEventHandler } from "react";
+import { useState, ChangeEventHandler, useEffect } from "react";
 
 const useInput = (defaultValue: string) => {
   const [value, setValue] = useState(defaultValue);
@@ -8,6 +8,10 @@ const useInput = (defaultValue: string) => {
 
     setValue(target.value);
   };
+
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [defaultValue]);
 
   return { value, handleInputChange, setValue };
 };

--- a/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useMutation } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import styled from "@emotion/styled";
 
 import { queryClient } from "@/api";
@@ -14,7 +14,8 @@ import useInput from "@/hooks/useInput";
 import { REGEX } from "@/constants";
 import { useSnackbar } from "@/context/SnackbarContext";
 
-import { putTeamNickname } from "@/api/team";
+import { putTeamNickname, getTeamMyNickname } from "@/api/team";
+import { Team } from "@/types";
 
 interface NicknameEditModalForm {
   onClickCloseButton: () => void;
@@ -25,8 +26,15 @@ const NicknameEditModalForm = ({
 }: NicknameEditModalForm) => {
   const { openSnackbar } = useSnackbar();
   const teamId = useValidatedParam<number>("teamId");
-  const { value: nickname, handleInputChange: handleNicknameChange } =
-    useInput("");
+
+  const { data: teamNicknameResponse } = useQuery<Pick<Team, "nickname">>(
+    ["team-nickname", teamId],
+    () => getTeamMyNickname(teamId)
+  );
+
+  const { value: nickname, handleInputChange: handleNicknameChange } = useInput(
+    teamNicknameResponse?.nickname || ""
+  );
 
   const { mutate: editTeamNickname } = useMutation(
     async (nickname: string) => putTeamNickname({ id: teamId, nickname }),


### PR DESCRIPTION
## 구현 사항
- 닉네임 수정 모달 접속 시 기존의 닉네임을 보여주도록 수정
- 기존에 useQuery로 data만 가져올 시 hook으로 변경하지 않는 것 같아 이를 유지했습니다
<img width="375" alt="스크린샷 2022-09-09 오후 5 54 29" src="https://user-images.githubusercontent.com/67692759/189312136-8ac2eaaf-d1c6-4104-9180-bf183bd64bed.png">

## 고민
- prop으로 defaultValue로 useInput의 기본 값을 받아 사용하기 위해 useEffect를 사용했는데요, 혹시 더 좋은 방법이 있을까요....?

closed #305