### PR TITLE
refactor: 타입스크립트 컨벤션에 맞게 수정한다.

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosError, AxiosResponse } from "axios";
+import axios, { AxiosError } from "axios";
 import { QueryClient } from "@tanstack/react-query";
 
 import ApiError from "@/util/ApiError";
@@ -16,8 +16,8 @@ const setAppClientHeaderAuthorization = (accessToken: string) => {
   appClient.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
 };
 
-const requestApi = async <T>(
-  request: () => Promise<AxiosResponse<T>>,
+const requestApi = async (
+  request: () => Promise<any>,
   options?: ApiOptions
 ) => {
   try {

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,9 +1,9 @@
-import axios from "axios";
+import axios, { AxiosError, AxiosResponse } from "axios";
 import { QueryClient } from "@tanstack/react-query";
 
 import ApiError from "@/util/ApiError";
 
-import { ApiErrorResponse, ApiOptions } from "@/types";
+import { ApiErrorResponse, ApiOptions } from "@/types/api";
 
 const appClient = axios.create({
   baseURL: process.env.API_URL,
@@ -16,8 +16,8 @@ const setAppClientHeaderAuthorization = (accessToken: string) => {
   appClient.defaults.headers.common["Authorization"] = `Bearer ${accessToken}`;
 };
 
-const requestApi = async (
-  request: () => Promise<any>,
+const requestApi = async <T>(
+  request: () => Promise<AxiosResponse<T>>,
   options?: ApiOptions
 ) => {
   try {
@@ -25,9 +25,11 @@ const requestApi = async (
 
     return data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      const customError = error.response.data as ApiErrorResponse;
-      const { errorCode, message } = customError;
+    const axiosError = error as AxiosError;
+
+    if (axiosError.response) {
+      const { errorCode, message } = axiosError.response
+        .data as ApiErrorResponse;
 
       throw new ApiError({
         errorCode,

--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -1,10 +1,10 @@
 import { appClient, requestApi } from "@/api";
 
-import { RequestKakaoOauthBody } from "@/types/oauth";
+import { KakaoOauthRequest } from "@/types/api";
 import { ApiOptions } from "@/types";
 
 const postKakaoOauth = async (
-  { authorizationCode, redirectUri }: RequestKakaoOauthBody,
+  { authorizationCode, redirectUri }: KakaoOauthRequest,
   options?: ApiOptions
 ) =>
   requestApi(

--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -2,13 +2,12 @@ import { appClient, requestApi } from "@/api";
 
 import { ApiOptions } from "@/types/api";
 import { postKakaoOauthRequest } from "@/types/apiRequest";
-import { PostKakaoOauthResponse } from "@/types/apiResponse";
 
 const postKakaoOauth = async (
   { authorizationCode, redirectUri }: postKakaoOauthRequest,
   options?: ApiOptions
 ) =>
-  requestApi<PostKakaoOauthResponse>(
+  requestApi(
     () =>
       appClient.post("/oauth/kakao", {
         authorizationCode,

--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -1,6 +1,6 @@
 import { appClient, requestApi } from "@/api";
 
-import { KakaoOauthRequest } from "@/types/api";
+import { KakaoOauthRequest } from "@/types/apiRequest";
 import { ApiOptions } from "@/types";
 
 const postKakaoOauth = async (

--- a/frontend/src/api/kakaoOauth.ts
+++ b/frontend/src/api/kakaoOauth.ts
@@ -1,13 +1,14 @@
 import { appClient, requestApi } from "@/api";
 
-import { KakaoOauthRequest } from "@/types/apiRequest";
-import { ApiOptions } from "@/types";
+import { ApiOptions } from "@/types/api";
+import { postKakaoOauthRequest } from "@/types/apiRequest";
+import { PostKakaoOauthResponse } from "@/types/apiResponse";
 
 const postKakaoOauth = async (
-  { authorizationCode, redirectUri }: KakaoOauthRequest,
+  { authorizationCode, redirectUri }: postKakaoOauthRequest,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<PostKakaoOauthResponse>(
     () =>
       appClient.post("/oauth/kakao", {
         authorizationCode,

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -1,27 +1,30 @@
 import { appClient, requestApi } from "@/api";
 
-import { ApiOptions } from "@/types";
+import { ApiOptions, UserInfo } from "@/types";
+import {
+  GetMyReceivedRollingpapersRequest,
+  GetMySentMessagesRequest,
+} from "@/types/api";
 
 const getMyInfo = async (options?: ApiOptions) =>
   requestApi(() => appClient.get("/members/me"), options);
 
 const getMyInfoWithAccessToken = async (
-  accessToken: string | null,
+  accessToken: string,
   options?: ApiOptions
 ) =>
   requestApi(
     () =>
       appClient.get("/members/me", {
         headers: {
-          Authorization: `Bearer ${accessToken || ""}`,
+          Authorization: `Bearer ${accessToken}`,
         },
       }),
     options
   );
 
 const getMyReceivedRollingpapers = async (
-  page = 0,
-  count = 5,
+  { page = 0, count = 5 }: GetMyReceivedRollingpapersRequest,
   options?: ApiOptions
 ) =>
   requestApi(
@@ -32,20 +35,25 @@ const getMyReceivedRollingpapers = async (
     options
   );
 
-const getMySentMessage = async (page = 0, count = 5, options?: ApiOptions) =>
+const getMySentMessages = async (
+  { page = 0, count = 5 }: GetMySentMessagesRequest,
+  options?: ApiOptions
+) =>
   requestApi(
     () =>
       appClient.get(`/members/me/messages/written?page=${page}&count=${count}`),
     options
   );
 
-const putMyNickname = async (username: string, options?: ApiOptions) =>
-  requestApi(() => appClient.put("/members/me", { username }), options);
+const putMyNickname = async (
+  username: UserInfo["username"],
+  options?: ApiOptions
+) => requestApi(() => appClient.put("/members/me", { username }), options);
 
 export {
   getMyInfo,
   getMyInfoWithAccessToken,
   getMyReceivedRollingpapers,
-  getMySentMessage,
+  getMySentMessages,
   putMyNickname,
 };

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -1,6 +1,6 @@
 import { appClient, requestApi } from "@/api";
 
-import { ApiOptions, UserInfo } from "@/types";
+import { ApiOptions, User } from "@/types";
 import {
   GetMyReceivedRollingpapersRequest,
   GetMySentMessagesRequest,
@@ -46,7 +46,7 @@ const getMySentMessages = async (
   );
 
 const putMyNickname = async (
-  username: UserInfo["username"],
+  username: User["username"],
   options?: ApiOptions
 ) => requestApi(() => appClient.put("/members/me", { username }), options);
 

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -8,19 +8,14 @@ import {
   GetMySentMessagesRequest,
 } from "@/types/apiRequest";
 
-import {
-  GetMyReceivedRollingpapersResponse,
-  GetMySentMessagesResponse,
-} from "@/types/apiResponse";
-
 const getMyInfo = async (options?: ApiOptions) =>
-  requestApi<User>(() => appClient.get("/members/me"), options);
+  requestApi(() => appClient.get("/members/me"), options);
 
 const getMyInfoWithAccessToken = async (
   accessToken: string,
   options?: ApiOptions
 ) =>
-  requestApi<User>(
+  requestApi(
     () =>
       appClient.get("/members/me", {
         headers: {
@@ -34,7 +29,7 @@ const getMyReceivedRollingpapers = async (
   { page = 0, count = 5 }: GetMyReceivedRollingpapersRequest,
   options?: ApiOptions
 ) =>
-  requestApi<GetMyReceivedRollingpapersResponse>(
+  requestApi(
     () =>
       appClient.get(
         `/members/me/rollingpapers/received?page=${page}&count=${count}`
@@ -46,7 +41,7 @@ const getMySentMessages = async (
   { page = 0, count = 5 }: GetMySentMessagesRequest,
   options?: ApiOptions
 ) =>
-  requestApi<GetMySentMessagesResponse>(
+  requestApi(
     () =>
       appClient.get(`/members/me/messages/written?page=${page}&count=${count}`),
     options

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -4,7 +4,7 @@ import { ApiOptions, User } from "@/types";
 import {
   GetMyReceivedRollingpapersRequest,
   GetMySentMessagesRequest,
-} from "@/types/api";
+} from "@/types/apiRequest";
 
 const getMyInfo = async (options?: ApiOptions) =>
   requestApi(() => appClient.get("/members/me"), options);

--- a/frontend/src/api/member.ts
+++ b/frontend/src/api/member.ts
@@ -1,19 +1,26 @@
 import { appClient, requestApi } from "@/api";
 
-import { ApiOptions, User } from "@/types";
+import { User } from "@/types";
+import { ApiOptions } from "@/types/api";
+
 import {
   GetMyReceivedRollingpapersRequest,
   GetMySentMessagesRequest,
 } from "@/types/apiRequest";
 
+import {
+  GetMyReceivedRollingpapersResponse,
+  GetMySentMessagesResponse,
+} from "@/types/apiResponse";
+
 const getMyInfo = async (options?: ApiOptions) =>
-  requestApi(() => appClient.get("/members/me"), options);
+  requestApi<User>(() => appClient.get("/members/me"), options);
 
 const getMyInfoWithAccessToken = async (
   accessToken: string,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<User>(
     () =>
       appClient.get("/members/me", {
         headers: {
@@ -27,7 +34,7 @@ const getMyReceivedRollingpapers = async (
   { page = 0, count = 5 }: GetMyReceivedRollingpapersRequest,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<GetMyReceivedRollingpapersResponse>(
     () =>
       appClient.get(
         `/members/me/rollingpapers/received?page=${page}&count=${count}`
@@ -39,7 +46,7 @@ const getMySentMessages = async (
   { page = 0, count = 5 }: GetMySentMessagesRequest,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<GetMySentMessagesResponse>(
     () =>
       appClient.get(`/members/me/messages/written?page=${page}&count=${count}`),
     options

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -8,13 +8,11 @@ import {
   DeleteMessageRequest,
 } from "@/types/apiRequest";
 
-import { PostMessageResponse } from "@/types/apiResponse";
-
 const postMessage = async (
   { rollingpaperId, content, color, anonymous, secret }: PostMessageRequest,
   options?: ApiOptions
 ) =>
-  requestApi<PostMessageResponse>(
+  requestApi(
     () =>
       appClient.post(`/rollingpapers/${rollingpaperId}/messages`, {
         content,

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -5,7 +5,7 @@ import {
   PostMessageRequest,
   PutMessageRequest,
   DeleteMessageRequest,
-} from "@/types/api";
+} from "@/types/apiRequest";
 
 const postMessage = async (
   { rollingpaperId, content, color, anonymous, secret }: PostMessageRequest,

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -1,29 +1,14 @@
 import { appClient, requestApi } from "@/api";
 
 import { ApiOptions } from "@/types";
-
-interface PutMessageRequest {
-  rollingpaperId: number;
-  id: number | null;
-  content: string;
-  color: string;
-  anonymous: boolean;
-  secret: boolean;
-}
-
-interface DeleteMessageRequest {
-  rollingpaperId: number;
-  id: number;
-}
+import {
+  PostMessageRequest,
+  PutMessageRequest,
+  DeleteMessageRequest,
+} from "@/types/api";
 
 const postMessage = async (
-  {
-    rollingpaperId,
-    content,
-    color,
-    anonymous,
-    secret,
-  }: Partial<PutMessageRequest>,
+  { rollingpaperId, content, color, anonymous, secret }: PostMessageRequest,
   options?: ApiOptions
 ) =>
   requestApi(

--- a/frontend/src/api/message.ts
+++ b/frontend/src/api/message.ts
@@ -1,17 +1,20 @@
 import { appClient, requestApi } from "@/api";
 
-import { ApiOptions } from "@/types";
+import { ApiOptions } from "@/types/api";
+
 import {
   PostMessageRequest,
   PutMessageRequest,
   DeleteMessageRequest,
 } from "@/types/apiRequest";
 
+import { PostMessageResponse } from "@/types/apiResponse";
+
 const postMessage = async (
   { rollingpaperId, content, color, anonymous, secret }: PostMessageRequest,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<PostMessageResponse>(
     () =>
       appClient.post(`/rollingpapers/${rollingpaperId}/messages`, {
         content,

--- a/frontend/src/api/rollingpaper.ts
+++ b/frontend/src/api/rollingpaper.ts
@@ -5,7 +5,7 @@ import {
   GetRollingpaperRequest,
   PostTeamRollingpaperRequest,
   PostMemberRollingpaperRequest,
-} from "@/types/api";
+} from "@/types/apiRequest";
 
 const getRollingpaper = async (
   { teamId, id }: GetRollingpaperRequest,

--- a/frontend/src/api/rollingpaper.ts
+++ b/frontend/src/api/rollingpaper.ts
@@ -8,17 +8,11 @@ import {
   PostMemberRollingpaperRequest,
 } from "@/types/apiRequest";
 
-import {
-  GetRollingpaperResponse,
-  PostMemberRollingpaperResponse,
-  PostTeamRollingpaperResponse,
-} from "@/types/apiResponse";
-
 const getRollingpaper = async (
   { teamId, id }: GetRollingpaperRequest,
   options?: ApiOptions
 ) =>
-  requestApi<GetRollingpaperResponse>(
+  requestApi(
     () => appClient.get(`/teams/${teamId}/rollingpapers/${id}`),
     options
   );
@@ -27,7 +21,7 @@ const postTeamRollingpaper = async (
   { teamId, title }: PostTeamRollingpaperRequest,
   options?: ApiOptions
 ) =>
-  requestApi<PostTeamRollingpaperResponse>(
+  requestApi(
     () =>
       appClient.post(`/teams/${teamId}/team-rollingpapers`, {
         title,
@@ -39,7 +33,7 @@ const postMemberRollingpaper = async (
   { teamId, title, addresseeId }: PostMemberRollingpaperRequest,
   options?: ApiOptions
 ) =>
-  requestApi<PostMemberRollingpaperResponse>(
+  requestApi(
     () =>
       appClient.post(`/teams/${teamId}/rollingpapers`, {
         title,

--- a/frontend/src/api/rollingpaper.ts
+++ b/frontend/src/api/rollingpaper.ts
@@ -1,16 +1,14 @@
 import { appClient, requestApi } from "@/api";
 
 import { ApiOptions } from "@/types";
-
-interface RequestPostRollingpaper {
-  teamId: number;
-  title: string;
-  addresseeId: number;
-}
+import {
+  GetRollingpaperRequest,
+  PostTeamRollingpaperRequest,
+  PostMemberRollingpaperRequest,
+} from "@/types/api";
 
 const getRollingpaper = async (
-  teamId: number,
-  id: number,
+  { teamId, id }: GetRollingpaperRequest,
   options?: ApiOptions
 ) =>
   requestApi(
@@ -19,7 +17,7 @@ const getRollingpaper = async (
   );
 
 const postTeamRollingpaper = async (
-  { teamId, title }: Omit<RequestPostRollingpaper, "addresseeId">,
+  { teamId, title }: PostTeamRollingpaperRequest,
   options?: ApiOptions
 ) =>
   requestApi(
@@ -31,7 +29,7 @@ const postTeamRollingpaper = async (
   );
 
 const postMemberRollingpaper = async (
-  { teamId, title, addresseeId }: RequestPostRollingpaper,
+  { teamId, title, addresseeId }: PostMemberRollingpaperRequest,
   options?: ApiOptions
 ) =>
   requestApi(

--- a/frontend/src/api/rollingpaper.ts
+++ b/frontend/src/api/rollingpaper.ts
@@ -1,17 +1,24 @@
 import { appClient, requestApi } from "@/api";
 
-import { ApiOptions } from "@/types";
+import { ApiOptions } from "@/types/api";
+
 import {
   GetRollingpaperRequest,
   PostTeamRollingpaperRequest,
   PostMemberRollingpaperRequest,
 } from "@/types/apiRequest";
 
+import {
+  GetRollingpaperResponse,
+  PostMemberRollingpaperResponse,
+  PostTeamRollingpaperResponse,
+} from "@/types/apiResponse";
+
 const getRollingpaper = async (
   { teamId, id }: GetRollingpaperRequest,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<GetRollingpaperResponse>(
     () => appClient.get(`/teams/${teamId}/rollingpapers/${id}`),
     options
   );
@@ -20,7 +27,7 @@ const postTeamRollingpaper = async (
   { teamId, title }: PostTeamRollingpaperRequest,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<PostTeamRollingpaperResponse>(
     () =>
       appClient.post(`/teams/${teamId}/team-rollingpapers`, {
         title,
@@ -32,7 +39,7 @@ const postMemberRollingpaper = async (
   { teamId, title, addresseeId }: PostMemberRollingpaperRequest,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<PostMemberRollingpaperResponse>(
     () =>
       appClient.post(`/teams/${teamId}/rollingpapers`, {
         title,

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -9,26 +9,14 @@ import {
   PostTeamMemberWithInviteTokenRequest,
 } from "@/types/apiRequest";
 
-import {
-  GetTeamResponse,
-  GetTeamWithInviteTokenResponse,
-  GetMyTeamsResponse,
-  GetTeamSearchResultResponse,
-  GetTeamMembersResponse,
-  GetTeamRollingpapersResponse,
-  GetTeamMyNicknameResponse,
-  PostTeamResponse,
-  PostTeamInviteTokenResponse,
-} from "@/types/apiResponse";
-
 const getTeam = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi<GetTeamResponse>(() => appClient.get(`/teams/${id}`), options);
+  requestApi(() => appClient.get(`/teams/${id}`), options);
 
 const getTeamWithInviteToken = async (
   inviteToken: string,
   options?: ApiOptions
 ) =>
-  requestApi<GetTeamWithInviteTokenResponse>(
+  requestApi(
     () => appClient.get(`/teams/invite?inviteToken=${inviteToken}`),
     options
   );
@@ -36,7 +24,7 @@ const getTeamWithInviteToken = async (
 const getMyTeams =
   (teamPageCount = 5, options?: ApiOptions) =>
   async ({ pageParam = 0 }) =>
-    requestApi<GetMyTeamsResponse>(
+    requestApi(
       () => appClient.get(`teams/me?page=${pageParam}&count=${teamPageCount}`),
       options
     );
@@ -44,7 +32,7 @@ const getMyTeams =
 const getTeamSearchResult =
   ({ keyword, count }: GetTeamSearchResultRequest, options?: ApiOptions) =>
   async ({ pageParam = 0 }) =>
-    requestApi<GetTeamSearchResultResponse>(
+    requestApi(
       () =>
         appClient.get(
           `teams?keyword=${keyword}&page=${pageParam}&count=${count}`
@@ -53,19 +41,13 @@ const getTeamSearchResult =
     );
 
 const getTeamMembers = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi<GetTeamMembersResponse>(
-    () => appClient.get(`/teams/${id}/members`),
-    options
-  );
+  requestApi(() => appClient.get(`/teams/${id}/members`), options);
 
 const getTeamRollingpapers = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi<GetTeamRollingpapersResponse>(
-    () => appClient.get(`/teams/${id}/rollingpapers`),
-    options
-  );
+  requestApi(() => appClient.get(`/teams/${id}/rollingpapers`), options);
 
 const getTeamMyNickname = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi<GetTeamMyNicknameResponse>(
+  requestApi(
     () => appClient.get(`/teams/${id}/me`).then((response) => response.data),
     options
   );
@@ -74,7 +56,7 @@ const postTeam = async (
   { name, description, emoji, color, nickname, secret }: PostTeamRequest,
   options?: ApiOptions
 ) =>
-  requestApi<PostTeamResponse>(
+  requestApi(
     () =>
       appClient.post("/teams", {
         name,
@@ -106,10 +88,7 @@ const postTeamMemberWithInviteToken = async (
   );
 
 const postTeamInviteToken = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi<PostTeamInviteTokenResponse>(
-    () => appClient.post(`/teams/${id}/invite`),
-    options
-  );
+  requestApi(() => appClient.post(`/teams/${id}/invite`), options);
 
 const putTeamNickname = async (
   { id, nickname }: TeamMember,

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -1,16 +1,42 @@
 import { appClient, requestApi } from "@/api";
 
-import { ApiOptions, Team, TeamMember } from "@/types";
+import { Team, TeamMember } from "@/types";
+import { ApiOptions } from "@/types/api";
+
 import {
   GetTeamSearchResultRequest,
   PostTeamRequest,
   PostTeamMemberWithInviteTokenRequest,
 } from "@/types/apiRequest";
 
+import {
+  GetTeamResponse,
+  GetTeamWithInviteTokenResponse,
+  GetMyTeamsResponse,
+  GetTeamSearchResultResponse,
+  GetTeamMembersResponse,
+  GetTeamRollingpapersResponse,
+  GetTeamMyNicknameResponse,
+  PostTeamResponse,
+  PostTeamInviteTokenResponse,
+} from "@/types/apiResponse";
+
+const getTeam = async (id: Team["id"], options?: ApiOptions) =>
+  requestApi<GetTeamResponse>(() => appClient.get(`/teams/${id}`), options);
+
+const getTeamWithInviteToken = async (
+  inviteToken: string,
+  options?: ApiOptions
+) =>
+  requestApi<GetTeamWithInviteTokenResponse>(
+    () => appClient.get(`/teams/invite?inviteToken=${inviteToken}`),
+    options
+  );
+
 const getMyTeams =
   (teamPageCount = 5, options?: ApiOptions) =>
   async ({ pageParam = 0 }) =>
-    requestApi(
+    requestApi<GetMyTeamsResponse>(
       () => appClient.get(`teams/me?page=${pageParam}&count=${teamPageCount}`),
       options
     );
@@ -18,7 +44,7 @@ const getMyTeams =
 const getTeamSearchResult =
   ({ keyword, count }: GetTeamSearchResultRequest, options?: ApiOptions) =>
   async ({ pageParam = 0 }) =>
-    requestApi(
+    requestApi<GetTeamSearchResultResponse>(
       () =>
         appClient.get(
           `teams?keyword=${keyword}&page=${pageParam}&count=${count}`
@@ -26,26 +52,20 @@ const getTeamSearchResult =
       options
     );
 
-const getTeam = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi(() => appClient.get(`/teams/${id}`), options);
-
 const getTeamMembers = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi(() => appClient.get(`/teams/${id}/members`), options);
+  requestApi<GetTeamMembersResponse>(
+    () => appClient.get(`/teams/${id}/members`),
+    options
+  );
 
 const getTeamRollingpapers = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi(() => appClient.get(`/teams/${id}/rollingpapers`), options);
-
-const getTeamWithInviteToken = async (
-  inviteToken: string,
-  options?: ApiOptions
-) =>
-  requestApi(
-    () => appClient.get(`/teams/invite?inviteToken=${inviteToken}`),
+  requestApi<GetTeamRollingpapersResponse>(
+    () => appClient.get(`/teams/${id}/rollingpapers`),
     options
   );
 
 const getTeamMyNickname = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi(
+  requestApi<GetTeamMyNicknameResponse>(
     () => appClient.get(`/teams/${id}/me`).then((response) => response.data),
     options
   );
@@ -54,7 +74,7 @@ const postTeam = async (
   { name, description, emoji, color, nickname, secret }: PostTeamRequest,
   options?: ApiOptions
 ) =>
-  requestApi(
+  requestApi<PostTeamResponse>(
     () =>
       appClient.post("/teams", {
         name,
@@ -66,9 +86,6 @@ const postTeam = async (
       }),
     options
   );
-
-const postTeamInviteToken = async (id: Team["id"], options?: ApiOptions) =>
-  requestApi(() => appClient.post(`/teams/${id}/invite`), options);
 
 const postTeamMember = async (
   { id, nickname }: TeamMember,
@@ -85,6 +102,12 @@ const postTeamMemberWithInviteToken = async (
         inviteToken,
         nickname,
       }),
+    options
+  );
+
+const postTeamInviteToken = async (id: Team["id"], options?: ApiOptions) =>
+  requestApi<PostTeamInviteTokenResponse>(
+    () => appClient.post(`/teams/${id}/invite`),
     options
   );
 

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -1,11 +1,11 @@
 import { appClient, requestApi } from "@/api";
 
-import { ApiOptions, Team } from "@/types";
-
-interface SearchRequest {
-  keyword: string;
-  count: number;
-}
+import { ApiOptions, Team, TeamMember } from "@/types";
+import {
+  GetTeamSearchResultRequest,
+  PostTeamRequest,
+  PostTeamMemberWithInviteTokenRequest,
+} from "@/types/api";
 
 const getMyTeams =
   (teamPageCount = 5, options?: ApiOptions) =>
@@ -16,7 +16,7 @@ const getMyTeams =
     );
 
 const getTeamSearchResult =
-  ({ keyword, count }: SearchRequest, options?: ApiOptions) =>
+  ({ keyword, count }: GetTeamSearchResultRequest, options?: ApiOptions) =>
   async ({ pageParam = 0 }) =>
     requestApi(
       () =>
@@ -26,13 +26,13 @@ const getTeamSearchResult =
       options
     );
 
-const getTeam = async (id: number, options?: ApiOptions) =>
+const getTeam = async (id: Team["id"], options?: ApiOptions) =>
   requestApi(() => appClient.get(`/teams/${id}`), options);
 
-const getTeamMembers = async (id: number, options?: ApiOptions) =>
+const getTeamMembers = async (id: Team["id"], options?: ApiOptions) =>
   requestApi(() => appClient.get(`/teams/${id}/members`), options);
 
-const getTeamRollingpapers = async (id: number, options?: ApiOptions) =>
+const getTeamRollingpapers = async (id: Team["id"], options?: ApiOptions) =>
   requestApi(() => appClient.get(`/teams/${id}/rollingpapers`), options);
 
 const getTeamWithInviteToken = async (
@@ -44,21 +44,14 @@ const getTeamWithInviteToken = async (
     options
   );
 
-const getTeamMyNickname = async (id: number, options?: ApiOptions) =>
+const getTeamMyNickname = async (id: Team["id"], options?: ApiOptions) =>
   requestApi(
     () => appClient.get(`/teams/${id}/me`).then((response) => response.data),
     options
   );
 
 const postTeam = async (
-  {
-    name,
-    description,
-    emoji,
-    color,
-    nickname,
-    secret,
-  }: Omit<Team, "id" | "joined">,
+  { name, description, emoji, color, nickname, secret }: PostTeamRequest,
   options?: ApiOptions
 ) =>
   requestApi(
@@ -74,18 +67,16 @@ const postTeam = async (
     options
   );
 
-const postTeamInviteToken = async (
-  { id }: Pick<Team, "id">,
-  options?: ApiOptions
-) => requestApi(() => appClient.post(`/teams/${id}/invite`), options);
+const postTeamInviteToken = async (id: Team["id"], options?: ApiOptions) =>
+  requestApi(() => appClient.post(`/teams/${id}/invite`), options);
 
 const postTeamMember = async (
-  { id, nickname }: Pick<Team, "id" | "nickname">,
+  { id, nickname }: TeamMember,
   options?: ApiOptions
 ) => requestApi(() => appClient.post(`/teams/${id}`, { nickname }), options);
 
 const postTeamMemberWithInviteToken = async (
-  { inviteToken, nickname }: Pick<Team, "nickname"> & { inviteToken: string },
+  { inviteToken, nickname }: PostTeamMemberWithInviteTokenRequest,
   options?: ApiOptions
 ) =>
   requestApi(
@@ -98,7 +89,7 @@ const postTeamMemberWithInviteToken = async (
   );
 
 const putTeamNickname = async (
-  { id, nickname }: Pick<Team, "id" | "nickname">,
+  { id, nickname }: TeamMember,
   options?: ApiOptions
 ) => requestApi(() => appClient.put(`/teams/${id}/me`, { nickname }), options);
 

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -5,7 +5,7 @@ import {
   GetTeamSearchResultRequest,
   PostTeamRequest,
   PostTeamMemberWithInviteTokenRequest,
-} from "@/types/api";
+} from "@/types/apiRequest";
 
 const getMyTeams =
   (teamPageCount = 5, options?: ApiOptions) =>

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -40,8 +40,8 @@ const KAKAO_OAUTH_URL = {
 };
 
 const RECIPIENT = {
-  TEAM: "team",
-  MEMBER: "member",
+  TEAM: "TEAM",
+  MEMBER: "MEMBER",
 } as const;
 
 export {

--- a/frontend/src/hooks/useAutoLogin.tsx
+++ b/frontend/src/hooks/useAutoLogin.tsx
@@ -5,7 +5,7 @@ import { setAppClientHeaderAuthorization } from "@/api";
 import { getMyInfoWithAccessToken } from "@/api/member";
 
 import { getCookie } from "@/util/cookie";
-import { UserInfo } from "@/types/index";
+import { User } from "@/types/index";
 
 const COOKIE_KEY = {
   ACCESS_TOKEN: "accessToken",
@@ -14,7 +14,7 @@ const COOKIE_KEY = {
 function useAutoLogin() {
   const accessTokenCookie = getCookie(COOKIE_KEY.ACCESS_TOKEN);
 
-  return useQuery<UserInfo>(
+  return useQuery<User>(
     ["memberId"],
     () => getMyInfoWithAccessToken(accessTokenCookie!),
     {

--- a/frontend/src/hooks/useAutoLogin.tsx
+++ b/frontend/src/hooks/useAutoLogin.tsx
@@ -16,12 +16,11 @@ function useAutoLogin() {
 
   return useQuery<UserInfo>(
     ["memberId"],
-    () => getMyInfoWithAccessToken(accessTokenCookie),
-
+    () => getMyInfoWithAccessToken(accessTokenCookie!),
     {
       enabled: !!accessTokenCookie,
       onSuccess: () => {
-        setAppClientHeaderAuthorization(accessTokenCookie || "");
+        setAppClientHeaderAuthorization(accessTokenCookie!);
       },
     }
   );

--- a/frontend/src/hooks/useAutoLogin.tsx
+++ b/frontend/src/hooks/useAutoLogin.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { setAppClientHeaderAuthorization } from "@/api";
@@ -14,7 +13,7 @@ const COOKIE_KEY = {
 function useAutoLogin() {
   const accessTokenCookie = getCookie(COOKIE_KEY.ACCESS_TOKEN);
 
-  return useQuery<User>(
+  return useQuery(
     ["memberId"],
     () => getMyInfoWithAccessToken(accessTokenCookie!),
     {

--- a/frontend/src/pages/InvitePage/hooks/useCheckLogin.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useCheckLogin.tsx
@@ -1,9 +1,8 @@
-import React, { useContext } from "react";
+import { useContext } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { useSnackbar } from "@/context/SnackbarContext";
 import { UserContext } from "@/context/UserContext";
-
 
 const useCheckLogin = (inviteToken: string) => {
   const navigate = useNavigate();

--- a/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
@@ -8,9 +8,9 @@ import { useSnackbar } from "@/context/SnackbarContext";
 import { postTeamMemberWithInviteToken } from "@/api/team";
 
 import { CustomError } from "@/types";
-import { PostTeamMemberWithInviteTokenRequest } from "@/types/api";
+import { PostTeamMemberWithInviteTokenRequest } from "@/types/apiRequest";
 
-const useJoinTeamWithInviteToken = (teamId: number | undefined) => {
+const useJoinTeamWithInviteToken = (teamId?: number) => {
   const navigate = useNavigate();
   const { openSnackbar } = useSnackbar();
 

--- a/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import axios from "axios";

--- a/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useJoinTeamWithInviteToken.tsx
@@ -3,21 +3,19 @@ import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import axios from "axios";
 
-import { postTeamMemberWithInviteToken } from "@/api/team";
-
-import { CustomError, Team } from "@/types";
 import { useSnackbar } from "@/context/SnackbarContext";
 
-type RequestJoinTeamWithInviteToken = Pick<Team, "nickname"> & {
-  inviteToken: string;
-};
+import { postTeamMemberWithInviteToken } from "@/api/team";
+
+import { CustomError } from "@/types";
+import { PostTeamMemberWithInviteTokenRequest } from "@/types/api";
 
 const useJoinTeamWithInviteToken = (teamId: number | undefined) => {
   const navigate = useNavigate();
   const { openSnackbar } = useSnackbar();
 
   const { mutate: joinTeamWithInviteToken } = useMutation(
-    ({ inviteToken, nickname }: RequestJoinTeamWithInviteToken) => {
+    ({ inviteToken, nickname }: PostTeamMemberWithInviteTokenRequest) => {
       return postTeamMemberWithInviteToken({
         inviteToken,
         nickname,

--- a/frontend/src/pages/InvitePage/hooks/useTeamDetailWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useTeamDetailWithInviteToken.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getTeamWithInviteToken } from "@/api/team";
@@ -16,7 +15,7 @@ const useTeamDetailWithInviteToken = ({
   onSuccess,
   onError,
 }: UseTeamDetailWithInviteTokenArgs) => {
-  return useQuery<Team>(
+  return useQuery(
     ["teamDetailWithInviteToken", inviteToken],
     () => getTeamWithInviteToken(inviteToken),
     { onSuccess, onError }

--- a/frontend/src/pages/InvitePage/hooks/useTeamDetailWithInviteToken.tsx
+++ b/frontend/src/pages/InvitePage/hooks/useTeamDetailWithInviteToken.tsx
@@ -7,8 +7,8 @@ import { Team } from "@/types";
 
 type UseTeamDetailWithInviteTokenArgs = {
   inviteToken: string;
-  onSuccess?: ((data: Team) => void) | undefined;
-  onError?: ((err: unknown) => void) | undefined;
+  onSuccess?: (data: Team) => void;
+  onError?: (err: unknown) => void;
 };
 
 const useTeamDetailWithInviteToken = ({

--- a/frontend/src/pages/KakaoRedirectPage/index.tsx
+++ b/frontend/src/pages/KakaoRedirectPage/index.tsx
@@ -8,7 +8,7 @@ import { UserContext } from "@/context/UserContext";
 import { postKakaoOauth } from "@/api/kakaoOauth";
 
 import { CustomError } from "@/types";
-import { KakaoOauthRequest } from "@/types/api";
+import { KakaoOauthRequest } from "@/types/apiRequest";
 
 const KakaoRedirectPage = () => {
   const navigate = useNavigate();

--- a/frontend/src/pages/KakaoRedirectPage/index.tsx
+++ b/frontend/src/pages/KakaoRedirectPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useContext } from "react";
+import { useEffect, useContext } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import axios from "axios";
@@ -8,31 +8,34 @@ import { UserContext } from "@/context/UserContext";
 import { postKakaoOauth } from "@/api/kakaoOauth";
 
 import { CustomError } from "@/types";
-import { KakaoOauthRequest } from "@/types/apiRequest";
+import { postKakaoOauthRequest } from "@/types/apiRequest";
 
 const KakaoRedirectPage = () => {
   const navigate = useNavigate();
   const { login } = useContext(UserContext);
+
   const params = new URLSearchParams(useLocation().search);
   const authorizationCode = params.get("code");
   const inviteToken = params.get("state");
 
   const { mutate: kakaoOauthLogin } = useMutation(
-    ({ authorizationCode, redirectUri }: KakaoOauthRequest) =>
+    ({ authorizationCode, redirectUri }: postKakaoOauthRequest) =>
       postKakaoOauth({
         authorizationCode,
         redirectUri,
       }),
     {
       onSuccess: (data) => {
-        login(data.accessToken, data.id);
+        if (data) {
+          login(data.accessToken, data.id);
 
-        if (inviteToken) {
-          navigate(`/invite/${inviteToken}`, { replace: true });
-          return;
+          if (inviteToken) {
+            navigate(`/invite/${inviteToken}`, { replace: true });
+            return;
+          }
+
+          navigate("/", { replace: true });
         }
-
-        navigate("/", { replace: true });
       },
       onError: (error) => {
         if (axios.isAxiosError(error) && error.response) {

--- a/frontend/src/pages/KakaoRedirectPage/index.tsx
+++ b/frontend/src/pages/KakaoRedirectPage/index.tsx
@@ -8,7 +8,7 @@ import { UserContext } from "@/context/UserContext";
 import { postKakaoOauth } from "@/api/kakaoOauth";
 
 import { CustomError } from "@/types";
-import { RequestKakaoOauthBody } from "@/types/oauth";
+import { KakaoOauthRequest } from "@/types/api";
 
 const KakaoRedirectPage = () => {
   const navigate = useNavigate();
@@ -18,7 +18,7 @@ const KakaoRedirectPage = () => {
   const inviteToken = params.get("state");
 
   const { mutate: kakaoOauthLogin } = useMutation(
-    ({ authorizationCode, redirectUri }: RequestKakaoOauthBody) =>
+    ({ authorizationCode, redirectUri }: KakaoOauthRequest) =>
       postKakaoOauth({
         authorizationCode,
         redirectUri,

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import axios from "axios";
 import styled from "@emotion/styled";
@@ -13,11 +12,6 @@ import useIntersect from "@/hooks/useIntersect";
 
 const TEAM_PAGING_COUNT = 10;
 
-interface MyTeamListResponse {
-  teams: Team[];
-  currentPage: number;
-  totalCount: number;
-}
 interface Team {
   id: number;
   name: string;
@@ -45,17 +39,16 @@ const MainPage = () => {
     isFetching,
     isError,
     isLoading,
-  } = useInfiniteQuery<MyTeamListResponse>(
-    ["my-teams"],
-    getMyTeams(TEAM_PAGING_COUNT),
-    {
-      getNextPageParam: (lastPage) => {
-        if (lastPage.currentPage * TEAM_PAGING_COUNT < lastPage.totalCount) {
-          return lastPage.currentPage + 1;
-        }
-      },
-    }
-  );
+  } = useInfiniteQuery(["my-teams"], getMyTeams(TEAM_PAGING_COUNT), {
+    getNextPageParam: (lastPage) => {
+      if (
+        lastPage &&
+        lastPage.currentPage * TEAM_PAGING_COUNT < lastPage.totalCount
+      ) {
+        return lastPage.currentPage + 1;
+      }
+    },
+  });
 
   if (isLoading) {
     return <div>로딩 중</div>;
@@ -73,7 +66,7 @@ const MainPage = () => {
     return <div>에러</div>;
   }
 
-  if (myTeamListResponse.pages[0].teams.length === 0) {
+  if (myTeamListResponse.pages[0]?.teams.length === 0) {
     return (
       <StyledEmptyMain>
         <EmptyMyTeamList />
@@ -85,7 +78,7 @@ const MainPage = () => {
     <StyledMain>
       <StyledCardList>
         {myTeamListResponse.pages.map((page) =>
-          page.teams.map(({ id, name, description, emoji, color }: Team) => (
+          page!.teams.map(({ id, name, description, emoji, color }: Team) => (
             <MyTeamCard
               key={id}
               id={id}

--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -41,10 +41,7 @@ const MainPage = () => {
     isLoading,
   } = useInfiniteQuery(["my-teams"], getMyTeams(TEAM_PAGING_COUNT), {
     getNextPageParam: (lastPage) => {
-      if (
-        lastPage &&
-        lastPage.currentPage * TEAM_PAGING_COUNT < lastPage.totalCount
-      ) {
+      if (lastPage.currentPage * TEAM_PAGING_COUNT < lastPage.totalCount) {
         return lastPage.currentPage + 1;
       }
     },
@@ -78,7 +75,7 @@ const MainPage = () => {
     <StyledMain>
       <StyledCardList>
         {myTeamListResponse.pages.map((page) =>
-          page!.teams.map(({ id, name, description, emoji, color }: Team) => (
+          page.teams.map(({ id, name, description, emoji, color }: Team) => (
             <MyTeamCard
               key={id}
               id={id}

--- a/frontend/src/pages/MyPage/components/MessageList.tsx
+++ b/frontend/src/pages/MyPage/components/MessageList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import styled from "@emotion/styled";
 
-import { getMySentMessage } from "@/api/member";
+import { getMySentMessages } from "@/api/member";
 
 import MessageListItem from "@/pages/MyPage/components/MessageListItem";
 import Paging from "@/components/Paging";
@@ -23,7 +23,11 @@ const MessageList = ({ lastPage }: MessageListProp) => {
 
   const { isLoading, isError, error, data } = useQuery<ResponseSentMessages>(
     ["sent-messages", currentPage],
-    () => getMySentMessage(currentPage, MYPAGE_MESSAGE_PAGING_COUNT),
+    () =>
+      getMySentMessages({
+        page: currentPage,
+        count: MYPAGE_MESSAGE_PAGING_COUNT,
+      }),
     { keepPreviousData: true }
   );
 

--- a/frontend/src/pages/MyPage/components/MessageList.tsx
+++ b/frontend/src/pages/MyPage/components/MessageList.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import styled from "@emotion/styled";
 
@@ -10,7 +9,6 @@ import Paging from "@/components/Paging";
 import EmptyStateImg from "@/assets/images/empty-state.svg";
 import { MYPAGE_MESSAGE_PAGING_COUNT } from "@/constants";
 
-import { ResponseSentMessages } from "@/types";
 import usePaging from "@/hooks/usePaging";
 
 interface MessageListProp {
@@ -21,7 +19,7 @@ const MessageList = ({ lastPage }: MessageListProp) => {
   const { currentPage, handleNumberClick, handleNextClick, handlePrevClick } =
     usePaging(lastPage);
 
-  const { isLoading, isError, error, data } = useQuery<ResponseSentMessages>(
+  const { isLoading, isError, error, data } = useQuery(
     ["sent-messages", currentPage],
     () =>
       getMySentMessages({

--- a/frontend/src/pages/MyPage/components/MessageList.tsx
+++ b/frontend/src/pages/MyPage/components/MessageList.tsx
@@ -10,6 +10,7 @@ import EmptyStateImg from "@/assets/images/empty-state.svg";
 import { MYPAGE_MESSAGE_PAGING_COUNT } from "@/constants";
 
 import usePaging from "@/hooks/usePaging";
+import { GetMySentMessagesResponse } from "@/types/apiResponse";
 
 interface MessageListProp {
   lastPage: number;
@@ -19,15 +20,16 @@ const MessageList = ({ lastPage }: MessageListProp) => {
   const { currentPage, handleNumberClick, handleNextClick, handlePrevClick } =
     usePaging(lastPage);
 
-  const { isLoading, isError, error, data } = useQuery(
-    ["sent-messages", currentPage],
-    () =>
-      getMySentMessages({
-        page: currentPage,
-        count: MYPAGE_MESSAGE_PAGING_COUNT,
-      }),
-    { keepPreviousData: true }
-  );
+  const { isLoading, isError, error, data } =
+    useQuery<GetMySentMessagesResponse>(
+      ["sent-messages", currentPage],
+      () =>
+        getMySentMessages({
+          page: currentPage,
+          count: MYPAGE_MESSAGE_PAGING_COUNT,
+        }),
+      { keepPreviousData: true }
+    );
 
   if (isError || !data) {
     return <div>에러</div>;

--- a/frontend/src/pages/MyPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperList.tsx
@@ -10,6 +10,7 @@ import { getMyReceivedRollingpapers } from "@/api/member";
 import { MYPAGE_ROLLINGPAPER_PAGING_COUNT } from "@/constants";
 
 import EmptyStateImg from "@/assets/images/empty-state.svg";
+import { GetMyReceivedRollingpapersResponse } from "@/types/apiResponse";
 
 interface RollingpaperListProp {
   lastPage: number;
@@ -19,15 +20,16 @@ const RollingpaperList = ({ lastPage }: RollingpaperListProp) => {
   const { currentPage, handleNumberClick, handleNextClick, handlePrevClick } =
     usePaging(lastPage);
 
-  const { isLoading, isError, error, data } = useQuery(
-    ["received-rollingpapers", currentPage],
-    () =>
-      getMyReceivedRollingpapers({
-        page: currentPage,
-        count: MYPAGE_ROLLINGPAPER_PAGING_COUNT,
-      }),
-    { keepPreviousData: true }
-  );
+  const { isLoading, isError, error, data } =
+    useQuery<GetMyReceivedRollingpapersResponse>(
+      ["received-rollingpapers", currentPage],
+      () =>
+        getMyReceivedRollingpapers({
+          page: currentPage,
+          count: MYPAGE_ROLLINGPAPER_PAGING_COUNT,
+        }),
+      { keepPreviousData: true }
+    );
 
   if (isError || !data) {
     return <div>에러</div>;

--- a/frontend/src/pages/MyPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperList.tsx
@@ -25,10 +25,10 @@ const RollingpaperList = ({ lastPage }: RollingpaperListProp) => {
     useQuery<ResponseReceivedRollingpapers>(
       ["received-rollingpapers", currentPage],
       () =>
-        getMyReceivedRollingpapers(
-          currentPage,
-          MYPAGE_ROLLINGPAPER_PAGING_COUNT
-        ),
+        getMyReceivedRollingpapers({
+          page: currentPage,
+          count: MYPAGE_ROLLINGPAPER_PAGING_COUNT,
+        }),
       { keepPreviousData: true }
     );
 

--- a/frontend/src/pages/MyPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/MyPage/components/RollingpaperList.tsx
@@ -1,17 +1,15 @@
-import React from "react";
 import { useQuery } from "@tanstack/react-query";
 import styled from "@emotion/styled";
-
-import { getMyReceivedRollingpapers } from "@/api/member";
 
 import RollingpaperListItem from "@/pages/MyPage/components/RollingpaperListItem";
 import Paging from "@/components/Paging";
 
-import EmptyStateImg from "@/assets/images/empty-state.svg";
+import usePaging from "@/hooks/usePaging";
+
+import { getMyReceivedRollingpapers } from "@/api/member";
 import { MYPAGE_ROLLINGPAPER_PAGING_COUNT } from "@/constants";
 
-import { ResponseReceivedRollingpapers } from "@/types";
-import usePaging from "@/hooks/usePaging";
+import EmptyStateImg from "@/assets/images/empty-state.svg";
 
 interface RollingpaperListProp {
   lastPage: number;
@@ -21,16 +19,15 @@ const RollingpaperList = ({ lastPage }: RollingpaperListProp) => {
   const { currentPage, handleNumberClick, handleNextClick, handlePrevClick } =
     usePaging(lastPage);
 
-  const { isLoading, isError, error, data } =
-    useQuery<ResponseReceivedRollingpapers>(
-      ["received-rollingpapers", currentPage],
-      () =>
-        getMyReceivedRollingpapers({
-          page: currentPage,
-          count: MYPAGE_ROLLINGPAPER_PAGING_COUNT,
-        }),
-      { keepPreviousData: true }
-    );
+  const { isLoading, isError, error, data } = useQuery(
+    ["received-rollingpapers", currentPage],
+    () =>
+      getMyReceivedRollingpapers({
+        page: currentPage,
+        count: MYPAGE_ROLLINGPAPER_PAGING_COUNT,
+      }),
+    { keepPreviousData: true }
+  );
 
   if (isError || !data) {
     return <div>에러</div>;

--- a/frontend/src/pages/MyPage/index.tsx
+++ b/frontend/src/pages/MyPage/index.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/constants";
 
 import {
-  UserInfo,
+  User,
   ResponseSentMessages,
   ResponseReceivedRollingpapers,
   CustomError,
@@ -42,7 +42,7 @@ const MyPage = () => {
     isError: isErrorGetUserProfile,
     error: getUserProfileError,
     data: userProfile,
-  } = useQuery<UserInfo>(["user-profile"], () => getMyInfo());
+  } = useQuery<User>(["user-profile"], () => getMyInfo());
 
   const {
     isLoading: isLoadingGetReceivedRollingpapers,

--- a/frontend/src/pages/MyPage/index.tsx
+++ b/frontend/src/pages/MyPage/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import { useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import styled from "@emotion/styled";
@@ -19,13 +19,7 @@ import {
   MYPAGE_MESSAGE_PAGING_COUNT,
 } from "@/constants";
 
-import {
-  User,
-  ResponseSentMessages,
-  ResponseReceivedRollingpapers,
-  CustomError,
-  ValueOf,
-} from "@/types";
+import { CustomError, ValueOf } from "@/types";
 
 type TabMode = ValueOf<typeof TAB>;
 
@@ -42,14 +36,14 @@ const MyPage = () => {
     isError: isErrorGetUserProfile,
     error: getUserProfileError,
     data: userProfile,
-  } = useQuery<User>(["user-profile"], () => getMyInfo());
+  } = useQuery(["user-profile"], () => getMyInfo());
 
   const {
     isLoading: isLoadingGetReceivedRollingpapers,
     isError: isErrorGetReceivedRollingpapers,
     error: getReceivedRollingpapersError,
     data: responseReceivedRollingpapers,
-  } = useQuery<ResponseReceivedRollingpapers>(
+  } = useQuery(
     ["received-rollingpapers", 0],
     () =>
       getMyReceivedRollingpapers({
@@ -64,7 +58,7 @@ const MyPage = () => {
     isError: isErrorGetSentMessages,
     error: getSentMessagesError,
     data: responseSentMessages,
-  } = useQuery<ResponseSentMessages>(
+  } = useQuery(
     ["sent-messages", 0],
     () => getMySentMessages({ page: 0, count: MYPAGE_MESSAGE_PAGING_COUNT }),
     { keepPreviousData: true }

--- a/frontend/src/pages/MyPage/index.tsx
+++ b/frontend/src/pages/MyPage/index.tsx
@@ -11,7 +11,7 @@ import MessageList from "@/pages/MyPage/components/MessageList";
 import {
   getMyInfo,
   getMyReceivedRollingpapers,
-  getMySentMessage,
+  getMySentMessages,
 } from "@/api/member";
 
 import {
@@ -51,7 +51,11 @@ const MyPage = () => {
     data: responseReceivedRollingpapers,
   } = useQuery<ResponseReceivedRollingpapers>(
     ["received-rollingpapers", 0],
-    () => getMyReceivedRollingpapers(0, MYPAGE_ROLLINGPAPER_PAGING_COUNT),
+    () =>
+      getMyReceivedRollingpapers({
+        page: 0,
+        count: MYPAGE_ROLLINGPAPER_PAGING_COUNT,
+      }),
     { keepPreviousData: true }
   );
 
@@ -62,7 +66,7 @@ const MyPage = () => {
     data: responseSentMessages,
   } = useQuery<ResponseSentMessages>(
     ["sent-messages", 0],
-    () => getMySentMessage(0, MYPAGE_MESSAGE_PAGING_COUNT),
+    () => getMySentMessages({ page: 0, count: MYPAGE_MESSAGE_PAGING_COUNT }),
     { keepPreviousData: true }
   );
 

--- a/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/RecipientBox.tsx
@@ -4,13 +4,13 @@ import styled from "@emotion/styled";
 import { RECIPIENT } from "@/constants";
 import { Recipient } from "@/types";
 
-const boxInput = {
-  team: {
+const CONTENTS = {
+  [RECIPIENT.TEAM]: {
     recipient: RECIPIENT.TEAM,
     to: "모임",
     description: "모임을 대상으로 한 롤링페이퍼 작성하기",
   },
-  member: {
+  [RECIPIENT.MEMBER]: {
     recipient: RECIPIENT.MEMBER,
     to: "멤버",
     description: "모임 내의 멤버에게 롤링페이퍼 작성하기",
@@ -27,7 +27,7 @@ interface StyledRecipientBoxProps {
 }
 
 export const RecipientBox = ({ type, onClick }: RecipientBoxProps) => {
-  const { recipient, to, description } = boxInput[type];
+  const { recipient, to, description } = CONTENTS[type];
 
   return (
     <StyledRecipientBox type={type} onClick={onClick(recipient)}>
@@ -49,7 +49,9 @@ const StyledRecipientBox = styled.div<StyledRecipientBoxProps>`
   padding: 10px;
 
   background-color: ${({ theme, type }) =>
-    type === "team" ? theme.colors.YELLOW_200 : theme.colors.LIGHT_GREEN_200};
+    type === RECIPIENT.TEAM
+      ? theme.colors.YELLOW_200
+      : theme.colors.LIGHT_GREEN_200};
 
   border-radius: 8px;
 
@@ -57,7 +59,9 @@ const StyledRecipientBox = styled.div<StyledRecipientBoxProps>`
 
   &:hover {
     background-color: ${({ theme, type }) =>
-      type === "team" ? theme.colors.YELLOW_300 : theme.colors.LIGHT_GREEN_300};
+      type === RECIPIENT.TEAM
+        ? theme.colors.YELLOW_300
+        : theme.colors.LIGHT_GREEN_300};
   }
 `;
 

--- a/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
@@ -3,13 +3,11 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getTeamMembers } from "@/api/team";
 
+import { TeamMember } from "@/types";
+
 interface UseReadTeamMembersArgs {
   teamId: number;
   onSuccess: (data: ResponseTeamMember) => void;
-}
-interface TeamMember {
-  id: number;
-  nickname: string;
 }
 
 interface ResponseTeamMember {

--- a/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
@@ -1,27 +1,18 @@
-import React from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { getTeamMembers } from "@/api/team";
 
-import { TeamMember } from "@/types";
+import { GetTeamMembersResponse } from "@/types/apiResponse";
 
 interface UseReadTeamMembersArgs {
   teamId: number;
-  onSuccess: (data: ResponseTeamMember) => void;
-}
-
-interface ResponseTeamMember {
-  members: TeamMember[];
+  onSuccess: (data: GetTeamMembersResponse) => void;
 }
 
 const useReadTeamMembers = ({ teamId, onSuccess }: UseReadTeamMembersArgs) => {
-  return useQuery<ResponseTeamMember>(
-    ["team-member", teamId],
-    () => getTeamMembers(+teamId),
-    {
-      onSuccess,
-    }
-  );
+  return useQuery(["team-member", teamId], () => getTeamMembers(+teamId), {
+    onSuccess,
+  });
 };
 
 export default useReadTeamMembers;

--- a/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
@@ -3,7 +3,7 @@ import styled from "@emotion/styled";
 
 import IconButton from "@components/IconButton";
 
-import { Message, RollingpaperRecipient } from "@/types";
+import { Message, Recipient } from "@/types";
 
 import PencilIcon from "@/assets/icons/bx-pencil.svg";
 
@@ -14,7 +14,7 @@ import useSliceMessageList from "../hooks/useSliceMessageList";
 
 interface LetterPaperProp {
   to: string;
-  recipientType: RollingpaperRecipient;
+  recipientType: Recipient;
   messageList: Message[];
 }
 

--- a/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageBox.tsx
@@ -11,7 +11,7 @@ import MessageUpdateForm from "@/pages/RollingpaperPage/components/MessageUpdate
 import useMessageBox from "@/pages/RollingpaperPage/hooks/useMessageBox";
 import SecretMessage from "@/pages/RollingpaperPage/components/SecretMessage";
 
-import { Message, RollingpaperRecipient } from "@/types";
+import { Message, Recipient } from "@/types";
 import useValidatedParam from "@/hooks/useValidatedParam";
 
 const MessageBox = ({
@@ -24,7 +24,7 @@ const MessageBox = ({
   editable,
   visible,
   recipientType,
-}: Message & { recipientType: RollingpaperRecipient }) => {
+}: Message & { recipientType: Recipient }) => {
   const rollingpaperId = useValidatedParam<number>("rollingpaperId");
 
   const {

--- a/frontend/src/pages/RollingpaperPage/index.tsx
+++ b/frontend/src/pages/RollingpaperPage/index.tsx
@@ -1,11 +1,10 @@
-import React from "react";
-import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
+import { useQuery } from "@tanstack/react-query";
 
 import PageTitleWithBackButton from "@/components/PageTitleWithBackButton";
 import LetterPaper from "@/pages/RollingpaperPage/components/LetterPaper";
 
-import { Rollingpaper, CustomError } from "@/types";
+import { CustomError } from "@/types";
 import { getRollingpaper } from "@/api/rollingpaper";
 
 import useValidatedParam from "@/hooks/useValidatedParam";
@@ -19,7 +18,7 @@ const RollingpaperPage = () => {
     isError,
     error: rollingpaperError,
     data: rollingpaper,
-  } = useQuery<Rollingpaper>(["rollingpaper", rollingpaperId], () =>
+  } = useQuery(["rollingpaper", rollingpaperId], () =>
     getRollingpaper({ teamId, id: rollingpaperId })
   );
 

--- a/frontend/src/pages/RollingpaperPage/index.tsx
+++ b/frontend/src/pages/RollingpaperPage/index.tsx
@@ -20,7 +20,7 @@ const RollingpaperPage = () => {
     error: rollingpaperError,
     data: rollingpaper,
   } = useQuery<Rollingpaper>(["rollingpaper", rollingpaperId], () =>
-    getRollingpaper(teamId, rollingpaperId)
+    getRollingpaper({ teamId, id: rollingpaperId })
   );
 
   if (isLoading) {

--- a/frontend/src/pages/TeamCreationPage/hooks/useCreateTeam.tsx
+++ b/frontend/src/pages/TeamCreationPage/hooks/useCreateTeam.tsx
@@ -1,10 +1,12 @@
-import React, { useState } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useMutation } from "@tanstack/react-query";
 import axios from "axios";
 
-import { CustomError, Team } from "@/types";
 import { postTeam } from "@/api/team";
+
+import { CustomError } from "@/types";
+import { PostTeamRequest } from "@/types/api";
 
 const useCreateTeam = () => {
   const navigate = useNavigate();
@@ -17,7 +19,7 @@ const useCreateTeam = () => {
       color,
       nickname,
       secret,
-    }: Omit<Team, "id" | "joined">) => {
+    }: PostTeamRequest) => {
       return postTeam({
         name,
         description,

--- a/frontend/src/pages/TeamCreationPage/hooks/useCreateTeam.tsx
+++ b/frontend/src/pages/TeamCreationPage/hooks/useCreateTeam.tsx
@@ -6,7 +6,7 @@ import axios from "axios";
 import { postTeam } from "@/api/team";
 
 import { CustomError } from "@/types";
-import { PostTeamRequest } from "@/types/api";
+import { PostTeamRequest } from "@/types/apiRequest";
 
 const useCreateTeam = () => {
   const navigate = useNavigate();

--- a/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
@@ -15,7 +15,6 @@ import { REGEX } from "@/constants";
 import { useSnackbar } from "@/context/SnackbarContext";
 
 import { putTeamNickname, getTeamMyNickname } from "@/api/team";
-import { TeamMember } from "@/types";
 
 interface NicknameEditModalForm {
   onClickCloseButton: () => void;
@@ -27,7 +26,7 @@ const NicknameEditModalForm = ({
   const { openSnackbar } = useSnackbar();
   const teamId = useValidatedParam<number>("teamId");
 
-  const { data: teamNicknameResponse } = useQuery<Pick<TeamMember, "nickname">>(
+  const { data: teamNicknameResponse } = useQuery(
     ["team-nickname", teamId],
     () => getTeamMyNickname(teamId)
   );

--- a/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/NicknameEditModalForm.tsx
@@ -15,7 +15,7 @@ import { REGEX } from "@/constants";
 import { useSnackbar } from "@/context/SnackbarContext";
 
 import { putTeamNickname, getTeamMyNickname } from "@/api/team";
-import { Team } from "@/types";
+import { TeamMember } from "@/types";
 
 interface NicknameEditModalForm {
   onClickCloseButton: () => void;
@@ -27,7 +27,7 @@ const NicknameEditModalForm = ({
   const { openSnackbar } = useSnackbar();
   const teamId = useValidatedParam<number>("teamId");
 
-  const { data: teamNicknameResponse } = useQuery<Pick<Team, "nickname">>(
+  const { data: teamNicknameResponse } = useQuery<Pick<TeamMember, "nickname">>(
     ["team-nickname", teamId],
     () => getTeamMyNickname(teamId)
   );

--- a/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
@@ -11,6 +11,7 @@ import { CustomError } from "@/types";
 import PlusIcon from "@/assets/icons/bx-plus.svg";
 import { getTeamRollingpapers } from "@/api/team";
 import useValidatedParam from "@/hooks/useValidatedParam";
+import { GetTeamRollingpapersResponse } from "@/types/apiResponse";
 
 const RollingpaperList = () => {
   const navigate = useNavigate();
@@ -21,7 +22,7 @@ const RollingpaperList = () => {
     isError: isErrorGetTeamRollingpaperList,
     error: getTeamRollingpaperListError,
     data: teamRollinpaperListResponse,
-  } = useQuery(["rollingpaperList", teamId], () =>
+  } = useQuery<GetTeamRollingpapersResponse>(["rollingpaperList", teamId], () =>
     getTeamRollingpapers(teamId)
   );
 

--- a/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
@@ -1,5 +1,4 @@
-import React from "react";
-import { Link, useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import styled from "@emotion/styled";
@@ -7,15 +6,11 @@ import styled from "@emotion/styled";
 import IconButton from "@/components/IconButton";
 import RollingpaperListItem from "@/pages/TeamDetailPage/components/RollingpaperListItem";
 
-import { Rollingpaper, CustomError } from "@/types";
+import { CustomError } from "@/types";
 
 import PlusIcon from "@/assets/icons/bx-plus.svg";
 import { getTeamRollingpapers } from "@/api/team";
 import useValidatedParam from "@/hooks/useValidatedParam";
-
-interface RollingpaperListResponse {
-  rollingpapers: Omit<Rollingpaper, "messages">[];
-}
 
 const RollingpaperList = () => {
   const navigate = useNavigate();
@@ -26,7 +21,7 @@ const RollingpaperList = () => {
     isError: isErrorGetTeamRollingpaperList,
     error: getTeamRollingpaperListError,
     data: teamRollinpaperListResponse,
-  } = useQuery<RollingpaperListResponse>(["rollingpaperList", teamId], () =>
+  } = useQuery(["rollingpaperList", teamId], () =>
     getTeamRollingpapers(teamId)
   );
 

--- a/frontend/src/pages/TeamDetailPage/hooks/useCreateInviteLink.tsx
+++ b/frontend/src/pages/TeamDetailPage/hooks/useCreateInviteLink.tsx
@@ -13,7 +13,7 @@ const useCreateInviteLink = () => {
     isError,
     data,
   } = useMutation(({ id }: Pick<Team, "id">) => {
-    return postTeamInviteToken({ id });
+    return postTeamInviteToken(id);
   });
 
   return { createInviteLink, isLoading, isSuccess, isError, data };

--- a/frontend/src/pages/TeamDetailPage/index.tsx
+++ b/frontend/src/pages/TeamDetailPage/index.tsx
@@ -1,13 +1,12 @@
-import React from "react";
+import axios from "axios";
 import { useQuery } from "@tanstack/react-query";
 import styled from "@emotion/styled";
-import axios from "axios";
 
 import TeamDescriptionBox from "@/pages/TeamDetailPage/components/TeamDescriptionBox";
 import RollingpaperList from "@/pages/TeamDetailPage/components/RollingpaperList";
 import TeamJoinSection from "@/pages/TeamDetailPage/components/TeamJoinSection";
 
-import { Team, CustomError } from "@/types";
+import { CustomError } from "@/types";
 import { getTeam } from "@/api/team";
 import useValidatedParam from "@/hooks/useValidatedParam";
 
@@ -19,7 +18,7 @@ const TeamDetailPage = () => {
     isError: isErrorTeamDetail,
     error: TeamDetailError,
     data: teamDetail,
-  } = useQuery<Team>(["team", teamId], () => getTeam(teamId));
+  } = useQuery(["team", teamId], () => getTeam(teamId));
 
   if (isLoadingTeamDetail) {
     return <div>로딩중</div>;

--- a/frontend/src/pages/TeamSearchPage/index.tsx
+++ b/frontend/src/pages/TeamSearchPage/index.tsx
@@ -46,8 +46,8 @@ const TeamSearch = () => {
     {
       getNextPageParam: (lastPage) => {
         if (
-          lastPage.currentPage * TOTAL_TEAMS_PAGING_COUNT <
-          lastPage.totalCount
+          lastPage &&
+          lastPage.currentPage * TOTAL_TEAMS_PAGING_COUNT < lastPage.totalCount
         ) {
           return lastPage.currentPage + 1;
         }
@@ -86,7 +86,7 @@ const TeamSearch = () => {
     return <div>에러</div>;
   }
 
-  if (totalTeamResponse.pages[0].teams.length === 0) {
+  if (totalTeamResponse.pages[0]?.teams.length === 0) {
     return (
       <>
         <StyledSearch>
@@ -113,7 +113,7 @@ const TeamSearch = () => {
       </StyledSearch>
       <StyledTeamList>
         {totalTeamResponse.pages.map((page) =>
-          page.teams.map((team: Team) => (
+          page!.teams.map((team: Team) => (
             <SearchResultListItem
               key={team.id}
               onClick={() => {

--- a/frontend/src/pages/TeamSearchPage/index.tsx
+++ b/frontend/src/pages/TeamSearchPage/index.tsx
@@ -46,8 +46,8 @@ const TeamSearch = () => {
     {
       getNextPageParam: (lastPage) => {
         if (
-          lastPage &&
-          lastPage.currentPage * TOTAL_TEAMS_PAGING_COUNT < lastPage.totalCount
+          lastPage.currentPage * TOTAL_TEAMS_PAGING_COUNT <
+          lastPage.totalCount
         ) {
           return lastPage.currentPage + 1;
         }
@@ -113,7 +113,7 @@ const TeamSearch = () => {
       </StyledSearch>
       <StyledTeamList>
         {totalTeamResponse.pages.map((page) =>
-          page!.teams.map((team: Team) => (
+          page.teams.map((team: Team) => (
             <SearchResultListItem
               key={team.id}
               onClick={() => {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,66 +1,8 @@
-// kakao oauth
+export type ApiOptions = {
+  onError?: () => void;
+};
 
-import { Message, Rollingpaper, Team, TeamMember } from ".";
-
-export interface KakaoOauthRequest {
-  authorizationCode: string;
-  redirectUri: string;
-}
-
-// member
-export interface GetMyReceivedRollingpapersRequest {
-  page: number;
-  count: number;
-}
-
-export interface GetMySentMessagesRequest {
-  page: number;
-  count: number;
-}
-
-// message
-export interface PostMessageRequest
-  extends Pick<Message, "content" | "color" | "anonymous" | "secret"> {
-  rollingpaperId: Rollingpaper["id"];
-}
-export interface PutMessageRequest
-  extends Pick<Message, "id" | "content" | "color" | "anonymous" | "secret"> {
-  rollingpaperId: Rollingpaper["id"];
-}
-
-export interface DeleteMessageRequest {
-  rollingpaperId: Rollingpaper["id"];
-  id: Message["id"];
-}
-
-// rollingpaper
-export interface GetRollingpaperRequest {
-  teamId: Team["id"];
-  id: Rollingpaper["id"];
-}
-
-export interface PostTeamRollingpaperRequest {
-  teamId: Team["id"];
-  title: Rollingpaper["title"];
-}
-
-export interface PostMemberRollingpaperRequest {
-  teamId: Team["id"];
-  title: Rollingpaper["title"];
-  addresseeId: TeamMember["id"];
-}
-
-// teams
-export interface GetTeamSearchResultRequest {
-  keyword: string;
-  count: number;
-}
-
-export interface PostTeamRequest extends Omit<Team, "id" | "joined"> {
-  nickname: TeamMember["nickname"];
-}
-
-export interface PostTeamMemberWithInviteTokenRequest {
-  inviteToken: string;
-  nickname: TeamMember["nickname"];
-}
+export type ApiErrorResponse = {
+  errorCode: number;
+  message: string;
+};

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -51,3 +51,16 @@ export interface PostMemberRollingpaperRequest {
 }
 
 // teams
+export interface GetTeamSearchResultRequest {
+  keyword: string;
+  count: number;
+}
+
+export interface PostTeamRequest extends Omit<Team, "id" | "joined"> {
+  nickname: TeamMember["nickname"];
+}
+
+export interface PostTeamMemberWithInviteTokenRequest {
+  inviteToken: string;
+  nickname: TeamMember["nickname"];
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,6 +1,6 @@
 // kakao oauth
 
-import { Message, Rollingpaper } from ".";
+import { Message, Rollingpaper, Team, TeamMember } from ".";
 
 export interface KakaoOauthRequest {
   authorizationCode: string;
@@ -33,6 +33,21 @@ export interface DeleteMessageRequest {
   id: Message["id"];
 }
 
-// teams
-
 // rollingpaper
+export interface GetRollingpaperRequest {
+  teamId: Team["id"];
+  id: Rollingpaper["id"];
+}
+
+export interface PostTeamRollingpaperRequest {
+  teamId: Team["id"];
+  title: Rollingpaper["title"];
+}
+
+export interface PostMemberRollingpaperRequest {
+  teamId: Team["id"];
+  title: Rollingpaper["title"];
+  addresseeId: TeamMember["id"];
+}
+
+// teams

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,5 +1,7 @@
 // kakao oauth
 
+import { Message, Rollingpaper } from ".";
+
 export interface KakaoOauthRequest {
   authorizationCode: string;
   redirectUri: string;
@@ -15,3 +17,22 @@ export interface GetMySentMessagesRequest {
   page: number;
   count: number;
 }
+
+// message
+export interface PostMessageRequest
+  extends Pick<Message, "content" | "color" | "anonymous" | "secret"> {
+  rollingpaperId: Rollingpaper["id"];
+}
+export interface PutMessageRequest
+  extends Pick<Message, "id" | "content" | "color" | "anonymous" | "secret"> {
+  rollingpaperId: Rollingpaper["id"];
+}
+
+export interface DeleteMessageRequest {
+  rollingpaperId: Rollingpaper["id"];
+  id: Message["id"];
+}
+
+// teams
+
+// rollingpaper

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,17 @@
+// kakao oauth
+
+export interface KakaoOauthRequest {
+  authorizationCode: string;
+  redirectUri: string;
+}
+
+// member
+export interface GetMyReceivedRollingpapersRequest {
+  page: number;
+  count: number;
+}
+
+export interface GetMySentMessagesRequest {
+  page: number;
+  count: number;
+}

--- a/frontend/src/types/apiRequest.ts
+++ b/frontend/src/types/apiRequest.ts
@@ -1,0 +1,66 @@
+// kakao oauth
+
+import { Message, Rollingpaper, Team, TeamMember } from ".";
+
+export interface KakaoOauthRequest {
+  authorizationCode: string;
+  redirectUri: string;
+}
+
+// member
+export interface GetMyReceivedRollingpapersRequest {
+  page: number;
+  count: number;
+}
+
+export interface GetMySentMessagesRequest {
+  page: number;
+  count: number;
+}
+
+// message
+export interface PostMessageRequest
+  extends Pick<Message, "content" | "color" | "anonymous" | "secret"> {
+  rollingpaperId: Rollingpaper["id"];
+}
+export interface PutMessageRequest
+  extends Pick<Message, "id" | "content" | "color" | "anonymous" | "secret"> {
+  rollingpaperId: Rollingpaper["id"];
+}
+
+export interface DeleteMessageRequest {
+  rollingpaperId: Rollingpaper["id"];
+  id: Message["id"];
+}
+
+// rollingpaper
+export interface GetRollingpaperRequest {
+  teamId: Team["id"];
+  id: Rollingpaper["id"];
+}
+
+export interface PostTeamRollingpaperRequest {
+  teamId: Team["id"];
+  title: Rollingpaper["title"];
+}
+
+export interface PostMemberRollingpaperRequest {
+  teamId: Team["id"];
+  title: Rollingpaper["title"];
+  addresseeId: TeamMember["id"];
+}
+
+// teams
+export interface GetTeamSearchResultRequest {
+  keyword: string;
+  count: number;
+}
+
+export interface PostTeamRequest extends Omit<Team, "id" | "joined"> {
+  nickname: TeamMember["nickname"];
+}
+
+export interface PostTeamMemberWithInviteTokenRequest {
+  inviteToken: string;
+  nickname: TeamMember["nickname"];
+}

--- a/frontend/src/types/apiRequest.ts
+++ b/frontend/src/types/apiRequest.ts
@@ -1,8 +1,7 @@
-// kakao oauth
-
 import { Message, Rollingpaper, Team, TeamMember } from ".";
 
-export interface KakaoOauthRequest {
+// kakao oauth
+export interface postKakaoOauthRequest {
   authorizationCode: string;
   redirectUri: string;
 }

--- a/frontend/src/types/apiResponse.ts
+++ b/frontend/src/types/apiResponse.ts
@@ -1,0 +1,81 @@
+import {
+  Rollingpaper,
+  Message,
+  ReceivedRollingpaper,
+  SentMessage,
+  User,
+  Team,
+  TeamMember,
+} from "@/types";
+
+// Kakao OAuth
+export interface PostKakaoOauthResponse {
+  accessToken: string;
+  id: User["id"];
+}
+
+// member
+export interface GetMyReceivedRollingpapersResponse {
+  totalCount: number;
+  currentPage: number;
+  rollingpapers: ReceivedRollingpaper[];
+}
+
+export interface GetMySentMessagesResponse {
+  totalCount: number;
+  currentPage: number;
+  messages: SentMessage[];
+}
+
+// message
+export interface PostMessageResponse {
+  id: Message["id"];
+}
+
+// rollingpaper
+export interface GetRollingpaperResponse extends Rollingpaper {}
+
+export interface PostTeamRollingpaperResponse {
+  id: Rollingpaper["id"];
+}
+
+export interface PostMemberRollingpaperResponse {
+  id: Rollingpaper["id"];
+}
+
+// team
+export interface GetTeamResponse extends Team {}
+
+export interface GetTeamWithInviteTokenResponse extends Team {}
+
+export interface GetMyTeamsResponse {
+  totalCount: number;
+  currentPage: number;
+  teams: Team[];
+}
+
+export interface GetTeamSearchResultResponse {
+  totalCount: number;
+  currentPage: number;
+  teams: Team[];
+}
+
+export interface GetTeamMembersResponse {
+  members: TeamMember[];
+}
+
+export interface GetTeamRollingpapersResponse {
+  rollingpapers: Pick<Rollingpaper, "id" | "title" | "to" | "recipient">[];
+}
+
+export interface GetTeamMyNicknameResponse {
+  nickname: TeamMember["nickname"];
+}
+
+export interface PostTeamResponse {
+  id: Team["id"];
+}
+
+export interface PostTeamInviteTokenResponse {
+  inviteToken: string;
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -22,13 +22,11 @@ export interface Message {
   visible: boolean;
 }
 
-export type RollingpaperRecipient = "MEMBER" | "TEAM";
-
 export interface Rollingpaper {
   id: number;
   title: string;
   to: string;
-  recipient: RollingpaperRecipient;
+  recipient: Recipient;
   messages: Message[];
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -30,10 +30,15 @@ export interface Rollingpaper {
   messages: Message[];
 }
 
-export interface UserInfo {
+export interface User {
   id: number;
   username: string;
   email: string;
+}
+
+export interface TeamMember {
+  id: number;
+  nickname: string;
 }
 
 export interface ReceivedRollingpaper {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -40,34 +40,18 @@ export interface TeamMember {
   nickname: string;
 }
 
-export interface ReceivedRollingpaper {
-  id: number;
-  title: string;
-  teamId: number;
-  teamName: string;
+export interface ReceivedRollingpaper
+  extends Pick<Rollingpaper, "id" | "title"> {
+  teamId: Team["id"];
+  teamName: Team["name"];
 }
 
-export interface SentMessage {
-  id: number;
-  rollingpaperId: number;
-  rollingpaperTitle: string;
-  teamId: number;
-  teamName: string;
-  to: string;
-  content: string;
-  color: string;
-}
-
-export interface ResponseReceivedRollingpapers {
-  totalCount: number;
-  currentPage: number;
-  rollingpapers: ReceivedRollingpaper[];
-}
-
-export interface ResponseSentMessages {
-  totalCount: number;
-  currentPage: number;
-  messages: SentMessage[];
+export interface SentMessage extends Pick<Message, "id" | "content" | "color"> {
+  teamId: Team["id"];
+  teamName: Team["name"];
+  rollingpaperId: Rollingpaper["id"];
+  rollingpaperTitle: Rollingpaper["title"];
+  to: Rollingpaper["to"];
 }
 
 export type CustomError = {
@@ -78,12 +62,3 @@ export type CustomError = {
 export type ValueOf<T> = T[keyof T];
 
 export type Recipient = ValueOf<typeof RECIPIENT>;
-
-export type ApiOptions = {
-  onError?: () => void;
-};
-
-export type ApiErrorResponse = {
-  errorCode: number;
-  message: string;
-};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -6,7 +6,6 @@ export interface Team {
   description: string;
   emoji: string;
   color: string;
-  nickname: string;
   joined: boolean;
   secret: boolean;
 }

--- a/frontend/src/types/oauth.ts
+++ b/frontend/src/types/oauth.ts
@@ -1,4 +1,0 @@
-export type RequestKakaoOauthBody = {
-  authorizationCode: string;
-  redirectUri: string;
-};


### PR DESCRIPTION
작업을 끝내고 보니 더 나은 방향이 보여서 전반적인 규칙을 새로 제안하고 싶은데요.
우선 정했던 규칙에 따라 전체적인 작업 마무리하여 올립니다.
확인해보시고 코멘트 남겨주세요!

## 작업한 내용
### 페어로 함께 작업한 부분
- 함수 표현식과 화살표 함수로 컴포넌트 선언 방식 통일
- 객체 타입에는 interface를 사용. 유니온, 리터럴 타입에는 type alias을 사용.
- `apiRequest.ts`에 API 요청 관련 타입 정리

### 추가 작업한 부분
- `requestApi` 함수의 request 인자 타입 `() => Promise<AxiosResponse<T>>`로 변경
- `apiResponse.ts`에 API 응답 관련 타입 정리
- 위 작업들에 따라 react-query hook에 선언된 타입 제거 또는 타입 확인 코드 수정

<br >

## 개선 방향 제안
react-query에서 응답 타입을 지정해주면, onSuccess의 인자 data는 해당 응답 타입으로 추론됩니다. 
반면 계획했던 방식인 requestApi 함수에서 응답 타입을 지정하는 방식으로 사용하면, onSuccess 인자 data를 `지정한 응답 타입 | undefined`로 추론하여 이후 코드들에서 복잡한 타입 확인 구문이 더 필요해지는 상황입니다. 
1. 그러니 `requestApi` 함수의 request 인자 타입은 `() => Promise<any>`로 복구하고, 정의해둔 응답 타입 지정을 react-query에서 해주면 더 좋을 것 같고요.
2. 더하여 react-query 훅에서 `useQuery<TData, TError>` 형태로 에러 타입을 지정할 수 있더라고요. react-query에서 훅에서 AxiosError로 에러 타입을 지정하고, 훅의 onError에서 커스텀 에러를 throw하는 코드를 작성하면 어떨까요?

### => 논의 결과
- 이번에는 아래 항목까지만 진행
1. `requestApi` 함수의 request 인자 타입은 `() => Promise<any>`로 복구
2. TData 타입 지정이 필요한 react-query에서만 타입 지정

- 커스텀 훅에서의 타입 지정과 에러 처리는 #437 에서 진행

<br >

## 확인할 부분
- 컨벤션 관련 수정 필요한 부분 있는지 확인해보시고 의견주세요~!
- 전체적으로 테스트는 한번 했는데요. 수정된 부분이 많으니 오류 없는지 더블 체크 부탁합니다.

closed #443 