### PR TITLE
fix: 사용자 안내 문구를 변경한다.

### DIFF
--- a/frontend/src/pages/MainPage/index.tsx
+++ b/frontend/src/pages/MainPage/index.tsx
@@ -25,7 +25,7 @@ const MainPage = () => {
       <StyledNav>
         <NavigationButton
           icon="📜"
-          description={`롤링페이퍼\n시작하기`}
+          description={`롤링페이퍼\n만들기`}
           onClick={handleRollingpaperStartClick}
         />
         <NavigationButton

--- a/frontend/src/pages/TeamDetailPage/components/TeamJoinSection.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/TeamJoinSection.tsx
@@ -37,7 +37,7 @@ const TeamJoinSection = ({ isSecretTeam }: TeamJoinSectionProps) => {
   const PublicTeamModal = () => (
     <StyledTeamJoinModal>
       <p>롤링페이퍼를 확인하려면 모임에 참여해주세요</p>
-      <LineButton onClick={handleModalOpen}>참여 요청하기</LineButton>
+      <LineButton onClick={handleModalOpen}>모임 참여하기</LineButton>
     </StyledTeamJoinModal>
   );
 


### PR DESCRIPTION
## 구현 사항
- 사용자에게 혼란을 유발할 수 있는 안내 문구를 변경했습니다
- 메인 화면의 nav 버튼 문구들을 통일했습니다

<img width="757" alt="스크린샷 2022-10-19 오전 11 05 32" src="https://user-images.githubusercontent.com/67692759/196580245-adc7f4e1-00dd-46d1-8653-a0353603d152.png">


<img width="757" alt="스크린샷 2022-10-19 오전 11 05 39" src="https://user-images.githubusercontent.com/67692759/196580257-cdd955a2-9184-4308-878b-52a3346fabd3.png">

closed #560 