### PR TITLE
feat: API 커스텀 에러 적용

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { QueryClient } from "@tanstack/react-query";
 import ApiError from "@/util/ApiError";
+import { ApiErrorResponse } from "@/types";
 
 const appClient = axios.create({
   baseURL: process.env.API_URL,
@@ -20,7 +21,7 @@ const handleApiError = ({
   error: unknown;
 } & Pick<ApiError, "errorHandler">) => {
   if (axios.isAxiosError(error) && error.response) {
-    const customError = error.response.data as ApiError;
+    const customError = error.response.data as ApiErrorResponse;
     const { errorCode, message } = customError;
     throw new ApiError({
       errorCode,

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { QueryClient } from "@tanstack/react-query";
+import ApiError from "@/util/ApiError";
 
 const appClient = axios.create({
   baseURL: process.env.API_URL,
@@ -12,4 +13,26 @@ const setAppClientHeaderAuthorization = (accessToken: string) => {
   appClient.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
 };
 
-export { appClient, queryClient, setAppClientHeaderAuthorization };
+const handleApiError = ({
+  error,
+  errorHandler,
+}: {
+  error: unknown;
+} & Pick<ApiError, "errorHandler">) => {
+  if (axios.isAxiosError(error) && error.response) {
+    const customError = error.response.data as ApiError;
+    const { errorCode, message } = customError;
+    throw new ApiError({
+      errorCode,
+      message,
+      errorHandler: errorHandler,
+    });
+  }
+};
+
+export {
+  appClient,
+  queryClient,
+  setAppClientHeaderAuthorization,
+  handleApiError,
+};

--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -4,11 +4,12 @@ import { appClient } from "@/api";
 import ApiError from "@/util/ApiError";
 
 import { RequestKakaoOauthBody } from "@/types/oauth";
+import { ApiOptions } from "@/types";
 
-const postKakaoOauth = async ({
-  authorizationCode,
-  redirectUri,
-}: RequestKakaoOauthBody) => {
+const postKakaoOauth = async (
+  { authorizationCode, redirectUri }: RequestKakaoOauthBody,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.post("/oauth/kakao", {
       authorizationCode,
@@ -19,7 +20,12 @@ const postKakaoOauth = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };

--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -1,7 +1,4 @@
-import axios from "axios";
-
-import { appClient, handleApiError } from "@/api";
-import ApiError from "@/util/ApiError";
+import { appClient, requestApi } from "@/api";
 
 import { RequestKakaoOauthBody } from "@/types/oauth";
 import { ApiOptions } from "@/types";
@@ -9,20 +6,14 @@ import { ApiOptions } from "@/types";
 const postKakaoOauth = async (
   { authorizationCode, redirectUri }: RequestKakaoOauthBody,
   options?: ApiOptions
-) => {
-  try {
-    const response = await appClient.post("/oauth/kakao", {
-      authorizationCode,
-      redirectUri,
-    });
-
-    return response.data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) =>
+  requestApi(
+    () =>
+      appClient.post("/oauth/kakao", {
+        authorizationCode,
+        redirectUri,
+      }),
+    options
+  );
 
 export { postKakaoOauth };

--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -1,4 +1,7 @@
+import axios from "axios";
+
 import { appClient } from "@/api";
+import ApiError from "@/util/ApiError";
 
 import { RequestKakaoOauthBody } from "@/types/oauth";
 
@@ -6,11 +9,19 @@ const postKakaoOauth = async ({
   authorizationCode,
   redirectUri,
 }: RequestKakaoOauthBody) => {
-  const response = await appClient.post("/oauth/kakao", {
-    authorizationCode,
-    redirectUri,
-  });
-  return response.data;
+  try {
+    const { data } = await appClient.post("/oauth/kakao", {
+      authorizationCode,
+      redirectUri,
+    });
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
 };
 
 export { postKakaoOauth };

--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { appClient } from "@/api";
+import { appClient, handleApiError } from "@/api";
 import ApiError from "@/util/ApiError";
 
 import { RequestKakaoOauthBody } from "@/types/oauth";
@@ -11,22 +11,17 @@ const postKakaoOauth = async (
   options?: ApiOptions
 ) => {
   try {
-    const { data } = await appClient.post("/oauth/kakao", {
+    const response = await appClient.post("/oauth/kakao", {
       authorizationCode,
       redirectUri,
     });
 
-    return data;
+    return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -3,7 +3,9 @@ import axios from "axios";
 import { appClient } from "@/api";
 import ApiError from "@/util/ApiError";
 
-const getMyInfo = async () => {
+import { ApiOptions } from "@/types";
+
+const getMyInfo = async (options?: ApiOptions) => {
   try {
     const { data } = await appClient.get("/members/me");
 
@@ -11,12 +13,20 @@ const getMyInfo = async () => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const getMyInfoWithAccessToken = async (accessToken: string | null) => {
+const getMyInfoWithAccessToken = async (
+  accessToken: string | null,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.get("/members/me", {
       headers: {
@@ -28,12 +38,21 @@ const getMyInfoWithAccessToken = async (accessToken: string | null) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const getMyReceivedRollingpapers = async (page = 0, count = 5) => {
+const getMyReceivedRollingpapers = async (
+  page = 0,
+  count = 5,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.get(
       `/members/me/rollingpapers/received?page=${page}&count=${count}`
@@ -43,12 +62,17 @@ const getMyReceivedRollingpapers = async (page = 0, count = 5) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const getMySentMessage = async (page = 0, count = 5) => {
+const getMySentMessage = async (page = 0, count = 5, options?: ApiOptions) => {
   try {
     const { data } = await appClient.get(
       `/members/me/messages/written?page=${page}&count=${count}`
@@ -58,12 +82,17 @@ const getMySentMessage = async (page = 0, count = 5) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const putMyNickname = async (username: string) => {
+const putMyNickname = async (username: string, options?: ApiOptions) => {
   try {
     const { data } = await appClient.put("/members/me", { username });
 
@@ -71,7 +100,12 @@ const putMyNickname = async (username: string) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { appClient } from "@/api";
+import { appClient, handleApiError } from "@/api";
 import ApiError from "@/util/ApiError";
 
 import { ApiOptions } from "@/types";
@@ -11,15 +11,10 @@ const getMyInfo = async (options?: ApiOptions) => {
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -36,15 +31,10 @@ const getMyInfoWithAccessToken = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -60,15 +50,10 @@ const getMyReceivedRollingpapers = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -80,15 +65,10 @@ const getMySentMessage = async (page = 0, count = 5, options?: ApiOptions) => {
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -98,15 +78,10 @@ const putMyNickname = async (username: string, options?: ApiOptions) => {
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -1,89 +1,46 @@
-import axios from "axios";
-
-import { appClient, handleApiError } from "@/api";
-import ApiError from "@/util/ApiError";
+import { appClient, requestApi } from "@/api";
 
 import { ApiOptions } from "@/types";
 
-const getMyInfo = async (options?: ApiOptions) => {
-  try {
-    const { data } = await appClient.get("/members/me");
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+const getMyInfo = async (options?: ApiOptions) =>
+  requestApi(() => appClient.get("/members/me"), options);
 
 const getMyInfoWithAccessToken = async (
   accessToken: string | null,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.get("/members/me", {
-      headers: {
-        Authorization: `Bearer ${accessToken || ""}`,
-      },
-    });
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) =>
+  requestApi(
+    () =>
+      appClient.get("/members/me", {
+        headers: {
+          Authorization: `Bearer ${accessToken || ""}`,
+        },
+      }),
+    options
+  );
 
 const getMyReceivedRollingpapers = async (
   page = 0,
   count = 5,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.get(
-      `/members/me/rollingpapers/received?page=${page}&count=${count}`
-    );
+) =>
+  requestApi(
+    () =>
+      appClient.get(
+        `/members/me/rollingpapers/received?page=${page}&count=${count}`
+      ),
+    options
+  );
 
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+const getMySentMessage = async (page = 0, count = 5, options?: ApiOptions) =>
+  requestApi(
+    () =>
+      appClient.get(`/members/me/messages/written?page=${page}&count=${count}`),
+    options
+  );
 
-const getMySentMessage = async (page = 0, count = 5, options?: ApiOptions) => {
-  try {
-    const { data } = await appClient.get(
-      `/members/me/messages/written?page=${page}&count=${count}`
-    );
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
-
-const putMyNickname = async (username: string, options?: ApiOptions) => {
-  try {
-    const { data } = await appClient.put("/members/me", { username });
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+const putMyNickname = async (username: string, options?: ApiOptions) =>
+  requestApi(() => appClient.put("/members/me", { username }), options);
 
 export {
   getMyInfo,

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -1,35 +1,79 @@
-import { appClient } from "@/api";
+import axios from "axios";
 
-const getMyInfo = () => {
-  return appClient.get("/members/me").then((response) => response.data);
+import { appClient } from "@/api";
+import ApiError from "@/util/ApiError";
+
+const getMyInfo = async () => {
+  try {
+    const { data } = await appClient.get("/members/me");
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
 };
 
-const getMyInfoWithAccessToken = (accessToken: string | null) => {
-  return appClient
-    .get("/members/me", {
+const getMyInfoWithAccessToken = async (accessToken: string | null) => {
+  try {
+    const { data } = await appClient.get("/members/me", {
       headers: {
         Authorization: `Bearer ${accessToken || ""}`,
       },
-    })
-    .then((response) => response.data);
+    });
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
 };
 
-const getMyReceivedRollingpapers = (page = 0, count = 5) => {
-  return appClient
-    .get(`/members/me/rollingpapers/received?page=${page}&count=${count}`)
-    .then((response) => response.data);
+const getMyReceivedRollingpapers = async (page = 0, count = 5) => {
+  try {
+    const { data } = await appClient.get(
+      `/members/me/rollingpapers/received?page=${page}&count=${count}`
+    );
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
 };
 
-const getMySentMessage = (page = 0, count = 5) => {
-  return appClient
-    .get(`/members/me/messages/written?page=${page}&count=${count}`)
-    .then((response) => response.data);
+const getMySentMessage = async (page = 0, count = 5) => {
+  try {
+    const { data } = await appClient.get(
+      `/members/me/messages/written?page=${page}&count=${count}`
+    );
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
 };
 
-const putMyNickname = (username: string) => {
-  return appClient
-    .put("/members/me", { username })
-    .then((response) => response.data);
+const putMyNickname = async (username: string) => {
+  try {
+    const { data } = await appClient.put("/members/me", { username });
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
 };
 
 export {

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -1,4 +1,7 @@
+import axios from "axios";
+
 import { appClient } from "@/api";
+import ApiError from "@/util/ApiError";
 
 interface PutMessageRequest {
   rollingpaperId: number;
@@ -14,42 +17,74 @@ interface DeleteMessageRequest {
   id: number;
 }
 
-const putMessage = ({
+const postMessage = async ({
+  rollingpaperId,
+  content,
+  color,
+  anonymous,
+  secret,
+}: Partial<PutMessageRequest>) => {
+  try {
+    const { data } = await appClient.post(
+      `/rollingpapers/${rollingpaperId}/messages`,
+      {
+        content,
+        color,
+        anonymous,
+        secret,
+      }
+    );
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const putMessage = async ({
   rollingpaperId,
   id,
   content,
   color,
   anonymous,
   secret,
-}: PutMessageRequest) =>
-  appClient
-    .put(`/rollingpapers/${rollingpaperId}/messages/${id}`, {
-      content,
-      color,
-      anonymous,
-      secret,
-    })
-    .then((response) => response.data);
+}: PutMessageRequest) => {
+  try {
+    const { data } = await appClient.put(
+      `/rollingpapers/${rollingpaperId}/messages/${id}`,
+      {
+        content,
+        color,
+        anonymous,
+        secret,
+      }
+    );
 
-const postMessage = ({
-  rollingpaperId,
-  content,
-  color,
-  anonymous,
-  secret,
-}: Partial<PutMessageRequest>) =>
-  appClient
-    .post(`/rollingpapers/${rollingpaperId}/messages`, {
-      content,
-      color,
-      anonymous,
-      secret,
-    })
-    .then((response) => response.data);
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
 
-const deleteMessage = ({ rollingpaperId, id }: DeleteMessageRequest) =>
-  appClient
-    .delete(`/rollingpapers/${rollingpaperId}/messages/${id}`)
-    .then((response) => response.data);
+const deleteMessage = async ({ rollingpaperId, id }: DeleteMessageRequest) => {
+  try {
+    const { data } = await appClient.delete(
+      `/rollingpapers/${rollingpaperId}/messages/${id}`
+    );
+
+    return { data };
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
 
 export { putMessage, postMessage, deleteMessage };

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { appClient } from "@/api";
+import { appClient, handleApiError } from "@/api";
 import ApiError from "@/util/ApiError";
 
 import { ApiOptions } from "@/types";
@@ -42,15 +42,10 @@ const postMessage = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -71,15 +66,10 @@ const putMessage = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -94,15 +84,10 @@ const deleteMessage = async (
 
     return { data };
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -3,6 +3,8 @@ import axios from "axios";
 import { appClient } from "@/api";
 import ApiError from "@/util/ApiError";
 
+import { ApiOptions } from "@/types";
+
 interface PutMessageRequest {
   rollingpaperId: number;
   id: number | null;
@@ -17,13 +19,16 @@ interface DeleteMessageRequest {
   id: number;
 }
 
-const postMessage = async ({
-  rollingpaperId,
-  content,
-  color,
-  anonymous,
-  secret,
-}: Partial<PutMessageRequest>) => {
+const postMessage = async (
+  {
+    rollingpaperId,
+    content,
+    color,
+    anonymous,
+    secret,
+  }: Partial<PutMessageRequest>,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.post(
       `/rollingpapers/${rollingpaperId}/messages`,
@@ -39,19 +44,20 @@ const postMessage = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const putMessage = async ({
-  rollingpaperId,
-  id,
-  content,
-  color,
-  anonymous,
-  secret,
-}: PutMessageRequest) => {
+const putMessage = async (
+  { rollingpaperId, id, content, color, anonymous, secret }: PutMessageRequest,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.put(
       `/rollingpapers/${rollingpaperId}/messages/${id}`,
@@ -67,12 +73,20 @@ const putMessage = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const deleteMessage = async ({ rollingpaperId, id }: DeleteMessageRequest) => {
+const deleteMessage = async (
+  { rollingpaperId, id }: DeleteMessageRequest,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.delete(
       `/rollingpapers/${rollingpaperId}/messages/${id}`
@@ -82,7 +96,12 @@ const deleteMessage = async ({ rollingpaperId, id }: DeleteMessageRequest) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -1,7 +1,4 @@
-import axios from "axios";
-
-import { appClient, handleApiError } from "@/api";
-import ApiError from "@/util/ApiError";
+import { appClient, requestApi } from "@/api";
 
 import { ApiOptions } from "@/types";
 
@@ -28,67 +25,40 @@ const postMessage = async (
     secret,
   }: Partial<PutMessageRequest>,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.post(
-      `/rollingpapers/${rollingpaperId}/messages`,
-      {
+) =>
+  requestApi(
+    () =>
+      appClient.post(`/rollingpapers/${rollingpaperId}/messages`, {
         content,
         color,
         anonymous,
         secret,
-      }
-    );
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+      }),
+    options
+  );
 
 const putMessage = async (
   { rollingpaperId, id, content, color, anonymous, secret }: PutMessageRequest,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.put(
-      `/rollingpapers/${rollingpaperId}/messages/${id}`,
-      {
+) =>
+  requestApi(
+    () =>
+      appClient.put(`/rollingpapers/${rollingpaperId}/messages/${id}`, {
         content,
         color,
         anonymous,
         secret,
-      }
-    );
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+      }),
+    options
+  );
 
 const deleteMessage = async (
   { rollingpaperId, id }: DeleteMessageRequest,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.delete(
-      `/rollingpapers/${rollingpaperId}/messages/${id}`
-    );
-
-    return { data };
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) =>
+  requestApi(
+    () => appClient.delete(`/rollingpapers/${rollingpaperId}/messages/${id}`),
+    options
+  );
 
 export { putMessage, postMessage, deleteMessage };

--- a/frontend/src/api/rollingpaper.ts
+++ b/frontend/src/api/rollingpaper.ts
@@ -1,6 +1,4 @@
-import axios from "axios";
-
-import { appClient, handleApiError } from "@/api";
+import { appClient, requestApi } from "@/api";
 
 import { ApiOptions } from "@/types";
 
@@ -9,63 +7,40 @@ interface RequestPostRollingpaper {
   title: string;
   addresseeId: number;
 }
+
 const getRollingpaper = async (
   teamId: number,
   id: number,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.get(
-      `/teams/${teamId}/rollingpapers/${id}`
-    );
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) =>
+  requestApi(
+    () => appClient.get(`/teams/${teamId}/rollingpapers/${id}`),
+    options
+  );
 
 const postTeamRollingpaper = async (
   { teamId, title }: Omit<RequestPostRollingpaper, "addresseeId">,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.post(
-      `/teams/${teamId}/team-rollingpapers`,
-      {
+) =>
+  requestApi(
+    () =>
+      appClient.post(`/teams/${teamId}/team-rollingpapers`, {
         title,
-      }
-    );
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+      }),
+    options
+  );
 
 const postMemberRollingpaper = async (
   { teamId, title, addresseeId }: RequestPostRollingpaper,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.post(`/teams/${teamId}/rollingpapers`, {
-      title,
-      addresseeId,
-    });
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) =>
+  requestApi(
+    () =>
+      appClient.post(`/teams/${teamId}/rollingpapers`, {
+        title,
+        addresseeId,
+      }),
+    options
+  );
 
 export { getRollingpaper, postTeamRollingpaper, postMemberRollingpaper };

--- a/frontend/src/api/rollingpaper.ts
+++ b/frontend/src/api/rollingpaper.ts
@@ -1,35 +1,67 @@
+import axios from "axios";
+
 import { appClient } from "@/api";
+import ApiError from "@/util/ApiError";
 
 interface RequestPostRollingpaper {
   teamId: number;
   title: string;
   addresseeId: number;
 }
-const getRollingpaper = (teamId: number, id: number) =>
-  appClient
-    .get(`/teams/${teamId}/rollingpapers/${id}`)
-    .then((response) => response.data);
+const getRollingpaper = async (teamId: number, id: number) => {
+  try {
+    const { data } = await appClient.get(
+      `/teams/${teamId}/rollingpapers/${id}`
+    );
 
-const postTeamRollingpaper = ({
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const postTeamRollingpaper = async ({
   teamId,
   title,
-}: Omit<RequestPostRollingpaper, "addresseeId">) =>
-  appClient
-    .post(`/teams/${teamId}/team-rollingpapers`, {
-      title,
-    })
-    .then((response) => response.data);
+}: Omit<RequestPostRollingpaper, "addresseeId">) => {
+  try {
+    const { data } = await appClient.post(
+      `/teams/${teamId}/team-rollingpapers`,
+      {
+        title,
+      }
+    );
 
-const postMemberRollingpaper = ({
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const postMemberRollingpaper = async ({
   teamId,
   title,
   addresseeId,
-}: RequestPostRollingpaper) =>
-  appClient
-    .post(`/teams/${teamId}/rollingpapers`, {
+}: RequestPostRollingpaper) => {
+  try {
+    const { data } = await appClient.post(`/teams/${teamId}/rollingpapers`, {
       title,
       addresseeId,
-    })
-    .then((response) => response.data);
+    });
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
 
 export { getRollingpaper, postTeamRollingpaper, postMemberRollingpaper };

--- a/frontend/src/api/rollingpaper.ts
+++ b/frontend/src/api/rollingpaper.ts
@@ -3,12 +3,18 @@ import axios from "axios";
 import { appClient } from "@/api";
 import ApiError from "@/util/ApiError";
 
+import { ApiOptions } from "@/types";
+
 interface RequestPostRollingpaper {
   teamId: number;
   title: string;
   addresseeId: number;
 }
-const getRollingpaper = async (teamId: number, id: number) => {
+const getRollingpaper = async (
+  teamId: number,
+  id: number,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.get(
       `/teams/${teamId}/rollingpapers/${id}`
@@ -18,15 +24,20 @@ const getRollingpaper = async (teamId: number, id: number) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const postTeamRollingpaper = async ({
-  teamId,
-  title,
-}: Omit<RequestPostRollingpaper, "addresseeId">) => {
+const postTeamRollingpaper = async (
+  { teamId, title }: Omit<RequestPostRollingpaper, "addresseeId">,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.post(
       `/teams/${teamId}/team-rollingpapers`,
@@ -39,16 +50,20 @@ const postTeamRollingpaper = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const postMemberRollingpaper = async ({
-  teamId,
-  title,
-  addresseeId,
-}: RequestPostRollingpaper) => {
+const postMemberRollingpaper = async (
+  { teamId, title, addresseeId }: RequestPostRollingpaper,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.post(`/teams/${teamId}/rollingpapers`, {
       title,
@@ -59,7 +74,12 @@ const postMemberRollingpaper = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };

--- a/frontend/src/api/rollingpaper.ts
+++ b/frontend/src/api/rollingpaper.ts
@@ -1,7 +1,6 @@
 import axios from "axios";
 
-import { appClient } from "@/api";
-import ApiError from "@/util/ApiError";
+import { appClient, handleApiError } from "@/api";
 
 import { ApiOptions } from "@/types";
 
@@ -22,15 +21,10 @@ const getRollingpaper = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -48,15 +42,10 @@ const postTeamRollingpaper = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -72,15 +61,10 @@ const postMemberRollingpaper = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -1,7 +1,4 @@
-import axios from "axios";
-
-import { appClient, handleApiError } from "@/api";
-import ApiError from "@/util/ApiError";
+import { appClient, requestApi } from "@/api";
 
 import { ApiOptions, Team } from "@/types";
 
@@ -12,109 +9,46 @@ interface SearchRequest {
 
 const getMyTeams =
   (teamPageCount = 5, options?: ApiOptions) =>
-  async ({ pageParam = 0 }) => {
-    try {
-      const { data } = await appClient.get(
-        `teams/me?page=${pageParam}&count=${teamPageCount}`
-      );
-
-      return data;
-    } catch (error) {
-      handleApiError({
-        error,
-        errorHandler: options?.onError,
-      });
-    }
-  };
+  async ({ pageParam = 0 }) =>
+    requestApi(
+      () => appClient.get(`teams/me?page=${pageParam}&count=${teamPageCount}`),
+      options
+    );
 
 const getTeamSearchResult =
   ({ keyword, count }: SearchRequest, options?: ApiOptions) =>
-  async ({ pageParam = 0 }) => {
-    try {
-      const { data } = await appClient.get(
-        `teams?keyword=${keyword}&page=${pageParam}&count=${count}`
-      );
+  async ({ pageParam = 0 }) =>
+    requestApi(
+      () =>
+        appClient.get(
+          `teams?keyword=${keyword}&page=${pageParam}&count=${count}`
+        ),
+      options
+    );
 
-      return data;
-    } catch (error) {
-      handleApiError({
-        error,
-        errorHandler: options?.onError,
-      });
-    }
-  };
+const getTeam = async (id: number, options?: ApiOptions) =>
+  requestApi(() => appClient.get(`/teams/${id}`), options);
 
-const getTeam = async (id: number, options?: ApiOptions) => {
-  try {
-    const { data } = await appClient.get(`/teams/${id}`);
+const getTeamMembers = async (id: number, options?: ApiOptions) =>
+  requestApi(() => appClient.get(`/teams/${id}/members`), options);
 
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
-
-const getTeamMembers = async (id: number, options?: ApiOptions) => {
-  try {
-    const { data } = await appClient.get(`/teams/${id}/members`);
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
-
-const getTeamRollingpapers = async (id: number, options?: ApiOptions) => {
-  try {
-    const { data } = await appClient.get(`/teams/${id}/rollingpapers`);
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+const getTeamRollingpapers = async (id: number, options?: ApiOptions) =>
+  requestApi(() => appClient.get(`/teams/${id}/rollingpapers`), options);
 
 const getTeamWithInviteToken = async (
   inviteToken: string,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.get(
-      `/teams/invite?inviteToken=${inviteToken}`
-    );
+) =>
+  requestApi(
+    () => appClient.get(`/teams/invite?inviteToken=${inviteToken}`),
+    options
+  );
 
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
-
-const getTeamMyNickname = async (id: number, options?: ApiOptions) => {
-  try {
-    const { data } = await appClient
-      .get(`/teams/${id}/me`)
-      .then((response) => response.data);
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+const getTeamMyNickname = async (id: number, options?: ApiOptions) =>
+  requestApi(
+    () => appClient.get(`/teams/${id}/me`).then((response) => response.data),
+    options
+  );
 
 const postTeam = async (
   {
@@ -126,92 +60,47 @@ const postTeam = async (
     secret,
   }: Omit<Team, "id" | "joined">,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.post("/teams", {
-      name,
-      description,
-      emoji,
-      color,
-      nickname,
-      secret,
-    });
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) =>
+  requestApi(
+    () =>
+      appClient.post("/teams", {
+        name,
+        description,
+        emoji,
+        color,
+        nickname,
+        secret,
+      }),
+    options
+  );
 
 const postTeamInviteToken = async (
   { id }: Pick<Team, "id">,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.post(`/teams/${id}/invite`);
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) => requestApi(() => appClient.post(`/teams/${id}/invite`), options);
 
 const postTeamMember = async (
   { id, nickname }: Pick<Team, "id" | "nickname">,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.post(`/teams/${id}`, { nickname });
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) => requestApi(() => appClient.post(`/teams/${id}`, { nickname }), options);
 
 const postTeamMemberWithInviteToken = async (
   { inviteToken, nickname }: Pick<Team, "nickname"> & { inviteToken: string },
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.post(`/teams/invite/join`, {
-      inviteToken,
-      nickname,
-    });
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) =>
+  requestApi(
+    () =>
+      appClient.post(`/teams/invite/join`, {
+        inviteToken,
+        nickname,
+      }),
+    options
+  );
 
 const putTeamNickname = async (
   { id, nickname }: Pick<Team, "id" | "nickname">,
   options?: ApiOptions
-) => {
-  try {
-    const { data } = await appClient.put(`/teams/${id}/me`, { nickname });
-
-    return data;
-  } catch (error) {
-    handleApiError({
-      error,
-      errorHandler: options?.onError,
-    });
-  }
-};
+) => requestApi(() => appClient.put(`/teams/${id}/me`, { nickname }), options);
 
 export {
   getMyTeams,

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -1,4 +1,8 @@
+import axios from "axios";
+
 import { appClient } from "@/api";
+import ApiError from "@/util/ApiError";
+
 import { Team } from "@/types";
 
 interface SearchRequest {
@@ -8,76 +12,197 @@ interface SearchRequest {
 
 const getMyTeams =
   (teamPageCount = 5) =>
-  async ({ pageParam = 0 }) =>
-    appClient
-      .get(`teams/me?page=${pageParam}&count=${teamPageCount}`)
-      .then((response) => response.data);
+  async ({ pageParam = 0 }) => {
+    try {
+      const { data } = await appClient.get(
+        `teams/me?page=${pageParam}&count=${teamPageCount}`
+      );
+
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        const customError = error.response.data as ApiError;
+        throw new ApiError(customError.errorCode, customError.message);
+      }
+    }
+  };
 
 const getTeamSearchResult =
   ({ keyword, count }: SearchRequest) =>
-  async ({ pageParam = 0 }) =>
-    appClient
-      .get(`teams?keyword=${keyword}&page=${pageParam}&count=${count}`)
+  async ({ pageParam = 0 }) => {
+    try {
+      const { data } = await appClient.get(
+        `teams?keyword=${keyword}&page=${pageParam}&count=${count}`
+      );
+
+      return data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        const customError = error.response.data as ApiError;
+        throw new ApiError(customError.errorCode, customError.message);
+      }
+    }
+  };
+
+const getTeam = async (id: number) => {
+  try {
+    const { data } = await appClient.get(`/teams/${id}`);
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const getTeamMembers = async (id: number) => {
+  try {
+    const { data } = await appClient.get(`/teams/${id}/members`);
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const getTeamRollingpapers = async (id: number) => {
+  try {
+    const { data } = await appClient.get(`/teams/${id}/rollingpapers`);
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const getTeamWithInviteToken = async (inviteToken: string) => {
+  try {
+    const { data } = await appClient.get(
+      `/teams/invite?inviteToken=${inviteToken}`
+    );
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const getTeamMyNickname = async (id: number) => {
+  try {
+    const { data } = await appClient
+      .get(`/teams/${id}/me`)
       .then((response) => response.data);
 
-const getTeam = (id: number) =>
-  appClient.get(`/teams/${id}`).then((response) => response.data);
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
 
-const getTeamMembers = (id: number) =>
-  appClient.get(`/teams/${id}/members`).then((response) => response.data);
-
-const getTeamRollingpapers = (id: number) =>
-  appClient.get(`/teams/${id}/rollingpapers`).then((response) => {
-    return response.data;
-  });
-
-const getTeamWithInviteToken = (inviteToken: string) =>
-  appClient
-    .get(`/teams/invite?inviteToken=${inviteToken}`)
-    .then((response) => response.data);
-
-const getTeamMyNickname = (id: number) =>
-  appClient.get(`/teams/${id}/me`).then((response) => response.data);
-
-const postTeam = ({
+const postTeam = async ({
   name,
   description,
   emoji,
   color,
   nickname,
   secret,
-}: Omit<Team, "id" | "joined">) =>
-  appClient
-    .post("/teams", {
+}: Omit<Team, "id" | "joined">) => {
+  try {
+    const { data } = await appClient.post("/teams", {
       name,
       description,
       emoji,
       color,
       nickname,
       secret,
-    })
-    .then((response) => response.data);
+    });
 
-const postTeamInviteToken = ({ id }: Pick<Team, "id">) =>
-  appClient.post(`/teams/${id}/invite`).then((response) => response.data);
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
 
-const postTeamMember = ({ id, nickname }: Pick<Team, "id" | "nickname">) =>
-  appClient
-    .post(`/teams/${id}`, { nickname })
-    .then((response) => response.data);
+const postTeamInviteToken = async ({ id }: Pick<Team, "id">) => {
+  try {
+    const { data } = await appClient.post(`/teams/${id}/invite`);
 
-const postTeamMemberWithInviteToken = ({
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const postTeamMember = async ({
+  id,
+  nickname,
+}: Pick<Team, "id" | "nickname">) => {
+  try {
+    const { data } = await appClient.post(`/teams/${id}`, { nickname });
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const postTeamMemberWithInviteToken = async ({
   inviteToken,
   nickname,
-}: Pick<Team, "nickname"> & { inviteToken: string }) =>
-  appClient
-    .post(`/teams/invite/join`, { inviteToken, nickname })
-    .then((response) => response.data);
+}: Pick<Team, "nickname"> & { inviteToken: string }) => {
+  try {
+    const { data } = await appClient.post(`/teams/invite/join`, {
+      inviteToken,
+      nickname,
+    });
 
-const putTeamNickname = ({ id, nickname }: Pick<Team, "id" | "nickname">) =>
-  appClient
-    .put(`/teams/${id}/me`, { nickname })
-    .then((response) => response.data);
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
+
+const putTeamNickname = async ({
+  id,
+  nickname,
+}: Pick<Team, "id" | "nickname">) => {
+  try {
+    const { data } = await appClient.put(`/teams/${id}/me`, { nickname });
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      const customError = error.response.data as ApiError;
+      throw new ApiError(customError.errorCode, customError.message);
+    }
+  }
+};
 
 export {
   getMyTeams,

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-import { appClient } from "@/api";
+import { appClient, handleApiError } from "@/api";
 import ApiError from "@/util/ApiError";
 
 import { ApiOptions, Team } from "@/types";
@@ -20,15 +20,10 @@ const getMyTeams =
 
       return data;
     } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        const customError = error.response.data as ApiError;
-        const { errorCode, message } = customError;
-        throw new ApiError({
-          errorCode,
-          message,
-          errorHandler: options?.onError,
-        });
-      }
+      handleApiError({
+        error,
+        errorHandler: options?.onError,
+      });
     }
   };
 
@@ -42,15 +37,10 @@ const getTeamSearchResult =
 
       return data;
     } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
-        const customError = error.response.data as ApiError;
-        const { errorCode, message } = customError;
-        throw new ApiError({
-          errorCode,
-          message,
-          errorHandler: options?.onError,
-        });
-      }
+      handleApiError({
+        error,
+        errorHandler: options?.onError,
+      });
     }
   };
 
@@ -60,15 +50,10 @@ const getTeam = async (id: number, options?: ApiOptions) => {
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -78,15 +63,10 @@ const getTeamMembers = async (id: number, options?: ApiOptions) => {
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -96,15 +76,10 @@ const getTeamRollingpapers = async (id: number, options?: ApiOptions) => {
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -119,15 +94,10 @@ const getTeamWithInviteToken = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -139,15 +109,10 @@ const getTeamMyNickname = async (id: number, options?: ApiOptions) => {
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -174,15 +139,10 @@ const postTeam = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -195,15 +155,10 @@ const postTeamInviteToken = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -216,15 +171,10 @@ const postTeamMember = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -240,15 +190,10 @@ const postTeamMemberWithInviteToken = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 
@@ -261,15 +206,10 @@ const putTeamNickname = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiError;
-      const { errorCode, message } = customError;
-      throw new ApiError({
-        errorCode,
-        message,
-        errorHandler: options?.onError,
-      });
-    }
+    handleApiError({
+      error,
+      errorHandler: options?.onError,
+    });
   }
 };
 

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import { appClient } from "@/api";
 import ApiError from "@/util/ApiError";
 
-import { Team } from "@/types";
+import { ApiOptions, Team } from "@/types";
 
 interface SearchRequest {
   keyword: string;
@@ -11,7 +11,7 @@ interface SearchRequest {
 }
 
 const getMyTeams =
-  (teamPageCount = 5) =>
+  (teamPageCount = 5, options?: ApiOptions) =>
   async ({ pageParam = 0 }) => {
     try {
       const { data } = await appClient.get(
@@ -22,13 +22,18 @@ const getMyTeams =
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {
         const customError = error.response.data as ApiError;
-        throw new ApiError(customError.errorCode, customError.message);
+        const { errorCode, message } = customError;
+        throw new ApiError({
+          errorCode,
+          message,
+          errorHandler: options?.onError,
+        });
       }
     }
   };
 
 const getTeamSearchResult =
-  ({ keyword, count }: SearchRequest) =>
+  ({ keyword, count }: SearchRequest, options?: ApiOptions) =>
   async ({ pageParam = 0 }) => {
     try {
       const { data } = await appClient.get(
@@ -39,12 +44,17 @@ const getTeamSearchResult =
     } catch (error) {
       if (axios.isAxiosError(error) && error.response) {
         const customError = error.response.data as ApiError;
-        throw new ApiError(customError.errorCode, customError.message);
+        const { errorCode, message } = customError;
+        throw new ApiError({
+          errorCode,
+          message,
+          errorHandler: options?.onError,
+        });
       }
     }
   };
 
-const getTeam = async (id: number) => {
+const getTeam = async (id: number, options?: ApiOptions) => {
   try {
     const { data } = await appClient.get(`/teams/${id}`);
 
@@ -52,12 +62,17 @@ const getTeam = async (id: number) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const getTeamMembers = async (id: number) => {
+const getTeamMembers = async (id: number, options?: ApiOptions) => {
   try {
     const { data } = await appClient.get(`/teams/${id}/members`);
 
@@ -65,12 +80,17 @@ const getTeamMembers = async (id: number) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const getTeamRollingpapers = async (id: number) => {
+const getTeamRollingpapers = async (id: number, options?: ApiOptions) => {
   try {
     const { data } = await appClient.get(`/teams/${id}/rollingpapers`);
 
@@ -78,12 +98,20 @@ const getTeamRollingpapers = async (id: number) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const getTeamWithInviteToken = async (inviteToken: string) => {
+const getTeamWithInviteToken = async (
+  inviteToken: string,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.get(
       `/teams/invite?inviteToken=${inviteToken}`
@@ -93,12 +121,17 @@ const getTeamWithInviteToken = async (inviteToken: string) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const getTeamMyNickname = async (id: number) => {
+const getTeamMyNickname = async (id: number, options?: ApiOptions) => {
   try {
     const { data } = await appClient
       .get(`/teams/${id}/me`)
@@ -108,19 +141,27 @@ const getTeamMyNickname = async (id: number) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const postTeam = async ({
-  name,
-  description,
-  emoji,
-  color,
-  nickname,
-  secret,
-}: Omit<Team, "id" | "joined">) => {
+const postTeam = async (
+  {
+    name,
+    description,
+    emoji,
+    color,
+    nickname,
+    secret,
+  }: Omit<Team, "id" | "joined">,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.post("/teams", {
       name,
@@ -135,12 +176,20 @@ const postTeam = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const postTeamInviteToken = async ({ id }: Pick<Team, "id">) => {
+const postTeamInviteToken = async (
+  { id }: Pick<Team, "id">,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.post(`/teams/${id}/invite`);
 
@@ -148,15 +197,20 @@ const postTeamInviteToken = async ({ id }: Pick<Team, "id">) => {
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const postTeamMember = async ({
-  id,
-  nickname,
-}: Pick<Team, "id" | "nickname">) => {
+const postTeamMember = async (
+  { id, nickname }: Pick<Team, "id" | "nickname">,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.post(`/teams/${id}`, { nickname });
 
@@ -164,15 +218,20 @@ const postTeamMember = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const postTeamMemberWithInviteToken = async ({
-  inviteToken,
-  nickname,
-}: Pick<Team, "nickname"> & { inviteToken: string }) => {
+const postTeamMemberWithInviteToken = async (
+  { inviteToken, nickname }: Pick<Team, "nickname"> & { inviteToken: string },
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.post(`/teams/invite/join`, {
       inviteToken,
@@ -183,15 +242,20 @@ const postTeamMemberWithInviteToken = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };
 
-const putTeamNickname = async ({
-  id,
-  nickname,
-}: Pick<Team, "id" | "nickname">) => {
+const putTeamNickname = async (
+  { id, nickname }: Pick<Team, "id" | "nickname">,
+  options?: ApiOptions
+) => {
   try {
     const { data } = await appClient.put(`/teams/${id}/me`, { nickname });
 
@@ -199,7 +263,12 @@ const putTeamNickname = async ({
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
       const customError = error.response.data as ApiError;
-      throw new ApiError(customError.errorCode, customError.message);
+      const { errorCode, message } = customError;
+      throw new ApiError({
+        errorCode,
+        message,
+        errorHandler: options?.onError,
+      });
     }
   }
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -76,3 +76,7 @@ export type CustomError = {
 export type ValueOf<T> = T[keyof T];
 
 export type Recipient = ValueOf<typeof RECIPIENT>;
+
+export type ApiOptions = {
+  onError?: () => void;
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -80,3 +80,8 @@ export type Recipient = ValueOf<typeof RECIPIENT>;
 export type ApiOptions = {
   onError?: () => void;
 };
+
+export type ApiErrorResponse = {
+  errorCode: number;
+  message: string;
+};

--- a/frontend/src/util/ApiError.ts
+++ b/frontend/src/util/ApiError.ts
@@ -1,10 +1,14 @@
+type ErrorHandler = () => void;
+
 export default class ApiError extends Error {
   errorCode: number;
   message: string;
+  errorHandler: ErrorHandler | undefined;
 
-  constructor(errorCode: number, message: string) {
+  constructor(errorCode: number, message: string, errorHandler?: ErrorHandler) {
     super(message);
     this.errorCode = errorCode;
     this.message = message;
+    this.errorHandler = errorHandler;
   }
 }

--- a/frontend/src/util/ApiError.ts
+++ b/frontend/src/util/ApiError.ts
@@ -9,7 +9,7 @@ type ApiErrorArgs = {
 export default class ApiError extends Error {
   errorCode: number;
   message: string;
-  errorHandler: ErrorHandler | undefined;
+  errorHandler?: ErrorHandler;
 
   constructor({ errorCode, message, errorHandler }: ApiErrorArgs) {
     super(message);

--- a/frontend/src/util/ApiError.ts
+++ b/frontend/src/util/ApiError.ts
@@ -1,11 +1,17 @@
 type ErrorHandler = () => void;
 
+type ApiErrorArgs = {
+  errorCode: number;
+  message: string;
+  errorHandler?: ErrorHandler;
+};
+
 export default class ApiError extends Error {
   errorCode: number;
   message: string;
   errorHandler: ErrorHandler | undefined;
 
-  constructor(errorCode: number, message: string, errorHandler?: ErrorHandler) {
+  constructor({ errorCode, message, errorHandler }: ApiErrorArgs) {
     super(message);
     this.errorCode = errorCode;
     this.message = message;

--- a/frontend/src/util/ApiError.ts
+++ b/frontend/src/util/ApiError.ts
@@ -1,0 +1,10 @@
+export default class ApiError extends Error {
+  errorCode: number;
+  message: string;
+
+  constructor(errorCode: number, message: string) {
+    super(message);
+    this.errorCode = errorCode;
+    this.message = message;
+  }
+}


### PR DESCRIPTION
## 구현 사항
- 커스텀 에러 ApiError 정의 (errorCode, message, errorHandler를 가짐)
- API layer 함수에서 에러 발생 시 try-catch 문으로 ApiError throw 하도록 구현
- Api layer 함수에 option으로 onError 인자를 넘길 수 있도록 추가

### 위 구현 사항의 에러 처리 흐름
1. 호출된 api 함수는 api 요청을 보낸다. 이때 인자 option의 onError 속성으로 에러 핸들러와 함께 호출할 수 있다.
2. 요청 data를 받는 과정에서 에러 발생 시 catch 문에서 throw new ApiError로 커스텀 에러를 발생

### 참고사항
- API layer 함수에 option을 추가하되, 기존에 호출문에서 수정없이 사용하도록 작성해봤습니다. 
일관성을 생각하면 API 함수의 첫 번째 인자는 api request에 들어갈 인자를 담은 객체, 두 번째 인자는 options 객체 이렇게 정리해봐도 좋을 것 같은데 도리 의견 궁금합니다! 
- 커스텀 에러 관련해서 작성한 타입이 적절한지 확인해주세요.
- catch문의 코드들이 반복되는데 어떻게 정리하면 좋을지 고민입니다. try-catch문을 템플릿처럼 쓸 수 있도록 공통 함수를 만들면 어떨까요?

closed #169 