### PR TITLE
feat: 네이버 OAuth기능을 구현한다. 

### DIFF
--- a/backend/src/docs/asciidoc/auth.adoc
+++ b/backend/src/docs/asciidoc/auth.adoc
@@ -2,3 +2,6 @@
 
 === 카카오 Oauth
 operation::auth-controller-test/kakao-login[snippets='http-request,http-response']
+
+=== 네이버 Oauth
+operation::auth-controller-test/naver-login[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/auth/AuthController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/auth/AuthController.java
@@ -1,5 +1,6 @@
 package com.woowacourse.naepyeon.controller.auth;
 
+import com.woowacourse.naepyeon.controller.dto.NaverTokenRequest;
 import com.woowacourse.naepyeon.controller.dto.TokenRequest;
 import com.woowacourse.naepyeon.service.AuthService;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
@@ -22,6 +23,17 @@ public class AuthController {
     public ResponseEntity<TokenResponseDto> kakaoLogin(@RequestBody @Valid final TokenRequest tokenRequest) {
         final TokenResponseDto tokenResponseDto =
                 authService.createTokenWithKakaoOauth(tokenRequest.toServiceRequest());
+        return ResponseEntity.ok(tokenResponseDto);
+    }
+
+    @PostMapping("/naver")
+    public ResponseEntity<TokenResponseDto> naverLogin(@RequestBody @Valid final NaverTokenRequest naverTokenRequest) {
+        final TokenResponseDto tokenResponseDto =
+                authService.createTokenWithNaverOauth(
+                        naverTokenRequest.getAuthorizationCode(),
+                        naverTokenRequest.getRedirectUri(),
+                        naverTokenRequest.getState()
+                );
         return ResponseEntity.ok(tokenResponseDto);
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/dto/NaverTokenRequest.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/dto/NaverTokenRequest.java
@@ -1,14 +1,16 @@
-package com.woowacourse.naepyeon.support.oauth.kakao.dto;
+package com.woowacourse.naepyeon.controller.dto;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class AccessTokenResponse {
+@Getter
+public class NaverTokenRequest {
 
-    private String access_token;
+    private String authorizationCode;
+    private String redirectUri;
+    private String state;
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/NaverAuthorizationException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/NaverAuthorizationException.java
@@ -1,0 +1,17 @@
+package com.woowacourse.naepyeon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NaverAuthorizationException extends NaePyeonException {
+
+    public NaverAuthorizationException(final RuntimeException e) {
+        super(
+                String.format(
+                        "네이버 서버 에러입니다. errorMessage={%s}", e.getMessage()
+                ),
+                "네이버 로그인에 실패했습니다. 관리자에게 문의하세요.",
+                HttpStatus.BAD_REQUEST,
+                "3016"
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/NaverResourceException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/NaverResourceException.java
@@ -1,0 +1,19 @@
+package com.woowacourse.naepyeon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NaverResourceException extends NaePyeonException {
+
+    public NaverResourceException(final RuntimeException e, final String accessToken) {
+        super(
+                String.format(
+                        "네이버 리소스 서버 요청시 에러 발생 accessToken={%s}\nerrorMessage={%s}",
+                        accessToken,
+                        e.getMessage()
+                ),
+                "네이버 로그인에 실패했습니다. 관리자에게 문의하세요.",
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "3017"
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/AuthService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/AuthService.java
@@ -5,6 +5,7 @@ import com.woowacourse.naepyeon.service.dto.TokenRequestDto;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
 import com.woowacourse.naepyeon.support.JwtTokenProvider;
 import com.woowacourse.naepyeon.support.oauth.kakao.KakaoPlatformUserProvider;
+import com.woowacourse.naepyeon.support.oauth.naver.NaverPlatformUserProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ public class AuthService {
     private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
     private final KakaoPlatformUserProvider kakaoPlatformUserProvider;
+    private final NaverPlatformUserProvider naverPlatformUserProvider;
 
     public TokenResponseDto createTokenWithKakaoOauth(final TokenRequestDto tokenRequestDto) {
         final PlatformUserDto platformUser = kakaoPlatformUserProvider.getPlatformUser(
@@ -43,5 +45,17 @@ public class AuthService {
                 platformUser.getPlatform(),
                 platformUser.getPlatformId()
         );
+    }
+
+    public TokenResponseDto createTokenWithNaverOauth(final String authorizationCode, final String redirectUri,
+                                                      final String state) {
+        final PlatformUserDto platformUser = naverPlatformUserProvider.getPlatformUser(
+                authorizationCode,
+                redirectUri,
+                state
+        );
+        final Long memberId = createOrFindMemberId(platformUser);
+        final String accessToken = jwtTokenProvider.createToken(String.valueOf(memberId));
+        return new TokenResponseDto(accessToken, memberId);
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/dto/AccessTokenResponse.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/dto/AccessTokenResponse.java
@@ -1,0 +1,16 @@
+package com.woowacourse.naepyeon.support.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class AccessTokenResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/kakao/KakaoPlatformUserProvider.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/kakao/KakaoPlatformUserProvider.java
@@ -4,7 +4,7 @@ import com.woowacourse.naepyeon.domain.Platform;
 import com.woowacourse.naepyeon.exception.KakaoAuthorizationException;
 import com.woowacourse.naepyeon.exception.KakaoResourceException;
 import com.woowacourse.naepyeon.service.dto.PlatformUserDto;
-import com.woowacourse.naepyeon.support.oauth.kakao.dto.AccessTokenResponse;
+import com.woowacourse.naepyeon.support.oauth.dto.AccessTokenResponse;
 import com.woowacourse.naepyeon.support.oauth.kakao.dto.KakaoUserResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
@@ -44,7 +44,7 @@ public class KakaoPlatformUserProvider {
 
     public PlatformUserDto getPlatformUser(final String authorizationCode, final String redirectUri) {
         final AccessTokenResponse accessTokenResponse = requestAccessToken(authorizationCode, redirectUri);
-        final KakaoUserResponse kakaoUserResponse = requestPlatformUser(accessTokenResponse.getAccess_token());
+        final KakaoUserResponse kakaoUserResponse = requestPlatformUser(accessTokenResponse.getAccessToken());
         return new PlatformUserDto(
                 kakaoUserResponse.getNickname(),
                 kakaoUserResponse.getEmail(),

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/kakao/dto/KakaoUserResponse.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/kakao/dto/KakaoUserResponse.java
@@ -1,5 +1,6 @@
 package com.woowacourse.naepyeon.support.oauth.kakao.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -11,15 +12,17 @@ import lombok.NoArgsConstructor;
 public class KakaoUserResponse {
 
     private Long id;
-    private KakaoAccount kakao_account;
+
+    @JsonProperty("kakao_account")
+    private KakaoAccount kakaoAccount;
 
     public String getNickname() {
-        return kakao_account.getProfile()
+        return kakaoAccount.getProfile()
                 .getNickname();
     }
 
     public String getEmail() {
-        return kakao_account.getEmail();
+        return kakaoAccount.getEmail();
     }
 
     @Getter
@@ -37,6 +40,8 @@ public class KakaoUserResponse {
     private static class KakaoProfile {
 
         private String nickname;
-        private String profile_image_url;
+
+        @JsonProperty("profile_image_url")
+        private String profileImageUrl;
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/naver/NaverPlatformUserProvider.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/naver/NaverPlatformUserProvider.java
@@ -1,6 +1,9 @@
 package com.woowacourse.naepyeon.support.oauth.naver;
 
 import com.woowacourse.naepyeon.domain.Platform;
+import com.woowacourse.naepyeon.exception.KakaoAuthorizationException;
+import com.woowacourse.naepyeon.exception.NaverAuthorizationException;
+import com.woowacourse.naepyeon.exception.NaverResourceException;
 import com.woowacourse.naepyeon.service.dto.PlatformUserDto;
 import com.woowacourse.naepyeon.support.oauth.dto.AccessTokenResponse;
 import com.woowacourse.naepyeon.support.oauth.naver.dto.NaverUserResponse;
@@ -37,7 +40,8 @@ public class NaverPlatformUserProvider {
         this.naverClientSecret = naverClientSecret;
     }
 
-    public PlatformUserDto getPlatformUser(final String authorizationCode, final String redirectUri, final String state) {
+    public PlatformUserDto getPlatformUser(final String authorizationCode, final String redirectUri,
+                                           final String state) {
         final AccessTokenResponse accessTokenResponse = requestAccessToken(authorizationCode, redirectUri, state);
         final NaverUserResponse naverUserResponse = requestPlatformUser(accessTokenResponse.getAccessToken());
         return new PlatformUserDto(
@@ -63,10 +67,8 @@ public class NaverPlatformUserProvider {
                     ).retrieve()
                     .bodyToMono(AccessTokenResponse.class)
                     .block();
-
         } catch (final RuntimeException e) {
-            e.printStackTrace();
-            throw new IllegalArgumentException();
+            throw new NaverAuthorizationException(e);
         }
     }
 
@@ -80,8 +82,7 @@ public class NaverPlatformUserProvider {
                     .bodyToMono(NaverUserResponse.class)
                     .block();
         } catch (final RuntimeException e) {
-            e.printStackTrace();
-            throw new IllegalArgumentException();
+            throw new NaverResourceException(e, accessToken);
         }
     }
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/naver/NaverPlatformUserProvider.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/naver/NaverPlatformUserProvider.java
@@ -1,0 +1,87 @@
+package com.woowacourse.naepyeon.support.oauth.naver;
+
+import com.woowacourse.naepyeon.domain.Platform;
+import com.woowacourse.naepyeon.service.dto.PlatformUserDto;
+import com.woowacourse.naepyeon.support.oauth.dto.AccessTokenResponse;
+import com.woowacourse.naepyeon.support.oauth.naver.dto.NaverUserResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+public class NaverPlatformUserProvider {
+
+    private static final String AUTHORIZATION_SERVER_BASE_URL = "https://nid.naver.com/oauth2.0";
+    private static final String RESOURCE_SERVER_BASE_URL = "https://openapi.naver.com";
+    private static final String ACCESS_TOKEN_URI = "/token";
+    private static final String USER_INFO_URI = "v1/nid/me";
+
+    private final WebClient authorizationWebClient = WebClient.builder()
+            .baseUrl(AUTHORIZATION_SERVER_BASE_URL)
+            .build();
+
+    private final WebClient resourceWebClient = WebClient.builder()
+            .baseUrl(RESOURCE_SERVER_BASE_URL)
+            .build();
+
+    private final String naverClientId;
+    private final String naverClientSecret;
+
+    public NaverPlatformUserProvider(
+            @Value("${naver.client-id}") final String naverClientId,
+            @Value("${naver.client-secret}") final String naverClientSecret
+    ) {
+        this.naverClientId = naverClientId;
+        this.naverClientSecret = naverClientSecret;
+    }
+
+    public PlatformUserDto getPlatformUser(final String authorizationCode, final String redirectUri, final String state) {
+        final AccessTokenResponse accessTokenResponse = requestAccessToken(authorizationCode, redirectUri, state);
+        final NaverUserResponse naverUserResponse = requestPlatformUser(accessTokenResponse.getAccessToken());
+        return new PlatformUserDto(
+                naverUserResponse.getNickname(),
+                naverUserResponse.getEmail(),
+                Platform.NAVER.name(),
+                naverUserResponse.getId()
+        );
+    }
+
+    private AccessTokenResponse requestAccessToken(final String authorizationCode, final String redirectUri,
+                                                   final String state) {
+        try {
+            return authorizationWebClient.post()
+                    .uri(uriBuilder -> uriBuilder.path(ACCESS_TOKEN_URI)
+                            .queryParam("grant_type", "authorization_code")
+                            .queryParam("client_id", naverClientId)
+                            .queryParam("client_secret", naverClientSecret)
+                            .queryParam("redirect_uri", redirectUri)
+                            .queryParam("code", authorizationCode)
+                            .queryParam("state", state)
+                            .build()
+                    ).retrieve()
+                    .bodyToMono(AccessTokenResponse.class)
+                    .block();
+
+        } catch (final RuntimeException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+    }
+
+    private NaverUserResponse requestPlatformUser(final String accessToken) {
+        try {
+            return resourceWebClient.post()
+                    .uri(uriBuilder -> uriBuilder.path(USER_INFO_URI).build())
+                    .header(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", accessToken))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .retrieve()
+                    .bodyToMono(NaverUserResponse.class)
+                    .block();
+        } catch (final RuntimeException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/naver/dto/NaverUserResponse.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/oauth/naver/dto/NaverUserResponse.java
@@ -1,0 +1,43 @@
+package com.woowacourse.naepyeon.support.oauth.naver.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class NaverUserResponse {
+
+    @JsonProperty("resultcode")
+    private String resultCode;
+
+    private String message;
+    
+    @JsonProperty("response")
+    private NaverAccount naverAccount;
+
+    public String getNickname() {
+        return naverAccount.getNickname();
+    }
+
+    public String getEmail() {
+        return naverAccount.getEmail();
+    }
+
+    public String getId() {
+        return naverAccount.getId();
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    @AllArgsConstructor
+    private static class NaverAccount {
+
+        private String id;
+        private String nickname;
+        private String email;
+    }
+}

--- a/backend/src/main/resources/application-deploy.yml
+++ b/backend/src/main/resources/application-deploy.yml
@@ -34,5 +34,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
 
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+
 logging:
   config: classpath:log4j2-deploy.yml

--- a/backend/src/main/resources/application-develop.yml
+++ b/backend/src/main/resources/application-develop.yml
@@ -35,5 +35,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
 
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+
 logging:
   config: classpath:log4j2-develop.yml

--- a/backend/src/main/resources/application-flywayTest.yml
+++ b/backend/src/main/resources/application-flywayTest.yml
@@ -38,5 +38,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
 
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+
 logging:
   config: classpath:log4j2.yml

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -35,5 +35,9 @@ kakao:
   client-id: ${KAKAO_CLIENT_ID}
   client-secret: ${KAKAO_CLIENT_SECRET}
 
+naver:
+  client-id: ${NAVER_CLIENT_ID}
+  client-secret: ${NAVER_CLIENT_SECRET}
+
 logging:
   config: classpath:log4j2.yml

--- a/backend/src/test/java/com/woowacourse/naepyeon/document/AuthControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/document/AuthControllerTest.java
@@ -5,9 +5,11 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.woowacourse.naepyeon.controller.dto.NaverTokenRequest;
 import com.woowacourse.naepyeon.controller.dto.TokenRequest;
 import com.woowacourse.naepyeon.service.dto.PlatformUserDto;
 import com.woowacourse.naepyeon.support.oauth.kakao.KakaoPlatformUserProvider;
+import com.woowacourse.naepyeon.support.oauth.naver.NaverPlatformUserProvider;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -16,6 +18,9 @@ class AuthControllerTest extends TestSupport {
 
     @MockBean
     private KakaoPlatformUserProvider kakaoPlatformUserProvider;
+
+    @MockBean
+    private NaverPlatformUserProvider naverPlatformUserProvider;
 
     @Test
     void kakaoLogin() throws Exception {
@@ -27,6 +32,21 @@ class AuthControllerTest extends TestSupport {
                         post("/api/v1/oauth/kakao")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(objectMapper.writeValueAsString(tokenRequest))
+                )
+                .andExpect(status().isOk())
+                .andDo(restDocs.document());
+    }
+
+    @Test
+    void naverLogin() throws Exception {
+        when(naverPlatformUserProvider.getPlatformUser(anyString(), anyString(), anyString()))
+                .thenReturn(new PlatformUserDto("김승래", "email1@email.com", "NAVER", "2"));
+        final NaverTokenRequest naverTokenRequest = new NaverTokenRequest("seungpang", "https://...", "naepyeon");
+
+        mockMvc.perform(
+                        post("/api/v1/oauth/naver")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(naverTokenRequest))
                 )
                 .andExpect(status().isOk())
                 .andDo(restDocs.document());

--- a/backend/src/test/java/com/woowacourse/naepyeon/document/TestSupport.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/document/TestSupport.java
@@ -85,7 +85,7 @@ public abstract class TestSupport {
     private void saveBaseData() {
         memberId1 = memberService.save("홍길동", "email1@email.com", "KAKAO", "1");
         memberId2 = memberService.save("이순신", "email2@email.com", "KAKAO", "2");
-        memberId3 = memberService.save("아이유", "email3@email.com", "KAKAO", "3");
+        memberId3 = memberService.save("아이유", "email3@email.com", "NAVER", "1");
 
         teamId = teamService.save(
                 new TeamRequestDto("우테코 4기", "우테코 4기 크루원들 모임입니다.", "\\uD83D\\uDE00", "#212121", "길동이", false),

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/AuthServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/AuthServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 
+import com.woowacourse.naepyeon.controller.dto.NaverTokenRequest;
 import com.woowacourse.naepyeon.domain.Member;
 import com.woowacourse.naepyeon.domain.Platform;
 import com.woowacourse.naepyeon.repository.MemberRepository;
@@ -13,6 +14,7 @@ import com.woowacourse.naepyeon.service.dto.TokenRequestDto;
 import com.woowacourse.naepyeon.service.dto.TokenResponseDto;
 import com.woowacourse.naepyeon.support.JwtTokenProvider;
 import com.woowacourse.naepyeon.support.oauth.kakao.KakaoPlatformUserProvider;
+import com.woowacourse.naepyeon.support.oauth.naver.NaverPlatformUserProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,9 @@ class AuthServiceTest {
     @MockBean
     private KakaoPlatformUserProvider kakaoPlatformUserProvider;
 
+    @MockBean
+    private NaverPlatformUserProvider naverPlatformUserProvider;
+
     @Autowired
     private MemberRepository memberRepository;
 
@@ -41,12 +46,17 @@ class AuthServiceTest {
 
     @BeforeEach
     void setUp() {
-        authService = new AuthService(memberService, jwtTokenProvider, kakaoPlatformUserProvider);
+        authService = new AuthService(
+                memberService,
+                jwtTokenProvider,
+                kakaoPlatformUserProvider,
+                naverPlatformUserProvider
+        );
     }
 
     @Test
-    @DisplayName("사용자 정보를 받아 토큰을 만들어 반환한다.")
-    void createToken() {
+    @DisplayName("사용자 정보를 받아 카카오 Oauth로 토큰을 만들어 반환한다.")
+    void createKakaoToken() {
         final PlatformUserDto platformUserDto = new PlatformUserDto("alex", "email@email.com", "KAKAO", "1");
         when(kakaoPlatformUserProvider.getPlatformUser(anyString(), anyString())).thenReturn(platformUserDto);
 
@@ -58,13 +68,56 @@ class AuthServiceTest {
     }
 
     @Test
-    @DisplayName("사용자 정보가 DB에 없는 경우 DB에 사용자 정보를 추가하고 토큰을 반환한다.")
-    void createTokenWithNotExistMember() {
+    @DisplayName("사용자 정보를 받아 네이버 Oauth로 토큰을 만들어 반환한다.")
+    void createNaverToken() {
+        final PlatformUserDto platformUserDto = new PlatformUserDto("seungpang", "email@email.com", "NAVER", "2");
+        when(naverPlatformUserProvider.getPlatformUser(anyString(), anyString(), anyString())).thenReturn(platformUserDto);
+
+        final NaverTokenRequest naverTokenRequest = new NaverTokenRequest("authorizationCode", "https://...",
+                "naepyeon");
+        final TokenResponseDto tokenResponseDto = authService.createTokenWithNaverOauth(
+                naverTokenRequest.getAuthorizationCode(), naverTokenRequest.getRedirectUri(),
+                naverTokenRequest.getState());
+
+        assertThatCode(() -> jwtTokenProvider.validateAbleToken(tokenResponseDto.getAccessToken()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("카카오 Oauth로 접속한 사용자 정보가 DB에 없는 경우 DB에 사용자 정보를 추가하고 토큰을 반환한다.")
+    void createTokenWithKaKaoOauthAndNotExistMember() {
         final PlatformUserDto platformUserDto = new PlatformUserDto("alex", "email@email.com", "KAKAO", "1");
         when(kakaoPlatformUserProvider.getPlatformUser(anyString(), anyString())).thenReturn(platformUserDto);
         final TokenRequestDto tokenRequestDto = new TokenRequestDto("authorizationCode", "https://...");
 
         final TokenResponseDto tokenResponseDto = authService.createTokenWithKakaoOauth(tokenRequestDto);
+        final Long memberId = tokenResponseDto.getId();
+        final Member findMember = memberRepository.findById(memberId)
+                .get();
+
+        assertThat(findMember).extracting("id", "username", "email", "platform", "platformId")
+                .containsExactly(
+                        memberId,
+                        platformUserDto.getUsername(),
+                        platformUserDto.getEmail(),
+                        Platform.valueOf(platformUserDto.getPlatform()),
+                        platformUserDto.getPlatformId()
+                );
+    }
+
+    @Test
+    @DisplayName("네이버 Oauth로 접속한 사용자 정보가 DB에 없는 경우 DB에 사용자 정보를 추가하고 토큰을 반환한다.")
+    void createTokenWithNaverOauthAndNotExistMember() {
+        final PlatformUserDto platformUserDto = new PlatformUserDto("seungpang", "email@email.com", "NAVER", "2");
+        when(naverPlatformUserProvider.getPlatformUser(anyString(), anyString(), anyString())).thenReturn(platformUserDto);
+        final NaverTokenRequest naverTokenRequest = new NaverTokenRequest("authorizationCode", "https://...",
+                "naepyeon");
+
+        final TokenResponseDto tokenResponseDto = authService.createTokenWithNaverOauth(
+                naverTokenRequest.getAuthorizationCode(),
+                naverTokenRequest.getRedirectUri(),
+                naverTokenRequest.getState()
+        );
         final Long memberId = tokenResponseDto.getId();
         final Member findMember = memberRepository.findById(memberId)
                 .get();

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -40,5 +40,9 @@ kakao:
   client-id: client_id
   client-secret: client_secret
 
+naver:
+  client-id: client_id
+  client-secret: client_secret
+
 logging:
   config: classpath:log4j2.yml


### PR DESCRIPTION
## 구현사항 
1. 네이버 Oauth 구현
+ 큰 흐름은 카카오 Oauth와 비슷합니다. 다만 조금씩 다른 부분들이 존재합니다. ex) state값이 필수인점 카카오는 필수가 아님

2. 기존 snake case -> `@JsonProperty`를 활용하여 camel case로 변경

3. 테스트 코드 추가 및 수정 


close #349 