### PR TITLE
fix: 롤링페이퍼 생성 페이지의 받는 사람 자동완성 기능 오류를 해결한다.

### DIFF
--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -13,6 +13,8 @@ import useInput from "@/hooks/useInput";
 import useReadTeamMembers from "@/pages/RollingpaperCreationPage/hooks/useReadTeamMembers";
 import useCreateMemberRollingpaper from "@/pages/RollingpaperCreationPage/hooks/useCreateMemberRolliingpaper";
 
+import { GetTeamMembersResponse } from "@/types/apiResponse";
+
 const MemberRollingpaperCreateForm = () => {
   const teamId = useValidatedParam<number>("teamId");
   const { value: title, handleInputChange } = useInput("");
@@ -24,13 +26,21 @@ const MemberRollingpaperCreateForm = () => {
     handleAutoInputChange,
     handleAutoInputFocus,
     handleListItemClick,
+    setKeywordList,
   } = useAutoCompleteInput();
 
   const createMemberRollingpaper = useCreateMemberRollingpaper(teamId);
 
+  const handleReadTeamMembersSuccess = (data: GetTeamMembersResponse) => {
+    setKeywordList(data.members.map((member) => member.nickname));
+  };
+
   // 이런 경우에는 컴포넌트 단에서 onSuccess를 처리하는 것이 편할듯
   // 다른 커스텀 훅의 호출이 필요한 경우
-  const { data: teamMemberResponse } = useReadTeamMembers(teamId);
+  const { data: teamMemberResponse } = useReadTeamMembers(
+    teamId,
+    handleReadTeamMembersSuccess
+  );
 
   const findReceiverWithNickName = (nickName: string) => {
     return teamMemberResponse?.members.find(

--- a/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/MemberRollingpaperCreateForm.tsx
@@ -76,7 +76,7 @@ const MemberRollingpaperCreateForm = () => {
 
   return (
     <StyledMain>
-      <StyledHeader>맴버에게 롤링페이퍼 작성</StyledHeader>
+      <StyledHeader>멤버에게 롤링페이퍼 작성</StyledHeader>
       <StyledForm onSubmit={handleRollingpaperCreateSubmit}>
         <LabeledInput
           labelText="롤링페이퍼 제목"

--- a/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/hooks/useReadTeamMembers.tsx
@@ -1,20 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 
-import useAutoCompleteInput from "@/hooks/useAutoCompleteInput";
-
 import { getTeamMembers } from "@/api/team";
 
 import { GetTeamMembersResponse } from "@/types/apiResponse";
 
-const useReadTeamMembers = (teamId: number) => {
-  const { setKeywordList } = useAutoCompleteInput();
+const useReadTeamMembers = (
+  teamId: number,
+  onSuccess: (data: GetTeamMembersResponse) => void
+) => {
   return useQuery<GetTeamMembersResponse, AxiosError>(
     ["team-member", teamId],
     () => getTeamMembers(+teamId),
     {
-      onSuccess: (data: GetTeamMembersResponse) =>
-        setKeywordList(data.members.map((member) => member.nickname)),
+      onSuccess,
       useErrorBoundary: true,
     }
   );


### PR DESCRIPTION
## 작업 내용
- 맴버 -> 멤버로 오타 수정
- useReadTeamMembers 훅에 onSuccess 인자 및 success handler추가

closed #482 