### PR TITLE
refactor: 메시지 저장 후 윈도우 리사이즈 또는 스크롤 시 생기는 메시지 목록 업데이트 오류를 해결

### DIFF
--- a/frontend/src/pages/RollingpaperPage/hooks/useSliceMessageList.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useSliceMessageList.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 
 import { divideArrayByIndexRemainder } from "@/util";
 
 import { Message } from "@/types";
 
 const useSliceMessageList = (messageList: Message[]) => {
+  const messageListRef = useRef<Message[]>(messageList);
   const [slicedMessageLists, setSlicedMessageLists] = useState<Message[][]>(
     Array.from(Array(4), () => [])
   );
@@ -14,17 +15,24 @@ const useSliceMessageList = (messageList: Message[]) => {
 
     let newSlicedMessageList;
     if (width < 960) {
-      newSlicedMessageList = [messageList];
+      newSlicedMessageList = [messageListRef.current];
     } else if (width < 1280) {
-      newSlicedMessageList = divideArrayByIndexRemainder(messageList, 2);
+      newSlicedMessageList = divideArrayByIndexRemainder(
+        messageListRef.current,
+        2
+      );
     } else {
-      newSlicedMessageList = divideArrayByIndexRemainder(messageList, 3);
+      newSlicedMessageList = divideArrayByIndexRemainder(
+        messageListRef.current,
+        3
+      );
     }
 
     setSlicedMessageLists(newSlicedMessageList);
   };
 
   useEffect(() => {
+    messageListRef.current = messageList;
     updateSlicedMessageListByWindowWidth();
   }, [messageList]);
 


### PR DESCRIPTION
## 구현 사항
- 문제 발생 이유: 이벤트 등록시 사용되는 messageList가 클로저 형식으로 고정되어 리사이즈 시 문제가 발생했습니다.
- 해결방법: ref사용. ref를 사용하여 life cycle에 관계없이 값이 유지되도록 변경했습니다.
- dom을 직접 조작하기 위해서가 아니라 로컬 변수용으로 사용하였기 때문에 초기값을 지정해주었습니다. generic으로 따로 표현을 해주지 않아도 괜찮을 것 같기도 합니다(타입추론이 자동으로 되어서) 이와 관련해서는 조금 더 고민해보도록 하겠습니다(참고자료: https://driip.me/7126d5d5-1937-44a8-98ed-f9065a7c35b5)


closed #417 