### PR TITLE
feat: 롤링페이퍼 정렬/필터링 기능을 구현한다.

### DIFF
--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -48,7 +48,7 @@ const getTeamRollingpapers = async ({
     if (filter) {
       params.append("filter", filter);
     }
-    console.log(params, params.toString());
+
     return appClient.get(`/teams/${id}/rollingpapers?${params.toString()}`);
   });
 

--- a/frontend/src/api/team.ts
+++ b/frontend/src/api/team.ts
@@ -4,6 +4,7 @@ import { Team } from "@/types";
 
 import {
   GetTeamSearchResultRequest,
+  GetTeamRollingpapersRequest,
   PostTeamRequest,
   PostTeamMemberWithInviteCodeRequest,
   PostTeamMemberRequest,
@@ -34,8 +35,22 @@ const getTeamSearchResult =
 const getTeamMembers = async (id: Team["id"]) =>
   requestApi(() => appClient.get(`/teams/${id}/members`));
 
-const getTeamRollingpapers = async (id: Team["id"]) =>
-  requestApi(() => appClient.get(`/teams/${id}/rollingpapers`));
+const getTeamRollingpapers = async ({
+  id,
+  order,
+  filter,
+}: GetTeamRollingpapersRequest) =>
+  requestApi(() => {
+    const params = new URLSearchParams();
+    if (order) {
+      params.append("order", order);
+    }
+    if (filter) {
+      params.append("filter", filter);
+    }
+    console.log(params, params.toString());
+    return appClient.get(`/teams/${id}/rollingpapers?${params.toString()}`);
+  });
 
 const getTeamMyNickname = async (id: Team["id"]) =>
   requestApi(() => appClient.get(`/teams/${id}/me`));

--- a/frontend/src/constants/index.ts
+++ b/frontend/src/constants/index.ts
@@ -59,6 +59,11 @@ const COOKIE_KEY = {
   ACCESS_TOKEN: "accessToken",
 } as const;
 
+const ROLLINGPAPER_ORDER = {
+  LATEST: "latest",
+  OLDEST: "oldest",
+} as const;
+
 export {
   REGEX,
   COLORS,
@@ -72,4 +77,5 @@ export {
   GOOGLE_OAUTH_URL,
   RECIPIENT,
   COOKIE_KEY,
+  ROLLINGPAPER_ORDER,
 };

--- a/frontend/src/mocks/handlers/rollingpaperHandlers.js
+++ b/frontend/src/mocks/handlers/rollingpaperHandlers.js
@@ -1,5 +1,7 @@
 import { rest } from "msw";
 
+import { ROLLINGPAPER_ORDER } from "@/constants";
+
 import rollingPaperDummy from "../dummy/rollingpapers.json";
 
 const rollingpapers = rollingPaperDummy.rollingpapers;
@@ -46,9 +48,20 @@ const rollingpaperHandlers = [
   // 롤링페이퍼 목록 조회 by Team
   rest.get("/api/v1/teams/:teamId/rollingpapers", (req, res, ctx) => {
     const { teamId } = req.params;
+    const order = req.url.searchParams.get("order");
+    const filter = req.url.searchParams.get("filter");
+
+    const filteredRollingpapers = rollingpapers.filter((rollingpaper) =>
+      filter ? rollingpaper.recipient === filter.toUpperCase() : true
+    );
+
+    let sortedRollingpapers = [...filteredRollingpapers];
+    if (order === ROLLINGPAPER_ORDER.LATEST) {
+      sortedRollingpapers = sortedRollingpapers.reverse();
+    }
 
     const result = {
-      rollingpapers: rollingpapers.map(({ id, title, to }) => ({
+      rollingpapers: sortedRollingpapers.map(({ id, title, to }) => ({
         id,
         title,
         to,

--- a/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
@@ -1,18 +1,15 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
-
-import IconButton from "@/components/IconButton";
-import RollingpaperListItem from "@/pages/TeamDetailPage/components/RollingpaperListItem";
 
 import useValidateParam from "@/hooks/useValidateParam";
 import useReadTeamRollingpaper from "@/pages/TeamDetailPage/hooks/useReadTeamRollingpaper";
 
+import RollingpaperListItem from "@/pages/TeamDetailPage/components/RollingpaperListItem";
+
 import { RECIPIENT, ROLLINGPAPER_ORDER } from "@/constants";
 
 import { GetTeamRollingpapersRequest } from "@/types/apiRequest";
-
-import PlusIcon from "@/assets/icons/bx-plus.svg";
 
 const RollingpaperList = () => {
   const navigate = useNavigate();
@@ -25,16 +22,11 @@ const RollingpaperList = () => {
   const {
     isLoading: isLoadingGetTeamRollingpaperList,
     data: teamRollinpaperListResponse,
-    refetch,
   } = useReadTeamRollingpaper({
     id: teamId,
     order,
     filter,
   });
-
-  useEffect(() => {
-    refetch();
-  }, [order, filter]);
 
   if (isLoadingGetTeamRollingpaperList) {
     return <div>로딩중</div>;
@@ -46,36 +38,39 @@ const RollingpaperList = () => {
 
   return (
     <StyledRollingpaperListContainer>
+      <StyledRollingpaperCreateButton
+        onClick={() => {
+          navigate(`/rollingpaper/new?team-id=${teamId}`);
+        }}
+      >
+        📜 롤링페이퍼 만들기
+      </StyledRollingpaperCreateButton>
       <StyledRollingpaperListHead>
         <h4>롤링페이퍼 목록</h4>
-        <IconButton
-          size="small"
-          onClick={() => {
-            navigate(`/rollingpaper/new?team-id=${teamId}`);
-          }}
-        >
-          <PlusIcon />
-        </IconButton>
+        <StyledSelectContainer>
+          <select
+            value={order}
+            onChange={(e) => {
+              setOrder(e.target.value as GetTeamRollingpapersRequest["order"]);
+            }}
+          >
+            <option value={ROLLINGPAPER_ORDER.LATEST}>최신 순</option>
+            <option value={ROLLINGPAPER_ORDER.OLDEST}>오래된 순</option>
+          </select>
+          <select
+            value={filter}
+            onChange={(e) => {
+              setFilter(
+                e.target.value as GetTeamRollingpapersRequest["filter"]
+              );
+            }}
+          >
+            <option value={""}>전체</option>
+            <option value={RECIPIENT.TEAM.toLowerCase()}>모임</option>
+            <option value={RECIPIENT.MEMBER.toLowerCase()}>멤버</option>
+          </select>
+        </StyledSelectContainer>
       </StyledRollingpaperListHead>
-      <StyledSelectContainer>
-        <select
-          onChange={(e) => {
-            setOrder(e.target.value as GetTeamRollingpapersRequest["order"]);
-          }}
-        >
-          <option value={ROLLINGPAPER_ORDER.LATEST}>최신 순</option>
-          <option value={ROLLINGPAPER_ORDER.OLDEST}>오래된 순</option>
-        </select>
-        <select
-          onChange={(e) => {
-            setFilter(e.target.value as GetTeamRollingpapersRequest["filter"]);
-          }}
-        >
-          <option value={""}>전체</option>
-          <option value={RECIPIENT.TEAM.toLowerCase()}>모임</option>
-          <option value={RECIPIENT.MEMBER.toLowerCase()}>멤버</option>
-        </select>
-      </StyledSelectContainer>
 
       <StyledRollingpaperList>
         {teamRollinpaperListResponse.rollingpapers.map((rollingpaper) => (
@@ -89,21 +84,40 @@ const RollingpaperList = () => {
 };
 
 const StyledRollingpaperListContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
   width: 90%;
+`;
+
+const StyledRollingpaperCreateButton = styled.button`
+  width: 100%;
+  align-self: center;
+  padding: 16px;
+
+  font-size: 18px;
+  background: antiquewhite;
+
+  &:hover {
+    background: #f9e1c3;
+  }
 `;
 
 const StyledRollingpaperListHead = styled.div`
   width: 100%;
 
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   justify-content: space-between;
-
-  padding: 0 0 16px 0;
+  gap: 12px;
 
   h4 {
     font-size: 20px;
     font-weight: bold;
+  }
+
+  @media only screen and (min-width: 600px) {
+    flex-direction: row;
   }
 `;
 
@@ -111,8 +125,6 @@ const StyledSelectContainer = styled.div`
   display: flex;
   gap: 8px;
   justify-content: flex-end;
-
-  padding: 0 0 16px 0;
 
   select {
     padding: 6px 8px;

--- a/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
 
@@ -7,20 +8,33 @@ import RollingpaperListItem from "@/pages/TeamDetailPage/components/Rollingpaper
 import useValidateParam from "@/hooks/useValidateParam";
 import useReadTeamRollingpaper from "@/pages/TeamDetailPage/hooks/useReadTeamRollingpaper";
 
+import { RECIPIENT, ROLLINGPAPER_ORDER } from "@/constants";
+
+import { GetTeamRollingpapersRequest } from "@/types/apiRequest";
+
 import PlusIcon from "@/assets/icons/bx-plus.svg";
 
 const RollingpaperList = () => {
   const navigate = useNavigate();
   const teamId = useValidateParam<number>("teamId");
+  const [order, setOrder] = useState<GetTeamRollingpapersRequest["order"]>(
+    ROLLINGPAPER_ORDER.LATEST
+  );
+  const [filter, setFilter] = useState<GetTeamRollingpapersRequest["filter"]>();
 
   const {
     isLoading: isLoadingGetTeamRollingpaperList,
     data: teamRollinpaperListResponse,
+    refetch,
   } = useReadTeamRollingpaper({
     id: teamId,
-    order: "latest",
-    filter: "member",
+    order,
+    filter,
   });
+
+  useEffect(() => {
+    refetch();
+  }, [order, filter]);
 
   if (isLoadingGetTeamRollingpaperList) {
     return <div>로딩중</div>;
@@ -43,6 +57,26 @@ const RollingpaperList = () => {
           <PlusIcon />
         </IconButton>
       </StyledRollingpaperListHead>
+      <StyledSelectContainer>
+        <select
+          onChange={(e) => {
+            setOrder(e.target.value as GetTeamRollingpapersRequest["order"]);
+          }}
+        >
+          <option value={ROLLINGPAPER_ORDER.LATEST}>최신 순</option>
+          <option value={ROLLINGPAPER_ORDER.OLDEST}>오래된 순</option>
+        </select>
+        <select
+          onChange={(e) => {
+            setFilter(e.target.value as GetTeamRollingpapersRequest["filter"]);
+          }}
+        >
+          <option value={""}>전체</option>
+          <option value={RECIPIENT.TEAM.toLowerCase()}>모임</option>
+          <option value={RECIPIENT.MEMBER.toLowerCase()}>멤버</option>
+        </select>
+      </StyledSelectContainer>
+
       <StyledRollingpaperList>
         {teamRollinpaperListResponse.rollingpapers.map((rollingpaper) => (
           <Link key={rollingpaper.id} to={`rollingpaper/${rollingpaper.id}`}>
@@ -65,11 +99,23 @@ const StyledRollingpaperListHead = styled.div`
   flex-direction: row;
   justify-content: space-between;
 
-  padding: 16px 0;
+  padding: 0 0 16px 0;
 
   h4 {
     font-size: 20px;
     font-weight: bold;
+  }
+`;
+
+const StyledSelectContainer = styled.div`
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+
+  padding: 0 0 16px 0;
+
+  select {
+    padding: 6px 8px;
   }
 `;
 

--- a/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
@@ -4,9 +4,10 @@ import styled from "@emotion/styled";
 import IconButton from "@/components/IconButton";
 import RollingpaperListItem from "@/pages/TeamDetailPage/components/RollingpaperListItem";
 
-import PlusIcon from "@/assets/icons/bx-plus.svg";
 import useValidateParam from "@/hooks/useValidateParam";
 import useReadTeamRollingpaper from "@/pages/TeamDetailPage/hooks/useReadTeamRollingpaper";
+
+import PlusIcon from "@/assets/icons/bx-plus.svg";
 
 const RollingpaperList = () => {
   const navigate = useNavigate();
@@ -15,7 +16,11 @@ const RollingpaperList = () => {
   const {
     isLoading: isLoadingGetTeamRollingpaperList,
     data: teamRollinpaperListResponse,
-  } = useReadTeamRollingpaper(teamId);
+  } = useReadTeamRollingpaper({
+    id: teamId,
+    order: "latest",
+    filter: "member",
+  });
 
   if (isLoadingGetTeamRollingpaperList) {
     return <div>로딩중</div>;

--- a/frontend/src/pages/TeamDetailPage/hooks/useReadTeamRollingpaper.tsx
+++ b/frontend/src/pages/TeamDetailPage/hooks/useReadTeamRollingpaper.tsx
@@ -12,7 +12,7 @@ const useReadTeamRollingpaper = ({
   filter,
 }: GetTeamRollingpapersRequest) =>
   useQuery<GetTeamRollingpapersResponse, AxiosError>(
-    ["rollingpaperList", id],
+    ["rollingpaperList", id, order, filter],
     () => getTeamRollingpapers({ id, order, filter })
   );
 

--- a/frontend/src/pages/TeamDetailPage/hooks/useReadTeamRollingpaper.tsx
+++ b/frontend/src/pages/TeamDetailPage/hooks/useReadTeamRollingpaper.tsx
@@ -4,11 +4,16 @@ import { AxiosError } from "axios";
 import { getTeamRollingpapers } from "@/api/team";
 
 import { GetTeamRollingpapersResponse } from "@/types/apiResponse";
+import { GetTeamRollingpapersRequest } from "@/types/apiRequest";
 
-const useReadTeamRollingpaper = (teamId: number) =>
+const useReadTeamRollingpaper = ({
+  id,
+  order,
+  filter,
+}: GetTeamRollingpapersRequest) =>
   useQuery<GetTeamRollingpapersResponse, AxiosError>(
-    ["rollingpaperList", teamId],
-    () => getTeamRollingpapers(teamId)
+    ["rollingpaperList", id],
+    () => getTeamRollingpapers({ id, order, filter })
   );
 
 export default useReadTeamRollingpaper;

--- a/frontend/src/types/apiRequest.ts
+++ b/frontend/src/types/apiRequest.ts
@@ -1,4 +1,13 @@
-import { Message, Rollingpaper, Team, TeamMember, User } from ".";
+import {
+  User,
+  Message,
+  Recipient,
+  Rollingpaper,
+  Team,
+  TeamMember,
+  ValueOf,
+} from ".";
+import { ROLLINGPAPER_ORDER } from "@/constants";
 
 // oauth
 export interface OauthRequest {
@@ -67,6 +76,12 @@ export interface PostMemberRollingpaperRequest {
 export interface GetTeamSearchResultRequest {
   keyword: string;
   count: number;
+}
+
+export interface GetTeamRollingpapersRequest {
+  id: Team["id"];
+  order?: ValueOf<typeof ROLLINGPAPER_ORDER>;
+  filter?: Lowercase<Recipient>;
 }
 
 export interface PostTeamRequest extends Omit<Team, "id" | "joined"> {


### PR DESCRIPTION
## 작업 내용
- 모임 롤링페이퍼 조회 로직을 수정했습니다. 요청 url의 searchParams에 order와 filter를 추가했습니다.
- 모임 상세 페이지에서, order와 filter 상태를 추가하고 상태가 업데이트 되면 모임 롤링페이퍼 조회 요청을 refetch 하도록 했습니다.

### 수정 후
#### 모바일
<img src="https://user-images.githubusercontent.com/71116429/195998988-74a89513-2129-4b16-b2b7-d440f9f2732f.png" width="300px" />

#### 데스크탑
<img src="https://user-images.githubusercontent.com/71116429/195999011-f4a0b914-e7b3-43ad-9407-4139ae2d77ff.png" width="600px" />


## 논의할 부분
- 로직을 먼저 정리하는 과정에서 기본 select, option 태그로 구현해봤습니다. 이후에 Select, Dropdown을 추가로 직접 구현할까 생각도 했는데요. **제 생각에는 기본 select, option 태그의 UI도 깔끔하고 괜찮아서 커스텀 컴포넌트를 따로 만들지는 않았어요.** 
저는 지금도 충분히 괜찮다고 생각합니다. **스타일을 더 주는 게 필요하다고 생각하는지, 준다면 어떤 스타일이 괜찮은지** 도리 의견 궁금합니다~

closed #516 