### PR TITLE
feat: 새로운 메시지 저장 시 refetch 전까지 이전 메시지들을 보여주는 오류를 해결

### DIFF
--- a/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/LetterPaper.tsx
@@ -9,18 +9,25 @@ import PencilIcon from "@/assets/icons/bx-pencil.svg";
 
 import MessageCreateForm from "@/pages/RollingpaperPage/components/MessageCreateForm";
 import MessageBox from "@/pages/RollingpaperPage/components/MessageBox";
-import useMessageWrite from "@/pages/RollingpaperPage/hooks/useMessageWrite";
 import useSliceMessageList from "../hooks/useSliceMessageList";
 
 interface LetterPaperProp {
   to: string;
   recipientType: Recipient;
   messageList: Message[];
+  isWrite: boolean;
+  handleWriteButtonClick: () => void;
+  onEditEnd: () => void;
 }
 
-const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
-  const { isWrite, handleWriteButtonClick, handleWriteEnd } = useMessageWrite();
-
+const LetterPaper = ({
+  to,
+  recipientType,
+  messageList,
+  isWrite,
+  handleWriteButtonClick,
+  onEditEnd,
+}: LetterPaperProp) => {
   const elementList = useMemo(() => {
     const elementList = messageList
       .map((message) => (
@@ -36,7 +43,7 @@ const LetterPaper = ({ to, recipientType, messageList }: LetterPaperProp) => {
       ? [
           <MessageCreateForm
             enableSecretMessage={recipientType === "MEMBER"}
-            onEditEnd={handleWriteEnd}
+            onEditEnd={onEditEnd}
           />,
           ...elementList,
         ]

--- a/frontend/src/pages/RollingpaperPage/components/MessageCreateForm.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageCreateForm.tsx
@@ -25,7 +25,6 @@ export const MessageCreateForm = ({
     handleColorClick,
     handleAnonymousCheckBoxChange,
     handleSecretCheckBoxChange,
-    initMessage,
   } = useMessageForm({});
 
   const rollingpaperId = useValidatedParam<number>("rollingpaperId");
@@ -38,13 +37,10 @@ export const MessageCreateForm = ({
       anonymous,
       secret: enableSecretMessage && secret,
     });
-    initMessage();
-    onEditEnd();
   };
 
   const handleMessageCancel = () => {
     if (confirm("메시지 작성을 취소하시겠습니까?")) {
-      initMessage();
       onEditEnd();
     }
   };

--- a/frontend/src/pages/RollingpaperPage/components/MessageUpdateForm.tsx
+++ b/frontend/src/pages/RollingpaperPage/components/MessageUpdateForm.tsx
@@ -30,7 +30,6 @@ export const MessageUpdateForm = ({
     handleMessageChange,
     handleAnonymousCheckBoxChange,
     handleSecretCheckBoxChange,
-    initMessage,
   } = useMessageForm({
     initContent: content,
     initColor: color,
@@ -47,13 +46,11 @@ export const MessageUpdateForm = ({
       anonymous: newAnonymous,
       secret: enableSecretMessage && newSecret,
     });
-    initMessage();
     onEditEnd();
   };
 
   const handleMessageCancel = () => {
     if (confirm("메시지 작성을 취소하시겠습니까?")) {
-      initMessage();
       onEditEnd();
     }
   };

--- a/frontend/src/pages/RollingpaperPage/hooks/useMessageForm.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useMessageForm.tsx
@@ -36,11 +36,6 @@ const useMessageForm = ({
     setColor(color);
   };
 
-  const initMessage = () => {
-    setContent("");
-    setColor(INIT_COLOR);
-  };
-
   return {
     color,
     content,
@@ -50,7 +45,6 @@ const useMessageForm = ({
     handleColorClick,
     handleAnonymousCheckBoxChange,
     handleSecretCheckBoxChange,
-    initMessage,
   };
 };
 

--- a/frontend/src/pages/RollingpaperPage/hooks/useReadRollingpaper.tsx
+++ b/frontend/src/pages/RollingpaperPage/hooks/useReadRollingpaper.tsx
@@ -8,14 +8,22 @@ import { GetRollingpaperResponse } from "@/types/apiResponse";
 interface UseReadRollingpaperArgs {
   teamId: number;
   rollingpaperId: number;
+  handleWriteEnd: () => void;
 }
 
 export const useReadRollingpaper = ({
   teamId,
   rollingpaperId,
+  handleWriteEnd,
 }: UseReadRollingpaperArgs) =>
   useQuery<GetRollingpaperResponse, AxiosError>(
     ["rollingpaper", rollingpaperId],
     () => getRollingpaper({ teamId, id: rollingpaperId }),
-    { useErrorBoundary: true }
+    {
+      useErrorBoundary: true,
+      refetchOnWindowFocus: false,
+      onSuccess: () => {
+        handleWriteEnd();
+      },
+    }
   );

--- a/frontend/src/pages/RollingpaperPage/index.tsx
+++ b/frontend/src/pages/RollingpaperPage/index.tsx
@@ -3,14 +3,17 @@ import LetterPaper from "@/pages/RollingpaperPage/components/LetterPaper";
 
 import useValidatedParam from "@/hooks/useValidatedParam";
 import { useReadRollingpaper } from "@/pages/RollingpaperPage/hooks/useReadRollingpaper";
+import useMessageWrite from "./hooks/useMessageWrite";
 
 const RollingpaperPage = () => {
   const teamId = useValidatedParam<number>("teamId");
   const rollingpaperId = useValidatedParam<number>("rollingpaperId");
+  const { isWrite, handleWriteButtonClick, handleWriteEnd } = useMessageWrite();
 
   const { isLoading, data: rollingpaper } = useReadRollingpaper({
     teamId,
     rollingpaperId,
+    handleWriteEnd,
   });
 
   if (isLoading) {
@@ -26,9 +29,12 @@ const RollingpaperPage = () => {
       <PageTitleWithBackButton>{rollingpaper.title}</PageTitleWithBackButton>
       <main>
         <LetterPaper
+          isWrite={isWrite}
           to={rollingpaper.to}
           recipientType={rollingpaper.recipient}
           messageList={[...rollingpaper.messages]}
+          handleWriteButtonClick={handleWriteButtonClick}
+          onEditEnd={handleWriteEnd}
         />
       </main>
     </>


### PR DESCRIPTION
지금의 깜빡임은 메시지 폼이 사라지는 시점이 잘못되어서라고 생각했습니다. 메시지 폼은 refetch가 성공한 시점에 사라져야하는데 mutation이 성공한 시점에 사라져서 생기는 오류였습니다. 메시지 폼 열기 여부를 롤링페이퍼를 가져오는 시점으로 변경하여 해결했습니다

- 수정을 하다 이제는 initMessage가 불필요하다는 점을 알게 되어 이를 삭제했습니다(훅으로 빼 놓아서 알아서 초기화가 됨)

### 아쉬운점
- onSuccess마다 메시지 폼을 닫게 됩니다. 초기 가져오는 경우에도 닫게 되는데 로직적으로는 맞는 말인 것 같기는 하나 애매하다고 생각할 수도 있을 것 같습니다
- 이에 따라 useMessageWrite를 index로 옮겨야 했습니다. prop drilling이 조금 늘었습니다
- 화면 전환시에 리패치가 일어나는 것이 적절하지 않다고 생각되어 이 훅에서는 `refetchOnWindowFocus` 옵션을 false로 주었습니다. default로 false로 주는 것이 좋을지 고민입니다.
- 우선 스낵바가 수정하는 곳에서 나타나게 되어 스낵바가 나타나고 -> 이후에 다시 리패치한 정보들이 보여집니다. 스낵바가 보이는 시점이 조금 애매한 것 같기도 합니다. 다만 이를 리패치시로 옮기자니 첫번째로 정보를 가져올때도 스낵바가 나타나는 문제점이 있어… 우선은 기존의 방식을 유지했습니다

나름 다양하게 테스트해보았는데 리뷰어님도 한 번 확인해주세요😘

closed #497 