### PR TITLE
refactor: MessageForm 추가될 때 메시지 정렬 방식 변경

### DIFF
--- a/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
@@ -32,17 +32,18 @@ const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
       ))
       .reverse();
 
-    return isWrite ? [messageForm, ...elementList] : [...elementList];
+    return isWrite
+      ? [
+          <MessageCreateForm
+            enableSecretMessage={recipientType === "MEMBER"}
+            onEditEnd={handleWriteEnd}
+          />,
+          ...elementList,
+        ]
+      : [...elementList];
   }, [messageList, isWrite]);
 
   const slicedMessageLists = useSliceMessageList(elementList);
-
-  const messageForm = (
-    <MessageCreateForm
-      enableSecretMessage={recipientType === "MEMBER"}
-      onEditEnd={handleWriteEnd}
-    />
-  );
 
   return (
     <StyledLetterPaper>

--- a/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import styled from "@emotion/styled";
 
 import IconButton from "@components/IconButton";
@@ -19,9 +19,38 @@ interface LetterPaperProp {
 }
 
 const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
-  const { isWrite, handleWriteButtonClick, handleWriteEnd } = useMessageWrite();
+  const [elementList, setElementList] = useState(
+    messageList
+      .map((message) => (
+        <MessageBox
+          key={message.id}
+          enableSecretMessage={recipientType === "MEMBER"}
+          {...message}
+        />
+      ))
+      .reverse()
+  );
 
-  const slicedMessageLists = useSliceMessageList(messageList);
+  const { isWrite, handleWriteButtonClick, handleWriteEnd } = useMessageWrite({
+    onClickWriteButton: () =>
+      setElementList((prev) => {
+        return [messageForm, ...prev];
+      }),
+    onClickWriteEnd: () =>
+      setElementList((prev) => {
+        const newElementList = prev.slice(1);
+        return [...newElementList];
+      }),
+  });
+
+  const messageForm = (
+    <MessageCreateForm
+      enableSecretMessage={recipientType === "MEMBER"}
+      onEditEnd={handleWriteEnd}
+    />
+  );
+
+  const slicedMessageLists = useSliceMessageList(elementList);
 
   return (
     <StyledLetterPaper>
@@ -36,21 +65,7 @@ const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
       <StyledSlicedMessageLists>
         {slicedMessageLists.map((messageList, index) => (
           <StyledMessageList key={index}>
-            {index === 0 && isWrite && (
-              <MessageCreateForm
-                enableSecretMessage={recipientType === "MEMBER"}
-                onEditEnd={handleWriteEnd}
-              />
-            )}
-            {messageList.map((message) => {
-              return (
-                <MessageBox
-                  key={message.id}
-                  enableSecretMessage={recipientType === "MEMBER"}
-                  {...message}
-                />
-              );
-            })}
+            <>{...messageList}</>
           </StyledMessageList>
         ))}
       </StyledSlicedMessageLists>

--- a/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
@@ -33,7 +33,7 @@ const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
       .map((message) => (
         <MessageBox
           key={message.id}
-          enableSecretMessage={recipientType === "MEMBER"}
+          recipientType={recipientType}
           {...message}
         />
       ))

--- a/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useMemo } from "react";
 import styled from "@emotion/styled";
 
 import IconButton from "@components/IconButton";
@@ -19,29 +19,7 @@ interface LetterPaperProp {
 }
 
 const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
-  const [elementList, setElementList] = useState(
-    messageList
-      .map((message) => (
-        <MessageBox
-          key={message.id}
-          enableSecretMessage={recipientType === "MEMBER"}
-          {...message}
-        />
-      ))
-      .reverse()
-  );
-
-  const { isWrite, handleWriteButtonClick, handleWriteEnd } = useMessageWrite({
-    onClickWriteButton: () =>
-      setElementList((prev) => {
-        return [messageForm, ...prev];
-      }),
-    onClickWriteEnd: () =>
-      setElementList((prev) => {
-        const newElementList = prev.slice(1);
-        return [...newElementList];
-      }),
-  });
+  const { isWrite, handleWriteButtonClick, handleWriteEnd } = useMessageWrite();
 
   const messageForm = (
     <MessageCreateForm
@@ -49,6 +27,20 @@ const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
       onEditEnd={handleWriteEnd}
     />
   );
+
+  const elementList = useMemo(() => {
+    const elementList = messageList
+      .map((message) => (
+        <MessageBox
+          key={message.id}
+          enableSecretMessage={recipientType === "MEMBER"}
+          {...message}
+        />
+      ))
+      .reverse();
+
+    return isWrite ? [messageForm, ...elementList] : [...elementList];
+  }, [messageList, isWrite]);
 
   const slicedMessageLists = useSliceMessageList(elementList);
 

--- a/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
@@ -21,13 +21,6 @@ interface LetterPaperProp {
 const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
   const { isWrite, handleWriteButtonClick, handleWriteEnd } = useMessageWrite();
 
-  const messageForm = (
-    <MessageCreateForm
-      enableSecretMessage={recipientType === "MEMBER"}
-      onEditEnd={handleWriteEnd}
-    />
-  );
-
   const elementList = useMemo(() => {
     const elementList = messageList
       .map((message) => (
@@ -43,6 +36,13 @@ const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
   }, [messageList, isWrite]);
 
   const slicedMessageLists = useSliceMessageList(elementList);
+
+  const messageForm = (
+    <MessageCreateForm
+      enableSecretMessage={recipientType === "MEMBER"}
+      onEditEnd={handleWriteEnd}
+    />
+  );
 
   return (
     <StyledLetterPaper>

--- a/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
@@ -11,7 +11,7 @@ import MessageUpdateForm from "@/pages/RollingpaperPage/components/MessageUpdate
 import useMessageBox from "@/pages/RollingpaperPage/hooks/useMessageBox";
 import SecretMessage from "@/pages/RollingpaperPage/components/SecretMessage";
 
-import { Message } from "@/types";
+import { Message, RollingpaperRecipient } from "@/types";
 import useValidatedParam from "@/hooks/useValidatedParam";
 
 const MessageBox = ({
@@ -23,8 +23,8 @@ const MessageBox = ({
   secret,
   editable,
   visible,
-  enableSecretMessage,
-}: Message & { enableSecretMessage: boolean }) => {
+  recipientType,
+}: Message & { recipientType: RollingpaperRecipient }) => {
   const rollingpaperId = useValidatedParam<number>("rollingpaperId");
 
   const {
@@ -47,7 +47,7 @@ const MessageBox = ({
         anonymous={anonymous}
         secret={secret}
         onEditEnd={handleEditEnd}
-        enableSecretMessage={enableSecretMessage}
+        enableSecretMessage={recipientType === "MEMBER"}
       />
     );
   }

--- a/frontend/src/pages/RollingpaperPage/hooks/useMessageWrite.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useMessageWrite.tsx
@@ -1,23 +1,13 @@
 import React, { useState } from "react";
 
-type UseMessageWriterArgs = {
-  onClickWriteButton: () => void;
-  onClickWriteEnd: () => void;
-};
-
-const useMessageWrite = ({
-  onClickWriteButton,
-  onClickWriteEnd,
-}: UseMessageWriterArgs) => {
+const useMessageWrite = () => {
   const [isWrite, setIsWrite] = useState(false);
 
   const handleWriteButtonClick = () => {
-    onClickWriteButton();
     setIsWrite(true);
   };
 
   const handleWriteEnd = () => {
-    onClickWriteEnd();
     setIsWrite(false);
   };
 

--- a/frontend/src/pages/RollingpaperPage/hooks/useMessageWrite.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useMessageWrite.tsx
@@ -1,13 +1,23 @@
 import React, { useState } from "react";
 
-const useMessageWrite = () => {
+type UseMessageWriterArgs = {
+  onClickWriteButton: () => void;
+  onClickWriteEnd: () => void;
+};
+
+const useMessageWrite = ({
+  onClickWriteButton,
+  onClickWriteEnd,
+}: UseMessageWriterArgs) => {
   const [isWrite, setIsWrite] = useState(false);
 
   const handleWriteButtonClick = () => {
+    onClickWriteButton();
     setIsWrite(true);
   };
 
   const handleWriteEnd = () => {
+    onClickWriteEnd();
     setIsWrite(false);
   };
 

--- a/frontend/src/pages/RollingpaperPage/hooks/useSliceMessageList.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useSliceMessageList.tsx
@@ -1,14 +1,13 @@
 import React, { useState, useEffect, useRef } from "react";
 
 import { divideArrayByIndexRemainder } from "@/util";
+import { EmotionJSX } from "@emotion/react/types/jsx-namespace";
 
-import { Message } from "@/types";
-
-const useSliceMessageList = (messageList: Message[]) => {
+const useSliceMessageList = (messageList: (Element | EmotionJSX.Element)[]) => {
   const messageListRef = useRef(messageList);
-  const [slicedMessageLists, setSlicedMessageLists] = useState<Message[][]>(
-    Array.from(Array(4), () => [])
-  );
+  const [slicedMessageLists, setSlicedMessageLists] = useState<
+    (Element | EmotionJSX.Element)[][]
+  >(Array.from(Array(4), () => []));
 
   const updateSlicedMessageListByWindowWidth = () => {
     const width = window.innerWidth;

--- a/frontend/src/pages/RollingpaperPage/hooks/useSliceMessageList.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useSliceMessageList.tsx
@@ -1,12 +1,11 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, ReactElement } from "react";
 
 import { divideArrayByIndexRemainder } from "@/util";
-import { EmotionJSX } from "@emotion/react/types/jsx-namespace";
 
-const useSliceMessageList = (messageList: (Element | EmotionJSX.Element)[]) => {
+const useSliceMessageList = (messageList: ReactElement[]) => {
   const messageListRef = useRef(messageList);
   const [slicedMessageLists, setSlicedMessageLists] = useState<
-    (Element | EmotionJSX.Element)[][]
+    ReactElement[][]
   >(Array.from(Array(4), () => []));
 
   const updateSlicedMessageListByWindowWidth = () => {

--- a/frontend/src/pages/RollingpaperPage/index.tsx
+++ b/frontend/src/pages/RollingpaperPage/index.tsx
@@ -46,7 +46,7 @@ const RollingpaperPage = () => {
         <LetterPaper
           to={rollingpaper.to}
           recipientType={rollingpaper.recipient}
-          messageList={[...rollingpaper.messages].reverse()}
+          messageList={[...rollingpaper.messages]}
         />
       </main>
     </>


### PR DESCRIPTION
## 작업 내용
- LetterPaper에서 렌더링할 요소의 목록에 MessageForm 컴포넌트를 함께 추가하여, 메시지 작성 시에도 새로운 메시지가 추가된 것과 같은 상황으로 정렬되도록 수정

<br >

## UI 변경사항
### MessageForm이 추가되기 전
<img src="https://user-images.githubusercontent.com/71116429/189480813-3bcc73b0-3166-4e83-8aad-f666bf8c38e5.png" width="600px" />

<br >

### 수정 전
<img src="https://user-images.githubusercontent.com/71116429/189480884-bf953080-c3fc-44cf-b778-80f85c15d1c9.png" width="600px" />

- 맨 좌측 상단 배열에 MessageForm 컴포넌트가 추가된다.
- 가운데 배열, 우측 배열은 이동이 없다.

<br >

### 수정 후
<img src="https://user-images.githubusercontent.com/71116429/189480832-fce8f6d5-b52f-4f49-8d33-7b3eaefc1ade.png" width="600px" />

- 전체 메시지 목록에 MessageForm 컴포넌트를 추가한다.
- 모든 배열의 정렬이 오른쪽으로 한 칸씩 밀리는 방식으로 움직인다. (맨 우측에 위치한 경우 아래 칸 좌측으로 이동)

<br >

## 논의하고 싶은 부분
- 예상한 동작이 요 방식이 맞는지 확인해주세요.
- LetterPaper 내에 렌더링할 요소의 목록을 상태로 새로 정의했습니다. 우선은 LetterPaper의 요소들이라는 느낌으로,,, `elementList`라고 네이밍했는데 혹시 더 좋은 이름이 있다면 제안해주세요!
- elementList 관련한 동작들을 커스텀 훅으로 분리할까 싶었는데, 다른 커스텀 훅과 작업 범위(useSliceMessageList 관련)가 엮여있어서 조심스럽더라고요... 우선 LetterPaper에 대부분의 로직을 넣어뒀습니다. 어쨌든 리팩토링이 조금 더 필요할 것 같으니 어떤 방식이 좋을지 고민해볼게요. 도리도 보시고 아이디어 있으면 제안 부탁해요!
- 외에 다른 부분은 코멘트 남겨두겠습니다.

closed #416 