### PR TITLE
fix: 작성한 메시지 개수를 해당페이지 개수로만 가져오는 버그 수정

### DIFF
--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
@@ -125,18 +125,27 @@ class MessageRepositoryTest {
         messageRepository.save(message4);
         final Message message5 = createMessage();
         messageRepository.save(message5);
+        final Message message6 = createMessage();
+        messageRepository.save(message6);
+        final Message message7 = createMessage();
+        messageRepository.save(message7);
         final List<WrittenMessageResponseDto> expected = List.of(
+                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", message1),
+                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", message2),
                 WrittenMessageResponseDto.of(rollingpaper, team, "멤버", message3),
-                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", message4)
+                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", message4),
+                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", message5)
         );
 
         final Page<WrittenMessageResponseDto> writtenMessageResponseDtos =
-                messageRepository.findAllByAuthorId(author.getId(), PageRequest.of(1, 2));
+                messageRepository.findAllByAuthorId(author.getId(), PageRequest.of(0, 5));
         final List<WrittenMessageResponseDto> actual = writtenMessageResponseDtos.getContent();
-
-        assertThat(actual)
-                .usingRecursiveComparison()
-                .isEqualTo(expected);
+        assertAll(
+                () -> assertThat(writtenMessageResponseDtos.getTotalElements()).isEqualTo(7),
+                () -> assertThat(actual)
+                        .usingRecursiveComparison()
+                        .isEqualTo(expected)
+        );
     }
 
     @Test


### PR DESCRIPTION
close #473 

원인: totalCount가 현재 페이징된 메시지 번호 개수 (ex. 2페이지에 메시지 6~10번: 총 N개임에도 불구하고 N개가 아닌 10개라고 뜸.)
해결방법: Projections 스트림 count가 아닌 entity.count()하도록