### PR TITLE
refactor: 모임 추가하기 페이지 개선

### DIFF
--- a/frontend/src/components/LabeledInput.tsx
+++ b/frontend/src/components/LabeledInput.tsx
@@ -7,11 +7,15 @@ interface LabeledInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   labelText: string;
   errorMessage?: string;
+  showValueLength?: boolean;
 }
 
 const LabeledInput = ({
+  value = "",
+  maxLength,
   labelText,
   errorMessage,
+  showValueLength = false,
   ...prop
 }: LabeledInputProps) => {
   return (
@@ -22,11 +26,17 @@ const LabeledInput = ({
         <ErrorIcon />
         {errorMessage}
       </div>
+      {showValueLength && (
+        <StyledValueLength>
+          {value.toString().length}/{maxLength}
+        </StyledValueLength>
+      )}
     </StyledLabel>
   );
 };
 
 const StyledLabel = styled.label`
+  position: relative;
   display: flex;
   flex-direction: column;
 
@@ -74,6 +84,11 @@ const StyledLabel = styled.label`
       fill: ${({ theme }) => theme.colors.RED_300};
     }
   }
+`;
+
+const StyledValueLength = styled.span`
+  position: absolute;
+  right: 0;
 `;
 
 export default LabeledInput;

--- a/frontend/src/components/LabeledTextArea.tsx
+++ b/frontend/src/components/LabeledTextArea.tsx
@@ -3,19 +3,33 @@ import styled from "@emotion/styled";
 
 interface LabeledTextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  value: string;
   labelText: string;
+  showValueLength?: boolean;
 }
 
-const LabeledTextArea = ({ labelText, ...props }: LabeledTextAreaProps) => {
+const LabeledTextArea = ({
+  value,
+  maxLength,
+  labelText,
+  showValueLength = false,
+  ...props
+}: LabeledTextAreaProps) => {
   return (
     <StyledLabel>
       {labelText}
-      <StyledTextarea {...props} />
+      <StyledTextarea value={value} maxLength={maxLength} {...props} />
+      {showValueLength && (
+        <StyledValueLength>
+          {value.length}/{maxLength}
+        </StyledValueLength>
+      )}
     </StyledLabel>
   );
 };
 
 const StyledLabel = styled.label`
+  position: relative;
   display: flex;
   flex-direction: column;
 
@@ -29,9 +43,9 @@ const StyledLabel = styled.label`
 
 const StyledTextarea = styled.textarea`
   width: 100%;
-  height: 60px;
+  height: 100px;
   padding: 10px;
-  margin: 8px 0 28px 0;
+  margin: 12px 0 28px 0;
 
   font-size: 16px;
 
@@ -40,11 +54,15 @@ const StyledTextarea = styled.textarea`
   background-color: ${({ theme }) => theme.colors.GRAY_100};
 
   resize: none;
-  overflow: hidden;
 
   :focus {
     outline: none;
   }
+`;
+
+const StyledValueLength = styled.span`
+  position: absolute;
+  right: 0;
 `;
 
 export default LabeledTextArea;

--- a/frontend/src/components/LabeledTextArea.tsx
+++ b/frontend/src/components/LabeledTextArea.tsx
@@ -1,24 +1,16 @@
 import React from "react";
 import styled from "@emotion/styled";
 
-interface LabeledRadioProps
+interface LabeledTextAreaProps
   extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
   labelText: string;
 }
 
-const LabeledTextArea = ({
-  labelText,
-  placeholder,
-  onChange,
-}: LabeledRadioProps) => {
+const LabeledTextArea = ({ labelText, ...props }: LabeledTextAreaProps) => {
   return (
     <StyledLabel>
       {labelText}
-      <StyledTextarea
-        maxLength={100}
-        placeholder={placeholder}
-        onChange={onChange}
-      />
+      <StyledTextarea {...props} />
     </StyledLabel>
   );
 };

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -4,7 +4,7 @@ const REGEX = {
   EMAIL: /^[_a-z0-9-]+(.[_a-z0-9-]+)*@(?:\w+\.)+\w+$/,
   USERNAME: /^.{1,64}$/,
   PASSWORD: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d~!@#$%^&*()+|=]{8,20}$/,
-  TEAM_NAME: /^[가-힣a-zA-Z\d~!@#$%^&*()+_\-\s]{1,20}$/,
+  TEAM_NAME: /^.{1,20}$/,
   TEAM_NICKNAME: /^.{1,20}$/,
   ROLLINGPAPER_TITLE: /^.{1,20}$/,
 };

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -6,6 +6,7 @@ const REGEX = {
   PASSWORD: /^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d~!@#$%^&*()+|=]{8,20}$/,
   TEAM_NAME: /^.{1,20}$/,
   TEAM_NICKNAME: /^.{1,20}$/,
+  TEAM_DESCRIPTION: /^.{1,80}$/,
   ROLLINGPAPER_TITLE: /^.{1,20}$/,
 };
 

--- a/frontend/src/pages/TeamCreationPage/hooks/useTeamCreationForm.tsx
+++ b/frontend/src/pages/TeamCreationPage/hooks/useTeamCreationForm.tsx
@@ -2,13 +2,14 @@ import React, { useState } from "react";
 
 import useInput from "@/hooks/useInput";
 import useSwitch from "@/hooks/useSwitch";
-import useTextArea from "@/hooks/useTextArea";
 
 const useTeamCreationForm = () => {
   const { value: teamName, handleInputChange: handleTeamNameChange } =
     useInput("");
-  const { value: teamDescription, handleChange: handleTeamDescriptionChange } =
-    useTextArea({ initialValue: "" });
+  const {
+    value: teamDescription,
+    handleInputChange: handleTeamDescriptionChange,
+  } = useInput("");
   const [emoji, setEmoji] = useState("");
   const [color, setColor] = useState("");
   const { value: nickname, handleInputChange: handleNicknameChange } =

--- a/frontend/src/pages/TeamCreationPage/index.tsx
+++ b/frontend/src/pages/TeamCreationPage/index.tsx
@@ -86,12 +86,12 @@ const TeamCreationPage = () => {
           errorMessage={"1~20자 사이의 모임명을 입력해주세요"}
         />
         <LabeledTextArea
-          labelText="모임 설명"
+          labelText="한 줄 소개"
           value={teamDescription}
           onChange={handleTeamDescriptionChange}
           minLength={1}
-          maxLength={100}
-          placeholder="최대 100자까지 입력 가능합니다"
+          maxLength={80}
+          placeholder="어떤 모임인지 소개해주세요. 최대 80자까지 입력 가능합니다."
           showValueLength
         />
         <LabeledInput

--- a/frontend/src/pages/TeamCreationPage/index.tsx
+++ b/frontend/src/pages/TeamCreationPage/index.tsx
@@ -92,7 +92,7 @@ const TeamCreationPage = () => {
           minLength={1}
           maxLength={100}
           placeholder="최대 100자까지 입력 가능합니다"
-          showValueLength={true}
+          showValueLength
         />
         <LabeledInput
           labelText="나의 닉네임"

--- a/frontend/src/pages/TeamCreationPage/index.tsx
+++ b/frontend/src/pages/TeamCreationPage/index.tsx
@@ -6,7 +6,6 @@ import useTeamCreationForm from "@/pages/TeamCreationPage/hooks/useTeamCreationF
 
 import LabeledInput from "@/components/LabeledInput";
 import LabeledRadio from "@/components/LabeledRadio";
-import LabeledTextArea from "@/components/LabeledTextArea";
 import Button from "@/components/Button";
 import PageTitleWithBackButton from "@/components/PageTitleWithBackButton";
 import LabeledSwitch from "@/components/LabeledSwitch";
@@ -51,7 +50,7 @@ const TeamCreationPage = () => {
     if (!REGEX.TEAM_NAME.test(nickname)) {
       return alert("모임명을 입력해주세요");
     }
-    if (!teamDescription) {
+    if (!REGEX.TEAM_DESCRIPTION.test(teamDescription)) {
       return alert("모임 설명을 입력해주세요");
     }
     if (!REGEX.USERNAME.test(nickname)) {
@@ -85,13 +84,17 @@ const TeamCreationPage = () => {
           onChange={handleTeamNameChange}
           errorMessage={"1~20자 사이의 모임명을 입력해주세요"}
         />
-        <LabeledTextArea
+        <LabeledInput
           labelText="한 줄 소개"
           value={teamDescription}
+          pattern={REGEX.TEAM_DESCRIPTION.source}
           onChange={handleTeamDescriptionChange}
           minLength={1}
           maxLength={80}
-          placeholder="어떤 모임인지 소개해주세요. 최대 80자까지 입력 가능합니다."
+          placeholder={
+            "어떤 모임인지 소개해주세요. 최대 80자까지 입력 가능합니다."
+          }
+          errorMessage={"최대 80자까지 입력 가능합니다."}
           showValueLength
         />
         <LabeledInput
@@ -122,7 +125,7 @@ const TeamCreationPage = () => {
           disabled={
             !(
               REGEX.TEAM_NAME.test(nickname) &&
-              teamDescription &&
+              REGEX.TEAM_DESCRIPTION.test(teamDescription) &&
               REGEX.USERNAME.test(nickname) &&
               emoji &&
               color

--- a/frontend/src/pages/TeamCreationPage/index.tsx
+++ b/frontend/src/pages/TeamCreationPage/index.tsx
@@ -92,6 +92,7 @@ const TeamCreationPage = () => {
           minLength={1}
           maxLength={100}
           placeholder="최대 100자까지 입력 가능합니다"
+          showValueLength={true}
         />
         <LabeledInput
           labelText="나의 닉네임"


### PR DESCRIPTION
## 작업 내용
- 모임 이름 정규식 수정
  - 모든 문자 포함하도록 모임 이름 정규식 수정했습니다. 
- LabeledTextArea 글자 수 보여주기 UI 추가
  - 우측 상단에서 입력한 글자 수를 보여주도록 했습니다.
  - LabeledTextArea가 showValueLength(boolen, default는 false)을 prop으로 받아 조건부 렌더링 하도록 했습니다.
- LabeledTextArea css 수정
  최대 100자인 것에 비해 기존 높이가 너무 작고, 줄바꿈하며 작성할 경우 scroll이 필요할 것으로 보여 관련 css 수정했습니다.

## UI 변경사항
### 수정 전
<img src="https://user-images.githubusercontent.com/71116429/189475122-2481f2ea-3656-4dea-bbb6-44b777646734.png" width="300px" />

### 수정 후
<img src="https://user-images.githubusercontent.com/71116429/189475104-b0872e8e-80c2-4011-b0df-d7dd0ad9d5bb.png" width="300px" />

## 참고사항
- LabeledTextArea css 수정과 글자 보여주기 추가된 부분에 대해서 지금 UI 괜찮은지 도리 의견 궁금합니다.
- 글자 수 보여주기 방식을 구현하는 더 좋은 방식이 있다면 제안 부탁합니다.


closed #415 