### PR TITLE
fix: LabeledSwitch에서 발생하는 경고를 해결

### DIFF
--- a/frontend/src/components/LabeledSwitch.tsx
+++ b/frontend/src/components/LabeledSwitch.tsx
@@ -16,7 +16,7 @@ export const LabeledSwitch = ({
   return (
     <StyledLabeledSwitch>
       {labelText}
-      <StyledInput type="checkbox" checked={isChecked} />
+      <StyledInput type="checkbox" checked={isChecked} readOnly />
       <StyledMessage>
         {isChecked ? (
           <>


### PR DESCRIPTION
## 구현 사항
LabeledSwitch의 색상을 제공하기 위해 사용하는 컴포넌트에 onChange없이 checked 속성을 사용하여 발생하는 문제 readOnly option을 추가하여 해결했습니다


closed #495 