### PR TITLE
fix: 롤링페이퍼 만들기 페이지에서 보이는 불필요한 스크롤바를 제거한다.

### DIFF
--- a/frontend/src/pages/RollingpaperCreationPage/components/StepTitleWithLayout.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/StepTitleWithLayout.tsx
@@ -75,6 +75,12 @@ const StyledLayout = styled.div`
   padding: 10px;
 
   overflow: scroll;
+
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera*/
+  }
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
 `;
 
 export default forwardRef(StepTitleWithLayout);


### PR DESCRIPTION
## 구현 내용
- css 코드를 추가해서 스크롤바를 제거했습니다. 좌우, 상하 스크롤바 보이지는 않고 스크롤은 동작합니다.

## 논의할 점
모임 선택 스텝에서 수직 스크롤바까지 사라지는 부분이 아쉬운데요. 지금 구현 방식에서 overflow-x로 수평 스크롤을 제어하면 스텝단위로 넘어가는 액션이 동작하지 않아서 우선 임시로(?) 스크롤바를 모두 숨기는 방식으로 해봤습니다.
다른 방식 아시면 공유해주시고요!
이후에 여기 구조 개선하면 수직 스크롤바만 보이도록 할 수 있을 것 같아요.

### 개선 전
<img src="https://user-images.githubusercontent.com/71116429/195410379-f5f26c90-3652-4a10-a2a8-dc746550d71c.png" width=400px />

### 개선 후
<img src="https://user-images.githubusercontent.com/71116429/195420812-eb010a3b-3a66-4f43-8306-e94d2da74e9f.png" width="400px" />
<img src="https://user-images.githubusercontent.com/71116429/195420858-99e1c8c8-9330-42ea-b21c-617950b4df35.png" width="400px" />


closed #531 