### PR TITLE
refactor: tsconfig, webpack loader, devtool 변경

### DIFF
--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    "@babel/preset-react",
+    ["@babel/preset-react", { runtime: "automatic" }],
     "@babel/preset-env",
     "@babel/preset-typescript",
   ],

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   transform: {
-    "^.+\\.tsx?$": "ts-jest",
-    "^.+\\.js$": "babel-jest",
+    "^.+\\.tsx?$": "babel-jest",
+    "^.+\\.jsx?$": "babel-jest",
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
       "<rootDir>/__tests__/config_util/fileTransformer.js",
   },

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     /* Visit https://aka.ms/tsconfig.json to read more about this file */
 
     /* Projects */

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -9,19 +9,14 @@ require("dotenv").config({
 
 module.exports = merge(common, {
   mode: "development",
-  devtool: "eval-source-map",
+  devtool: "source-map",
   devServer: {
     historyApiFallback: true,
     port: 3000,
     hot: true,
   },
   module: {
-    rules: [
-      {
-        test: /\.tsx?$/,
-        use: "ts-loader",
-      },
-    ],
+    rules: [{ test: /\.tsx?$/, use: ["babel-loader", "ts-loader"] }],
   },
   plugins: [
     new webpack.DefinePlugin({


### PR DESCRIPTION
## 수정사항
### webpack.dev.js
- devtool: source-map으로 변경
- tsx? loader: ts-loader에서 ["babel-loader", "ts-loader"]로 변경

### tsconfig.json
- jsx: react-jsx에서 preserve로 변경

<br >

## 변경 이유
dev mode 빌드 시 1. 타입 체크와 2. 리액트 문법 체크 둘 다 진행되도록 하고 싶었음.
tsx는 ts-loader, babel-loader 각각을 사용하는 두 단계를 거쳐 트랜스파일링 되도록 함.
1. **tsx는 ts-loader를 통해 타입이 제거된 jsx로 변환됨**
    - tsconfig.json의 jsx: preserve로 tsx -> jsx로 변환되도록 설정 
      https://www.typescriptlang.org/docs/handbook/jsx.html
    - 이때 타입 체크가 진행됨.
2. **jsx는 babel-loader를 통해 js로 변환됨**
    - 이때 리액트 문법 체크가 진행됨
       babel-loader와 @babel/preset-react를 함께 사용하면 프리셋에 내장된 @babel/plugin-transform-react-jsx에서 리액트 문법 오류를 잡아준다.