### PR TITLE
fix: UserProfile에서 이름 수정 후 엔터를 눌렀을 때 새로고침 되는 버그를 해결한다.

### DIFF
--- a/frontend/src/pages/MyPage/components/UserProfile.tsx
+++ b/frontend/src/pages/MyPage/components/UserProfile.tsx
@@ -6,17 +6,11 @@ import { UserContext } from "@/context/UserContext";
 import useInput from "@/hooks/useInput";
 import useUpdateUserProfile from "@/pages/MyPage/hooks/useUpdateUserProfile";
 
-import IconButton from "@/components/IconButton";
 import LineButton from "@/components/LineButton";
 import UnderlineInput from "@/components/UnderlineInput";
 
-import useInput from "@/hooks/useInput";
-import useUpdateUserProfile from "@/pages/MyPage/hooks/useUpdateUserProfile";
-
 import { REGEX } from "@/constants";
 import { ValueOf } from "@/types";
-
-import Pencil from "@/assets/icons/bx-pencil.svg";
 
 const MODE = {
   NORMAL: "normal",

--- a/frontend/src/pages/MyPage/components/UserProfile.tsx
+++ b/frontend/src/pages/MyPage/components/UserProfile.tsx
@@ -10,6 +10,9 @@ import IconButton from "@/components/IconButton";
 import LineButton from "@/components/LineButton";
 import UnderlineInput from "@/components/UnderlineInput";
 
+import useInput from "@/hooks/useInput";
+import useUpdateUserProfile from "@/pages/MyPage/hooks/useUpdateUserProfile";
+
 import { REGEX } from "@/constants";
 import { ValueOf } from "@/types";
 
@@ -42,13 +45,17 @@ const UserProfile = ({ username, email }: UserProfileProps) => {
     }
   };
 
-  const handleEditCancelButtonClick = () => {
+  const handleEditCancelButtonClick: React.MouseEventHandler<
+    HTMLButtonElement
+  > = () => {
     if (confirm("이름 변경을 취소하시겠습니까?")) {
       setMode(MODE.NORMAL);
     }
   };
 
-  const handleEditSaveButtonClick = () => {
+  const handleUserProfileEditFormSubmit: React.FormEventHandler<
+    HTMLFormElement
+  > = () => {
     if (mode === MODE.EDIT) {
       updateUserProfile({ username: editName });
       setMode(MODE.NORMAL);
@@ -73,18 +80,22 @@ const UserProfile = ({ username, email }: UserProfileProps) => {
           <LineButton onClick={handleLogoutButtonClick}>로그아웃</LineButton>
         </>
       ) : (
-        <StyledUserProfileEditForm>
-          <UnderlineInput
-            value={editName}
-            pattern={REGEX.USERNAME.source}
-            errorMessage="1 ~ 64자 사이의 이름을 입력해주세요"
-            onChange={handleEditNameChange}
-          />
-          <StyledEditLineButtonContainer>
-            <LineButton onClick={handleEditCancelButtonClick}>취소</LineButton>
-            <LineButton onClick={handleEditSaveButtonClick}>완료</LineButton>
-          </StyledEditLineButtonContainer>
-        </StyledUserProfileEditForm>
+        <>
+          <StyledUserProfileEditForm onSubmit={handleUserProfileEditFormSubmit}>
+            <UnderlineInput
+              value={editName}
+              pattern={REGEX.USERNAME.source}
+              errorMessage="1 ~ 64자 사이의 이름을 입력해주세요"
+              onChange={handleEditNameChange}
+            />
+            <StyledEditLineButtonContainer>
+              <LineButton onClick={handleEditCancelButtonClick}>
+                취소
+              </LineButton>
+              <LineButton type="submit">완료</LineButton>
+            </StyledEditLineButtonContainer>
+          </StyledUserProfileEditForm>
+        </>
       )}
     </StyledProfile>
   );

--- a/frontend/src/pages/MyPage/components/UserProfile.tsx
+++ b/frontend/src/pages/MyPage/components/UserProfile.tsx
@@ -68,16 +68,20 @@ const UserProfile = ({ username, email }: UserProfileProps) => {
         <>
           <StyledNormal>
             <StyledName>{username}</StyledName>
-            <IconButton
-              onClick={() => {
-                setMode(MODE.EDIT);
-              }}
-            >
-              <Pencil />
-            </IconButton>
+            <StyledEmail>{email}</StyledEmail>
+            <StyledEditLineButtonContainer>
+              <LineButton
+                onClick={() => {
+                  setMode(MODE.EDIT);
+                }}
+              >
+                이름 수정하기
+              </LineButton>
+              <LineButton onClick={handleLogoutButtonClick}>
+                로그아웃
+              </LineButton>
+            </StyledEditLineButtonContainer>
           </StyledNormal>
-          <StyledEmail>{email}</StyledEmail>
-          <LineButton onClick={handleLogoutButtonClick}>로그아웃</LineButton>
         </>
       ) : (
         <>
@@ -107,13 +111,10 @@ const StyledProfile = styled.div`
 
 const StyledNormal = styled.div`
   display: flex;
+  flex-direction: column;
   justify-content: space-between;
 
-  width: 160px;
-
-  svg {
-    font-size: 20px;
-  }
+  gap: 12px;
 `;
 
 const StyledUserProfileEditForm = styled.form`
@@ -123,7 +124,6 @@ const StyledUserProfileEditForm = styled.form`
   font-size: 14px;
 
   input {
-    width: 160px;
     font-size: 24px;
   }
 `;
@@ -135,7 +135,6 @@ const StyledName = styled.div`
 
 const StyledEmail = styled.div`
   color: ${({ theme }) => theme.colors.GRAY_700};
-  margin-bottom: 12px;
 `;
 
 const StyledEditLineButtonContainer = styled.div`

--- a/frontend/src/pages/MyPage/components/UserProfile.tsx
+++ b/frontend/src/pages/MyPage/components/UserProfile.tsx
@@ -100,7 +100,7 @@ const UserProfile = ({ username, email }: UserProfileProps) => {
 };
 
 const StyledProfile = styled.div`
-  margin: 10px 0 40px 10px;
+  margin: 24px 10px;
 `;
 
 const StyledNormal = styled.div`
@@ -119,6 +119,18 @@ const StyledUserProfileEditForm = styled.form`
 
   input {
     font-size: 24px;
+  }
+
+  @media only screen and (min-width: 600px) {
+    input {
+      width: 70%;
+    }
+  }
+
+  @media only screen and (min-width: 960px) {
+    input {
+      width: 50%;
+    }
   }
 `;
 


### PR DESCRIPTION
## 작업 내용
### 핵심 개선사항
- 기존의 `handleEditSaveButtonClick`을 form의 submit handler로 주도록 변경했습니다. 이때 핸들러 이름을 `handleUserProfileEditFormSubmit`으로 변경했습니다.

### 추가 UI 관련 개선
- UserProfile 영역의 레이아웃을 정리했습니다. 불필요하게 감싸고 있는 div 태그를 정리하고, flex로 내부 컴포넌트의 정렬을 더 알아보기 쉽게 수정했습니다.
- 사용자 이름을 보여주는 영역, 사용자 이름을 수정하기 위한 Input의 크기를 키웠습니다. 사용자 이름 최대 길이가 길어지면서, 이름을 길게 작성하는 경우 UI가 어색해졌더라고요. 긴 사용자 이름에도 대응할 수 있도록, 해당 영역들의 가로 길이를 키웠고, 그 과정에서 수정 버튼을 아래로 보내봤습니다.

#### 변경 전
<img src="https://user-images.githubusercontent.com/71116429/196017335-a78ebf8e-5689-4994-b5bc-a599afc3a6f5.png" width="300px" />
<img src="https://user-images.githubusercontent.com/71116429/196017345-0bc392b5-7c11-48d1-becc-2268f1e0fad7.png" width="300px" />


#### 변경 후
<img src="https://user-images.githubusercontent.com/71116429/196017311-42b86320-7f6b-49fd-b4b9-d2f3d77995af.png" width="300px" />
<img src="https://user-images.githubusercontent.com/71116429/196017320-f2291e0a-04d5-48e3-bb12-7c2d3abd894b.png" width="300px" />


## 논의하고 싶은 부분
- 사용자 이름 변경을 테스트해보다가 UI가 어색해져서 같이 수정해봤는데요. 도리는 다른 의견일 수 있을 것 같아요. 확인해보고 의견주세요!

closed #565 

