### PR TITLE
feat: 모임 상세 페이지 롤링페이퍼 empty state UI 구현

### DIFF
--- a/frontend/src/assets/images/surprise-state.svg
+++ b/frontend/src/assets/images/surprise-state.svg
@@ -1,0 +1,8 @@
+<svg width="164" height="117" viewBox="0 0 164 117" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="3.5" y="3.5" width="157" height="110" stroke="#DADADA" stroke-width="7"/>
+<line x1="1.53448" y1="4.85431" x2="83.5345" y2="44.8543" stroke="#DADADA" stroke-width="7"/>
+<line x1="80.3865" y1="44.8941" x2="157.387" y2="4.89408" stroke="#DADADA" stroke-width="7"/>
+<circle cx="42" cy="66" r="5" fill="#D9D9D9"/>
+<circle cx="77" cy="66" r="5" fill="#D9D9D9"/>
+<path d="M66.5 88C66.5 93.319 63.0194 96.5 60 96.5C56.9806 96.5 53.5 93.319 53.5 88C53.5 82.681 56.9806 79.5 60 79.5C63.0194 79.5 66.5 82.681 66.5 88Z" stroke="#D9D9D9" stroke-width="7"/>
+</svg>

--- a/frontend/src/pages/TeamDetailPage/components/EmptyTeamRollingpaper.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/EmptyTeamRollingpaper.tsx
@@ -1,0 +1,35 @@
+import styled from "@emotion/styled";
+
+import SurpriseStateImg from "@/assets/images/surprise-state.svg";
+
+const EmptyTeamRollingpaper = () => {
+  return (
+    <StyledEmpty>
+      <SurpriseStateImg />
+      <StyledEmptyMessage>첫 롤링페이퍼를 만들어주세요!</StyledEmptyMessage>
+    </StyledEmpty>
+  );
+};
+
+const StyledEmpty = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  margin-top: 30px;
+
+  svg {
+    font-size: 170px;
+  }
+`;
+
+const StyledEmptyMessage = styled.div`
+  font-size: 24px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.GRAY_400};
+
+  margin-bottom: 20px;
+`;
+
+export default EmptyTeamRollingpaper;

--- a/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
+++ b/frontend/src/pages/TeamDetailPage/components/RollingpaperList.tsx
@@ -7,6 +7,7 @@ import useReadTeamRollingpaper from "@/pages/TeamDetailPage/hooks/useReadTeamRol
 
 import Loading from "@/components/Loading";
 import RollingpaperListItem from "@/pages/TeamDetailPage/components/RollingpaperListItem";
+import EmptyTeamRollingpaper from "@/pages/TeamDetailPage/components/EmptyTeamRollingpaper";
 
 import { RECIPIENT, ROLLINGPAPER_ORDER } from "@/constants";
 
@@ -35,6 +36,10 @@ const RollingpaperList = () => {
 
   if (!teamRollinpaperListResponse) {
     return <div>에러</div>;
+  }
+
+  if (teamRollinpaperListResponse.rollingpapers.length === 0) {
+    return <EmptyTeamRollingpaper />;
   }
 
   return (


### PR DESCRIPTION
## 구현 사항
- 팀에 작성된 롤링페이퍼가 없는 경우의 UI를 구현한다

<img width="1080" alt="스크린샷 2022-10-20 오전 12 12 41" src="https://user-images.githubusercontent.com/67692759/196731662-70364d33-955d-4424-bd35-744f9a36c009.png">


closed #580