### PR TITLE
feat: 불필요하게 롤링페이퍼를 찾는 쿼리를 날리던 현상 제거

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.woowacourse.naepyeon.repository.message;
 
 import com.woowacourse.naepyeon.domain.Message;
+import com.woowacourse.naepyeon.domain.rollingpaper.Rollingpaper;
 import com.woowacourse.naepyeon.service.dto.WrittenMessageResponseDto;
 import java.util.List;
 import org.springframework.data.domain.Page;
@@ -8,7 +9,7 @@ import org.springframework.data.domain.Pageable;
 
 public interface MessageRepositoryCustom {
 
-    List<Message> findAllByRollingpaperId(final Long rollingpaperId);
+    List<Message> findAllByRollingpaper(final Rollingpaper rollingpaper);
 
     Page<WrittenMessageResponseDto> findAllByAuthorId(final Long authorId, final Pageable pageRequest);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
@@ -84,10 +84,6 @@ public class MessageRepositoryImpl implements MessageRepositoryCustom {
         return nullSafeBuilder(() -> message.author.id.eq(authorId));
     }
 
-    private BooleanBuilder isMessageIdEq(final Long messageId) {
-        return nullSafeBuilder(() -> message.id.eq(messageId));
-    }
-
     private BooleanBuilder nullSafeBuilder(Supplier<BooleanExpression> f) {
         try {
             return new BooleanBuilder(f.get());

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
@@ -14,6 +14,7 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.woowacourse.naepyeon.domain.Message;
 import com.woowacourse.naepyeon.domain.rollingpaper.Recipient;
+import com.woowacourse.naepyeon.domain.rollingpaper.Rollingpaper;
 import com.woowacourse.naepyeon.service.dto.WrittenMessageResponseDto;
 import java.util.List;
 import java.util.function.Supplier;
@@ -28,10 +29,10 @@ public class MessageRepositoryImpl implements MessageRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<Message> findAllByRollingpaperId(final Long rollingpaperId) {
+    public List<Message> findAllByRollingpaper(final Rollingpaper rollingpaper) {
         return queryFactory
                 .selectFrom(message)
-                .where(isRollingpaperIdEq(rollingpaperId))
+                .where(isRollingpaperEq(rollingpaper))
                 .fetch();
     }
 
@@ -75,12 +76,16 @@ public class MessageRepositoryImpl implements MessageRepositoryCustom {
         );
     }
 
-    private BooleanBuilder isRollingpaperIdEq(final Long rollingpaperId) {
-        return nullSafeBuilder(() -> message.rollingpaper.id.eq(rollingpaperId));
+    private BooleanBuilder isRollingpaperEq(final Rollingpaper rollingpaper) {
+        return nullSafeBuilder(() -> message.rollingpaper.eq(rollingpaper));
     }
 
     private BooleanBuilder isAuthorIdEq(final Long authorId) {
         return nullSafeBuilder(() -> message.author.id.eq(authorId));
+    }
+
+    private BooleanBuilder isMessageIdEq(final Long messageId) {
+        return nullSafeBuilder(() -> message.id.eq(messageId));
     }
 
     private BooleanBuilder nullSafeBuilder(Supplier<BooleanExpression> f) {

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/MessageService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/MessageService.java
@@ -59,10 +59,8 @@ public class MessageService {
 
     @Transactional(readOnly = true)
     public List<MessageResponseDto> findMessages(
-            final Long rollingpaperId, final Long teamId, final Long loginMemberId) {
-        final Rollingpaper rollingpaper = rollingpaperRepository.findById(rollingpaperId)
-                .orElseThrow(() -> new NotFoundRollingpaperException(rollingpaperId));
-        return messageRepository.findAllByRollingpaperId(rollingpaperId)
+            final Rollingpaper rollingpaper, final Long teamId, final Long loginMemberId) {
+        return messageRepository.findAllByRollingpaper(rollingpaper)
                 .stream()
                 .map(message -> {
                     final Member author = message.getAuthor();
@@ -92,11 +90,6 @@ public class MessageService {
         );
     }
 
-    private String findMessageWriterNickname(final Long teamId, final Message message) {
-        final Member author = message.getAuthor();
-        return teamParticipationRepository.findNicknameByTeamIdAndMemberId(teamId, author.getId());
-    }
-
     @Transactional(readOnly = true)
     public MessageResponseDto findMessage(final Long messageId, final Long rollingpaperId, final Long loginMemberId) {
         final Message message = messageRepository.findById(messageId)
@@ -112,6 +105,11 @@ public class MessageService {
         final boolean visible = checkVisibleToLoginMember(message, rollingpaper, loginMemberId);
         final boolean editable = checkEditableToLoginMember(message, loginMemberId);
         return MessageResponseDto.of(message, responseContent, responseNickname, author.getId(), visible, editable);
+    }
+
+    private String findMessageWriterNickname(final Long teamId, final Message message) {
+        final Member author = message.getAuthor();
+        return teamParticipationRepository.findNicknameByTeamIdAndMemberId(teamId, author.getId());
     }
 
     private String hideAuthorNicknameWhenAnonymous(final Message message, final String nickname) {

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
@@ -80,7 +80,7 @@ public class RollingpaperService {
 
         return RollingpaperResponseDto.of(
                 RollingpaperPreviewResponseDto.createPreviewRollingpaper(rollingpaper, addresseeNickname),
-                messageService.findMessages(rollingpaper.getId(), teamId, loginMemberId)
+                messageService.findMessages(rollingpaper, teamId, loginMemberId)
         );
     }
 

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/MessageRepositoryTest.java
@@ -113,14 +113,14 @@ class MessageRepositoryTest {
     }
 
     @Test
-    @DisplayName("롤링페이퍼 id로 메시지 전체를 찾는다.")
+    @DisplayName("특정 롤링페이퍼의 메시지 전체를 찾는다.")
     void findAllByRollingpaperId() {
         final Message message1 = createMessage();
         messageRepository.save(message1);
         final Message message2 = createMessage();
         messageRepository.save(message2);
 
-        final List<Message> findMessages = messageRepository.findAllByRollingpaperId(rollingpaper.getId());
+        final List<Message> findMessages = messageRepository.findAllByRollingpaper(rollingpaper);
 
         assertThat(findMessages.size()).isEqualTo(2);
     }


### PR DESCRIPTION
close #512 

- 이미 롤링페이퍼를 찾았음에도 불구하고 다시 롤링페이퍼를 select 쿼리로 찾던 어이없는 현상을 제거했습니다.
- 더 상세한 내용들은 #512 참고바랍니다.

### 현재 롤링페이퍼 단건 조회 시 상당히 성능이 느린 상황
<img width="500" alt="image" src="https://user-images.githubusercontent.com/57135043/194623114-1d23cbc3-ccd7-4bde-93d4-6e92f16755a3.png">

### 불필요하게 롤링페이퍼를 재조회하는 쿼리를 날리는 현상 해결
<img width="911" alt="image" src="https://user-images.githubusercontent.com/57135043/194624209-7b617507-5686-4308-bce2-5b236a0b3fe3.png">

- RollingpaperService의 롤링페이퍼 단건 조회 메서드
- 이미 롤링페이퍼는 찾아졌다.
- 하지만 MessageService.findMessages 의 인자로 롤링페이퍼 id를 넘기고 있다.

<img width="851" alt="image" src="https://user-images.githubusercontent.com/57135043/194624379-b9fb852e-95e6-4fd6-acce-f0cf54a0f56a.png">

- MessageService의 해당 롤링페이퍼 메시지를 모두 조회하는 메서드 
- 이미 RollingpaperService에서 롤링페이퍼를 찾았음에도 불구하고 다시 select 쿼리로 롤링페이퍼를 찾아오고 있다.
- 해당 메서드는 api로도 쓰이지 않고 오로지 롤링페이퍼 단건조회 메서드만을 위해 쓰이고 있음.


### 리뷰받고 싶은 사항
- 혹시 롤링페이퍼 단건조회에서 성능을 더 향상시킬만한 방법이 있을까요?