### PR TITLE
feat: 데이터베이스 이중화 기능을 구현한다.

### DIFF
--- a/backend/docker/README.md
+++ b/backend/docker/README.md
@@ -40,7 +40,7 @@ mysql -uroot -p
 stop replica;
 
 CHANGE REPLICATION SOURCE TO
-SOURCE_HOST='172.23.0.3',
+SOURCE_HOST='소스서버 host주소',
 SOURCE_PORT=3306,
 SOURCE_USER='repl_user',
 SOURCE_PASSWORD='password',

--- a/backend/docker/README.md
+++ b/backend/docker/README.md
@@ -1,0 +1,70 @@
+## local에서 간편하게 mysql 이중화 설정하기
+
+### 도커 실행하기
+
+```shell
+# docker-compose.yml있는 디렉토리로 이동 후
+docker-compose up -d
+```
+
+### source mysql 접속해서 복제 계정 생성
+```shell
+docker ps
+docker exec -it {REPLICA_CONTAINER_ID} bash
+mysql -uroot -p
+#비밀번호는 password
+
+# 복제 계정 준비
+CREATE USER 'repl_user'@'%' IDENTIFIED BY 'password';
+GRANT REPLICATION SLAVE ON *.* To 'repl_user'@'%';
+flush privileges;
+```
+
+### replica mysql 접속하기
+```shell
+docker ps
+docker exec -it {REPLICA_CONTAINER_ID} bash
+mysql -uroot -p
+#비밀번호는 password
+```
+
+### source 서버 host 알기
+```shell
+docker network ls
+docker inspect {CONTAINER ID}
+# docker_net-mysql
+```
+
+### replica 도커 접속해서 복제 설정 입력하기
+```shell
+stop replica;
+
+CHANGE REPLICATION SOURCE TO
+SOURCE_HOST='source 서버 host 넣기',
+SOURCE_PORT=3306,
+SOURCE_USER='repl_user',
+SOURCE_PASSWORD='password',
+SOURCE_AUTO_POSITION=1,
+GET_SOURCE_PUBLIC_KEY=1;
+
+start replica;
+```
+
+### replica mysql 상태 확인하기
+```
+show replica status\G;
+```
+
+```shell
+ Replica_IO_Running: No 상태이고 
+ Last_IO_Error: Last_IO_Error: Fatal error: The slave I/O thread stops because master and slave have equal MySQL server ids; 
+ these ids must be different for replication to work 이런 에러상태이면
+ 
+ 해당 레플리카 서버의 server_id가 소스서버와 같은 상태
+ stop replica;
+ 
+ SET GLOBAL server_id=2
+ 
+ start replica;
+```
+

--- a/backend/docker/README.md
+++ b/backend/docker/README.md
@@ -10,7 +10,7 @@ docker-compose up -d
 ### source mysql 접속해서 복제 계정 생성
 ```shell
 docker ps
-docker exec -it {REPLICA_CONTAINER_ID} bash
+docker exec -it {SOURCE_CONTAINER_ID} bash
 mysql -uroot -p
 #비밀번호는 password
 
@@ -18,6 +18,13 @@ mysql -uroot -p
 CREATE USER 'repl_user'@'%' IDENTIFIED BY 'password';
 GRANT REPLICATION SLAVE ON *.* To 'repl_user'@'%';
 flush privileges;
+```
+
+### source 서버 host 알기
+```shell
+docker network ls
+docker inspect {CONTAINER ID}
+# docker_net-mysql
 ```
 
 ### replica mysql 접속하기
@@ -28,19 +35,12 @@ mysql -uroot -p
 #비밀번호는 password
 ```
 
-### source 서버 host 알기
-```shell
-docker network ls
-docker inspect {CONTAINER ID}
-# docker_net-mysql
-```
-
 ### replica 도커 접속해서 복제 설정 입력하기
 ```shell
 stop replica;
 
 CHANGE REPLICATION SOURCE TO
-SOURCE_HOST='source 서버 host 넣기',
+SOURCE_HOST='172.23.0.3',
 SOURCE_PORT=3306,
 SOURCE_USER='repl_user',
 SOURCE_PASSWORD='password',
@@ -68,3 +68,16 @@ show replica status\G;
  start replica;
 ```
 
+### 이중화가 정상적으로 이루어 지는지 확인하는 법
+```shell
+#mysql 접속
+#log상태 확인
+show variables like 'general%';
+
+#log 활성화
+set global general_log = ON;
+
+show variables like 'general%';
+
+#해당 위치에 있는 로그 파일을 확인하면서 CUD, R로 잘 분기되는지 확인해볼 수 있음
+```

--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -26,8 +26,6 @@ services:
     restart: always
     environment:
       MYSQL_DATABASE: 'naepyeon'
-      MYSQL_USER: 'user'
-      MYSQL_PASSWORD: 'password'
       MYSQL_ROOT_PASSWORD: 'password'
     ports:
       - '3307:3306'

--- a/backend/docker/docker-compose.yml
+++ b/backend/docker/docker-compose.yml
@@ -1,0 +1,48 @@
+version: "3"
+services:
+  db-source:
+    build:
+      context: ./
+      dockerfile: source/Dockerfile
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'naepyeon'
+      MYSQL_USER: 'user'
+      MYSQL_PASSWORD: 'password'
+      MYSQL_ROOT_PASSWORD: 'password'
+    ports:
+      - '3306:3306'
+    # Where our data will be persisted
+    volumes:
+      - my-db-source:/var/lib/mysql
+      - my-db-source:/var/lib/mysql-files
+    networks:
+      - net-mysql
+
+  db-replica:
+    build:
+      context: ./
+      dockerfile: replica/Dockerfile
+    restart: always
+    environment:
+      MYSQL_DATABASE: 'naepyeon'
+      MYSQL_USER: 'user'
+      MYSQL_PASSWORD: 'password'
+      MYSQL_ROOT_PASSWORD: 'password'
+    ports:
+      - '3307:3306'
+    # Where our data will be persisted
+    volumes:
+      - my-db-replica:/var/lib/mysql
+      - my-db-replica:/var/lib/mysql-files
+    networks:
+      - net-mysql
+
+# Names our volume
+volumes:
+  my-db-source:
+  my-db-replica:
+
+networks:
+  net-mysql:
+    driver: bridge

--- a/backend/docker/replica/Dockerfile
+++ b/backend/docker/replica/Dockerfile
@@ -1,0 +1,2 @@
+FROM --platform=linux/x86_64 mysql:8.0
+ADD ./replica/my.cnf /etc/mysql/my.cnf

--- a/backend/docker/replica/my.cnf
+++ b/backend/docker/replica/my.cnf
@@ -1,0 +1,8 @@
+[mysqld]
+gtid_mode=ON
+enforce_gtid_consistency=ON
+server_id=2
+relay_log =/var/lib/mysql/mysql-relay-bin
+relay_log_purge=ON
+read_only
+log_slave_updates

--- a/backend/docker/source/Dockerfile
+++ b/backend/docker/source/Dockerfile
@@ -1,0 +1,2 @@
+FROM --platform=linux/x86_64 mysql:8.0
+ADD ./source/my.cnf /etc/mysql/my.cnf

--- a/backend/docker/source/my.cnf
+++ b/backend/docker/source/my.cnf
@@ -1,0 +1,5 @@
+[mysqld]
+gtid_mode=ON
+enforce_gtid_consistency=ON
+server_id=1
+log_bin = mysql-bin

--- a/backend/src/main/java/com/woowacourse/naepyeon/config/DataSourceConfig.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/config/DataSourceConfig.java
@@ -38,10 +38,10 @@ public class DataSourceConfig {
     @Bean
     public DataSource routingDataSource() {
         final RoutingDataSource routingDataSource = new RoutingDataSource();
-
         final HashMap<Object, Object> dataSources = new HashMap<>();
+
         dataSources.put(DatabaseType.SOURCE, sourceDataSource());
-        dataSources.put(DatabaseType.REPLICA, sourceDataSource());
+        dataSources.put(DatabaseType.REPLICA, replicaDataSource());
 
         routingDataSource.setDefaultTargetDataSource(sourceDataSource());
         routingDataSource.setTargetDataSources(dataSources);

--- a/backend/src/main/java/com/woowacourse/naepyeon/config/DataSourceConfig.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/config/DataSourceConfig.java
@@ -1,0 +1,58 @@
+package com.woowacourse.naepyeon.config;
+
+import com.woowacourse.naepyeon.support.db.DatabaseType;
+import com.woowacourse.naepyeon.support.db.RoutingDataSource;
+import java.util.HashMap;
+import javax.sql.DataSource;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@RequiredArgsConstructor
+@ComponentScan(basePackages = {"com.woowacourse.naepyeon"})
+public class DataSourceConfig {
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.source.hikari")
+    public DataSource sourceDataSource() {
+        return DataSourceBuilder.create()
+                .build();
+    }
+
+    @Bean
+    @ConfigurationProperties(prefix = "spring.datasource.replica.hikari")
+    public DataSource replicaDataSource() {
+        return DataSourceBuilder.create()
+                .build();
+    }
+
+    @Bean
+    public DataSource routingDataSource() {
+        final RoutingDataSource routingDataSource = new RoutingDataSource();
+
+        final HashMap<Object, Object> dataSources = new HashMap<>();
+        dataSources.put(DatabaseType.SOURCE, sourceDataSource());
+        dataSources.put(DatabaseType.REPLICA, sourceDataSource());
+
+        routingDataSource.setDefaultTargetDataSource(sourceDataSource());
+        routingDataSource.setTargetDataSources(dataSources);
+
+        return routingDataSource;
+    }
+
+    @Primary
+    @Bean
+    @DependsOn({"sourceDataSource", "replicaDataSource", "routingDataSource"})
+    public DataSource dataSource() {
+        return new LazyConnectionDataSourceProxy(routingDataSource());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/config/DataSourceConfig.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/config/DataSourceConfig.java
@@ -8,17 +8,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
-import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
-@EnableTransactionManagement
 @RequiredArgsConstructor
-@ComponentScan(basePackages = {"com.woowacourse.naepyeon"})
 public class DataSourceConfig {
 
     @Bean

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/db/DatabaseType.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/db/DatabaseType.java
@@ -1,0 +1,18 @@
+package com.woowacourse.naepyeon.support.db;
+
+public enum DatabaseType {
+
+    SOURCE("SOURCE"),
+    REPLICA("REPLICA"),
+    ;
+
+    private final String type;
+
+    DatabaseType(final String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/db/DatabaseType.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/db/DatabaseType.java
@@ -3,7 +3,7 @@ package com.woowacourse.naepyeon.support.db;
 public enum DatabaseType {
 
     SOURCE("SOURCE"),
-    REPLICA("REPLICA"),
+    REPLICA("REPLICA")
     ;
 
     private final String type;

--- a/backend/src/main/java/com/woowacourse/naepyeon/support/db/RoutingDataSource.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/support/db/RoutingDataSource.java
@@ -1,0 +1,18 @@
+package com.woowacourse.naepyeon.support.db;
+
+import static com.woowacourse.naepyeon.support.db.DatabaseType.SOURCE;
+import static com.woowacourse.naepyeon.support.db.DatabaseType.REPLICA;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        if (TransactionSynchronizationManager.isCurrentTransactionReadOnly()) {
+            return REPLICA;
+        }
+        return SOURCE;
+    }
+}

--- a/backend/src/main/resources/application-deploy.yml
+++ b/backend/src/main/resources/application-deploy.yml
@@ -1,9 +1,18 @@
 spring:
   datasource:
-    url: ${MYSQL_URL}
-    password: ${MYSQL_PASSWORD}
-    username: ${MYSQL_USERNAME}
-    driver-class-name: com.mysql.cj.jdbc.Driver
+    source:
+      hikari:
+        jdbc-url: ${SOURCE_MYSQL_URL}
+        password: ${SOURCE_MYSQL_PASSWORD}
+        username: ${SOURCE_MYSQL_USERNAME}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+    replica:
+      hikari:
+        jdbc-url: ${REPLICA_MYSQL_URL}
+        password: ${REPLICA_MYSQL_PASSWORD}
+        username: ${REPLICA_MYSQL_USERNAME}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application-develop.yml
+++ b/backend/src/main/resources/application-develop.yml
@@ -1,11 +1,19 @@
 spring:
   datasource:
-    url: ${MYSQL_URL}
-    password: ${MYSQL_PASSWORD}
-    username: ${MYSQL_USERNAME}
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    hikari:
-      maximum-pool-size: ${MAX_CONNECTION_POOL_SIZE}
+    source:
+      hikari:
+        jdbc-url: ${SOURCE_MYSQL_URL}
+        password: ${SOURCE_MYSQL_PASSWORD}
+        username: ${SOURCE_MYSQL_USERNAME}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        maximum-pool-size: ${MAX_CONNECTION_POOL_SIZE}
+    replica:
+      hikari:
+        jdbc-url: ${REPLICA_MYSQL_URL}
+        password: ${REPLICA_MYSQL_PASSWORD}
+        username: ${REPLICA_MYSQL_USERNAME}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        maximum-pool-size: ${MAX_CONNECTION_POOL_SIZE}
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application-flywayTest.yml
+++ b/backend/src/main/resources/application-flywayTest.yml
@@ -1,8 +1,17 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MYSQL
-    username: sa
-    password:
+    source:
+      hikari:
+        jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
+        username: sa
+        password:
+        driver-class-name: org.h2.Driver
+    replica:
+      hikari:
+        jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
+        username: sa
+        password:
+        driver-class-name: org.h2.Driver
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,10 +3,18 @@ spring:
     console:
       enabled: true
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MYSQL
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    source:
+      hikari:
+        jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
+        username: sa
+        password:
+        driver-class-name: org.h2.Driver
+    replica:
+      hikari:
+        jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
+        username: sa
+        password:
+        driver-class-name: org.h2.Driver
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,20 +5,20 @@ spring:
   datasource:
     source:
       hikari:
-        jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
-        username: sa
-        password:
-        driver-class-name: org.h2.Driver
+        jdbc-url: jdbc:mysql://localhost:3306/naepyeon?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useUnicode=true
+        username: user
+        password: password
+        driver-class-name: com.mysql.cj.jdbc.Driver
     replica:
       hikari:
-        jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
-        username: sa
-        password:
-        driver-class-name: org.h2.Driver
+        jdbc-url: jdbc:mysql://localhost:3307/naepyeon?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&useUnicode=true
+        username: user
+        password: password
+        driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: validate
     properties:
       hibernate:
         format_sql: true
@@ -26,7 +26,7 @@ spring:
         dialect: org.hibernate.dialect.MySQL5Dialect
     open-in-view: false
   flyway:
-    enabled: false
+    enabled: true
     baseline-on-migrate: true
 
 security:

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,14 +1,17 @@
 spring:
-  h2:
-    console:
-      enabled: true
-  profiles:
-    active: local
   datasource:
-    url: jdbc:h2:mem:testdb
-    username: sa
-    password:
-    driver-class-name: org.h2.Driver
+    source:
+      hikari:
+        jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
+        username: sa
+        password:
+        driver-class-name: org.h2.Driver
+    replica:
+      hikari:
+        jdbc-url: jdbc:h2:mem:testdb;MODE=MYSQL
+        username: sa
+        password:
+        driver-class-name: org.h2.Driver
 
   jpa:
     hibernate:


### PR DESCRIPTION
### 기능 내용
일반적인 트랜잭션 로직에서는 Connection 객체를 먼저 확보하고 트랜잭션 동기화를 진행하는데

`@Transactional(readonly = true)`옵션에 따라 db를 분기하려면 트랜잭션 동기화를 먼저 마치고

해당 트랜잭션이 readOnly가 있냐 없냐에 따라 다른 Connection 객체를 가져야 하기 때문에 작업 순서를 변경해야 합니다.

그래서 트랜잭션 시작시에 Connection Proxy 객체를 리턴하고 실제 쿼리가 발생할 때 데이터 소스에서 올바른 Connection 객체를 얻도록
했습니다.

더 자세한 내용은 wiki로 작성해서 주말중에 업로드 하겠습니다!

close #435 