### PR TITLE
fix: 본인이 작성한 메시지 조회 시 최신순으로 정렬되도록 수정

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
@@ -44,6 +44,7 @@ public class MessageRepositoryImpl implements MessageRepositoryCustom {
                 .innerJoin(rollingpaper.team, team)
                 .leftJoin(rollingpaper.teamParticipation, teamParticipation)
                 .where(isAuthorIdEq(authorId))
+                .orderBy(message.createdDate.desc())
                 .offset(pageRequest.getOffset())
                 .limit(pageRequest.getPageSize())
                 .fetch();

--- a/backend/src/test/java/com/woowacourse/naepyeon/acceptance/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/acceptance/MemberAcceptanceTest.java
@@ -114,6 +114,8 @@ class MemberAcceptanceTest extends AcceptanceTest {
         final String messageContent3 = "테스트";
         final String messageColor1 = "green";
         final String messageColor2 = "red";
+
+        메시지_작성(kei, rollingpaperId2, new MessageRequest(messageContent3, "yellow", false, false));
         final Long messageId1 =
                 메시지_작성(kei, rollingpaperId1, new MessageRequest(messageContent1, messageColor1, false, false))
                         .as(CreateResponse.class)
@@ -122,23 +124,12 @@ class MemberAcceptanceTest extends AcceptanceTest {
                 메시지_작성(kei, rollingpaperId1, new MessageRequest(messageContent2, messageColor2, false, false))
                         .as(CreateResponse.class)
                         .getId();
-        메시지_작성(kei, rollingpaperId2, new MessageRequest(messageContent3, "yellow", false, false));
 
-        //내가 작성한 메시지를 2개만 조회
+        //내가 작성한 메시지를 최신순으로 2개만 조회
         final WrittenMessagesResponseDto writtenMessagesResponseDto = 나의_메시지_조회(kei, 0, 2)
                 .as(WrittenMessagesResponseDto.class);
         final List<WrittenMessageResponseDto> actual = writtenMessagesResponseDto.getMessages();
         final List<WrittenMessageResponseDto> expected = List.of(
-                new WrittenMessageResponseDto(
-                        messageId1,
-                        rollingpaperId1,
-                        rollingpaperTitle1,
-                        teamId,
-                        "woowacourse-4th",
-                        messageContent1,
-                        messageColor1,
-                        "나는야모임장"
-                ),
                 new WrittenMessageResponseDto(
                         messageId2,
                         rollingpaperId1,
@@ -147,6 +138,16 @@ class MemberAcceptanceTest extends AcceptanceTest {
                         "woowacourse-4th",
                         messageContent2,
                         messageColor2,
+                        "나는야모임장"
+                ),
+                new WrittenMessageResponseDto(
+                        messageId1,
+                        rollingpaperId1,
+                        rollingpaperTitle1,
+                        teamId,
+                        "woowacourse-4th",
+                        messageContent1,
+                        messageColor1,
                         "나는야모임장"
                 )
         );
@@ -189,21 +190,11 @@ class MemberAcceptanceTest extends AcceptanceTest {
                         .as(CreateResponse.class)
                         .getId();
 
-        //내가 작성한 메시지 조회
+        //내가 작성한 메시지 최신 순으로 조회
         final WrittenMessagesResponseDto writtenMessagesResponseDto = 나의_메시지_조회(kei, 0, 10)
                 .as(WrittenMessagesResponseDto.class);
         final List<WrittenMessageResponseDto> actual = writtenMessagesResponseDto.getMessages();
         final List<WrittenMessageResponseDto> expected = List.of(
-                new WrittenMessageResponseDto(
-                        messageId1,
-                        rollingpaperId1,
-                        rollingpaperTitle1,
-                        teamId,
-                        "woowacourse-4th",
-                        messageContent1,
-                        messageColor1,
-                        "나는야모임장"
-                ),
                 new WrittenMessageResponseDto(
                         messageId2,
                         rollingpaperId2,
@@ -213,6 +204,16 @@ class MemberAcceptanceTest extends AcceptanceTest {
                         messageContent2,
                         messageColor2,
                         "woowacourse-4th"
+                ),
+                new WrittenMessageResponseDto(
+                        messageId1,
+                        rollingpaperId1,
+                        rollingpaperTitle1,
+                        teamId,
+                        "woowacourse-4th",
+                        messageContent1,
+                        messageColor1,
+                        "나는야모임장"
                 )
         );
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
@@ -126,7 +126,7 @@ class MessageRepositoryTest {
     }
 
     @Test
-    @DisplayName("본인이 작성한 메시지들을 찾는다.")
+    @DisplayName("본인이 작성한 메시지들을 최신 순으로 찾는다.")
     void findAllByMemberIdAndPageRequest() {
         final Rollingpaper rollingpaper2 =
                 new Rollingpaper("AlexAndKei2", Recipient.TEAM, team, member);
@@ -139,11 +139,11 @@ class MessageRepositoryTest {
             messageRepository.save(message);
         }
         final List<WrittenMessageResponseDto> expected = List.of(
-                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(5)),
                 WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(6)),
-                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(7)),
-                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(8)),
-                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(9))
+                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(5)),
+                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(4)),
+                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(3)),
+                WrittenMessageResponseDto.of(rollingpaper, team, "멤버", messages.get(2))
         );
 
         final Page<WrittenMessageResponseDto> writtenMessageResponseDtos =

--- a/backend/src/test/java/com/woowacourse/naepyeon/service/MessageServiceTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/service/MessageServiceTest.java
@@ -236,16 +236,6 @@ class MessageServiceTest {
         final List<WrittenMessageResponseDto> actual = writtenMessagesResponseDto.getMessages();
         final List<WrittenMessageResponseDto> expected = List.of(
                 new WrittenMessageResponseDto(
-                        messageId,
-                        memberRollingpaper.getId(),
-                        memberRollingpaper.getTitle(),
-                        team.getId(),
-                        team.getName(),
-                        messageRequest.getContent(),
-                        messageRequest.getColor(),
-                        "일케이"
-                ),
-                new WrittenMessageResponseDto(
                         messageId2,
                         teamRollingpaper.getId(),
                         teamRollingpaper.getTitle(),
@@ -254,6 +244,16 @@ class MessageServiceTest {
                         messageRequest.getContent(),
                         messageRequest.getColor(),
                         TEAM_NAME
+                ),
+                new WrittenMessageResponseDto(
+                        messageId,
+                        memberRollingpaper.getId(),
+                        memberRollingpaper.getTitle(),
+                        team.getId(),
+                        team.getName(),
+                        messageRequest.getContent(),
+                        messageRequest.getColor(),
+                        "일케이"
                 )
         );
         assertThat(actual)


### PR DESCRIPTION
close #494 
마이페이지에서 본인이 작성한 메시지 조회 시, 오래된 순으로 보여지는 불편한 점이 존재했습니다.
최신순으로 보여지도록 수정했습니다.