### PR TITLE
feat: 실시간 알림 기능을 구현한다.

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core:6.4.2'
 	implementation 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.3'
 	implementation "com.querydsl:querydsl-jpa:5.0.0"
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0"
 
 	compileOnly 'org.projectlombok:lombok'

--- a/backend/src/docs/asciidoc/errorCodes.adoc
+++ b/backend/src/docs/asciidoc/errorCodes.adoc
@@ -192,3 +192,19 @@
 | 토큰의 유효기간이 만료됐습니다.
 | `400 Bad Request`
 |===
+
+=== 알림 에러
+|===
+| error code | error message | show message | status code
+
+|`5001`
+| 해당 알림은 존재하지 않습니다. id={%d}
+| 올바르지 않은 알림입니다.
+| `404 Not Found`
+
+|`5002`
+| 유효하지 않은 reids message입니다. message={%s}
+| 유효하지 않은 redis message입니다.
+| `400 Bad Request`
+
+|===

--- a/backend/src/docs/asciidoc/notifications.adoc
+++ b/backend/src/docs/asciidoc/notifications.adoc
@@ -1,0 +1,13 @@
+== 알림
+
+=== 구독
+operation::notification-controller-test/subscribe[snippets='http-request,http-response']
+
+=== 안 읽은 알림 전체 조회
+operation::notification-controller-test/notifications[snippets='http-request,http-response']
+
+=== 읽지 않은 알림 단건 읽기
+operation::notification-controller-test/read-notification[snippets='http-request,http-response']
+
+=== 읽지 않은 알림 모두 읽기
+operation::notification-controller-test/read-all-notifications[snippets='http-request,http-response']

--- a/backend/src/main/java/com/woowacourse/naepyeon/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/config/AuthenticationPrincipalConfig.java
@@ -20,10 +20,11 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new LoginInterceptor(jwtTokenProvider))
                 .addPathPatterns("/api/v1/**")
-                .excludePathPatterns("/api/v1/oauth/**")
+                .excludePathPatterns("/api/v1/oauth/*")
                 .excludePathPatterns("/api/v1/members")
                 .excludePathPatterns("/api/v1/renewal-token")
-                .excludePathPatterns("/api/v1/logout");
+                .excludePathPatterns("/api/v1/logout")
+                .excludePathPatterns("/api/v1/subscribe");
     }
 
     @Override

--- a/backend/src/main/java/com/woowacourse/naepyeon/config/RedisConfig.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/config/RedisConfig.java
@@ -1,0 +1,51 @@
+package com.woowacourse.naepyeon.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.naepyeon.service.dto.NotificationResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisOperations<String, NotificationResponseDto> eventRedisOperations(
+            RedisConnectionFactory redisConnectionFactory, ObjectMapper objectMapper) {
+        final Jackson2JsonRedisSerializer<NotificationResponseDto> jsonRedisSerializer = new Jackson2JsonRedisSerializer<>(
+                NotificationResponseDto.class);
+        jsonRedisSerializer.setObjectMapper(objectMapper);
+        final RedisTemplate<String, NotificationResponseDto> eventRedisTemplate = new RedisTemplate<>();
+        eventRedisTemplate.setConnectionFactory(redisConnectionFactory);
+        eventRedisTemplate.setKeySerializer(RedisSerializer.string());
+        eventRedisTemplate.setValueSerializer(jsonRedisSerializer);
+        eventRedisTemplate.setHashKeySerializer(RedisSerializer.string());
+        eventRedisTemplate.setHashValueSerializer(jsonRedisSerializer);
+        return eventRedisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory) {
+        final RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
+        redisMessageListenerContainer.setConnectionFactory(redisConnectionFactory);
+        return redisMessageListenerContainer;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/config/RedisConfig.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/config/RedisConfig.java
@@ -19,7 +19,7 @@ public class RedisConfig {
     @Value("${spring.redis.host}")
     private String host;
 
-    @Value("${spring.redis.port")
+    @Value("${spring.redis.port}")
     private int port;
 
     @Bean

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/NotificationController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/NotificationController.java
@@ -1,0 +1,49 @@
+package com.woowacourse.naepyeon.controller;
+
+import com.woowacourse.naepyeon.controller.auth.AuthenticationPrincipal;
+import com.woowacourse.naepyeon.controller.dto.LoginMemberRequest;
+import com.woowacourse.naepyeon.service.NotificationService;
+import com.woowacourse.naepyeon.service.dto.NotificationsResponseDto;
+import java.io.IOException;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping(value = "/subscribe", produces = "text/event-stream")
+    public SseEmitter subscribe(@RequestParam("id") Long id) throws IOException {
+        return notificationService.subscribe(id);
+    }
+
+    @GetMapping("/notifications")
+    public ResponseEntity<NotificationsResponseDto> notifications(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest) {
+        return ResponseEntity.ok().body(notificationService.findAllById(loginMemberRequest.getId()));
+    }
+
+    @PutMapping("/notifications/{id}")
+    public ResponseEntity<Void> readNotification(@PathVariable Long id) {
+        notificationService.readNotification(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/notifications/all")
+    public ResponseEntity<Void> readAllNotifications(
+            @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest) {
+        notificationService.readAllNotifications(loginMemberRequest.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/controller/NotificationController.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/controller/NotificationController.java
@@ -31,7 +31,7 @@ public class NotificationController {
     @GetMapping("/notifications")
     public ResponseEntity<NotificationsResponseDto> notifications(
             @AuthenticationPrincipal @Valid final LoginMemberRequest loginMemberRequest) {
-        return ResponseEntity.ok().body(notificationService.findAllById(loginMemberRequest.getId()));
+        return ResponseEntity.ok().body(notificationService.findAllByMemberIdAndUnread(loginMemberRequest.getId()));
     }
 
     @PutMapping("/notifications/{id}")

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/notification/ContentType.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/notification/ContentType.java
@@ -1,0 +1,7 @@
+package com.woowacourse.naepyeon.domain.notification;
+
+public enum ContentType {
+
+    ROLLINGPAPER_AT_MY_TEAM,
+    MESSAGE_AT_MY_ROLLINGPAPER
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/notification/Notification.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/notification/Notification.java
@@ -1,0 +1,63 @@
+package com.woowacourse.naepyeon.domain.notification;
+
+import com.woowacourse.naepyeon.domain.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Index;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "notification", indexes = {
+        @Index(name = "notification_read_index", columnList = "is_read")
+})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
+
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "content_type")
+    private ContentType contentType;
+
+    @Column(name = "team_name")
+    private String teamName;
+
+    @Column(name = "rollingpaper_title")
+    private String rollingpaperTitle;
+
+    @Column(name = "url")
+    private String url;
+
+    @Column(name = "is_read")
+    private boolean isRead;
+
+    public Notification(final Long memberId, final ContentType contentType, final String teamName,
+                        final String rollingpaperTitle, final String url,
+                        final boolean isRead) {
+        this.memberId = memberId;
+        this.contentType = contentType;
+        this.teamName = teamName;
+        this.rollingpaperTitle = rollingpaperTitle;
+        this.url = url;
+        this.isRead = isRead;
+    }
+
+    public void read() {
+        this.isRead = true;
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/InvalidRedisMessageException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/InvalidRedisMessageException.java
@@ -1,0 +1,16 @@
+package com.woowacourse.naepyeon.exception;
+
+import org.springframework.data.redis.connection.Message;
+import org.springframework.http.HttpStatus;
+
+public class InvalidRedisMessageException extends NaePyeonException {
+
+    public InvalidRedisMessageException(final Message message) {
+        super(
+                String.format("유효하지 않은 reids message입니다. message= {%s}", message),
+                "유효하지 않은 redis message입니다.",
+                HttpStatus.BAD_REQUEST,
+                "5002"
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/exception/NotFoundNotificationException.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/exception/NotFoundNotificationException.java
@@ -1,0 +1,15 @@
+package com.woowacourse.naepyeon.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class NotFoundNotificationException extends NaePyeonException {
+
+    public NotFoundNotificationException(final Long notificationId) {
+        super(
+                String.format("해당 알림은 존재하지 않습니다. id={%d}", notificationId),
+                "올바르지 않은 알림입니다.",
+                HttpStatus.NOT_FOUND,
+                "5001"
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/notification/NotificationRepository.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/notification/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.woowacourse.naepyeon.repository.notification;
+
+import com.woowacourse.naepyeon.domain.notification.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/notification/NotificationRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/notification/NotificationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.woowacourse.naepyeon.repository.notification;
+
+import com.woowacourse.naepyeon.domain.notification.Notification;
+import java.util.List;
+
+public interface NotificationRepositoryCustom {
+
+    List<Notification> findAllByMemberIdAndUnread(Long memberId);
+
+    void updateNotificationRead(final Long memberId);
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/notification/NotificationRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/notification/NotificationRepositoryImpl.java
@@ -22,6 +22,7 @@ public class NotificationRepositoryImpl implements NotificationRepositoryCustom 
                 .fetch();
     }
 
+    @Override
     public void updateNotificationRead(final Long memberId) {
         queryFactory.update(notification)
                 .set(notification.isRead, true)

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/notification/NotificationRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/notification/NotificationRepositoryImpl.java
@@ -1,0 +1,34 @@
+package com.woowacourse.naepyeon.repository.notification;
+
+import static com.woowacourse.naepyeon.domain.notification.QNotification.notification;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.woowacourse.naepyeon.domain.notification.Notification;
+import java.util.List;
+import javax.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    @Override
+    public List<Notification> findAllByMemberIdAndUnread(final Long memberId) {
+        return queryFactory.selectFrom(notification)
+                .where(notification.memberId.eq(memberId), notification.isRead.eq(false))
+                .orderBy(notification.id.desc())
+                .fetch();
+    }
+
+    public void updateNotificationRead(final Long memberId) {
+        queryFactory.update(notification)
+                .set(notification.isRead, true)
+                .where(notification.memberId.eq(memberId))
+                .execute();
+
+        em.flush();
+        em.clear();
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/MessageService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/MessageService.java
@@ -23,9 +23,11 @@ import com.woowacourse.naepyeon.service.dto.MessageResponseDto;
 import com.woowacourse.naepyeon.service.dto.MessageUpdateRequestDto;
 import com.woowacourse.naepyeon.service.dto.WrittenMessageResponseDto;
 import com.woowacourse.naepyeon.service.dto.WrittenMessagesResponseDto;
+import com.woowacourse.naepyeon.service.event.RollingpaperEvent;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -42,6 +44,7 @@ public class MessageService {
     private final RollingpaperRepository rollingpaperRepository;
     private final MemberRepository memberRepository;
     private final TeamParticipationRepository teamParticipationRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public Long saveMessage(final MessageRequestDto messageRequestDto, final Long rollingpaperId, final Long authorId) {
         final Rollingpaper rollingpaper = rollingpaperRepository.findById(rollingpaperId)
@@ -51,6 +54,8 @@ public class MessageService {
                 .orElseThrow(() -> new NotFoundMemberException(authorId));
         final Message message = new Message(messageRequestDto.getContent(), messageRequestDto.getColor(),
                 author, rollingpaper, messageRequestDto.isAnonymous(), messageRequestDto.isSecret());
+        final RollingpaperEvent rollingpaperEvent = new RollingpaperEvent(rollingpaper);
+        applicationEventPublisher.publishEvent(rollingpaperEvent);
         return messageRepository.save(message)
                 .getId();
     }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/NotificationService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/NotificationService.java
@@ -1,0 +1,153 @@
+package com.woowacourse.naepyeon.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.woowacourse.naepyeon.domain.TeamParticipation;
+import com.woowacourse.naepyeon.domain.notification.ContentType;
+import com.woowacourse.naepyeon.domain.notification.Notification;
+import com.woowacourse.naepyeon.domain.rollingpaper.Rollingpaper;
+import com.woowacourse.naepyeon.repository.notification.NotificationRepository;
+import com.woowacourse.naepyeon.repository.teamparticipation.TeamParticipationRepository;
+import com.woowacourse.naepyeon.service.dto.NotificationResponseDto;
+import com.woowacourse.naepyeon.service.dto.NotificationsResponseDto;
+import com.woowacourse.naepyeon.service.event.RollingpaperAndTeamIdEvent;
+import com.woowacourse.naepyeon.service.event.RollingpaperEvent;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+
+    private static final long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+    private static final List<SseEmitter> emitters = new CopyOnWriteArrayList<>();
+
+    private final NotificationRepository notificationRepository;
+    private final TeamParticipationRepository teamParticipationRepository;
+    private final RedisOperations<String, NotificationResponseDto> eventRedisOperations;
+    private final RedisMessageListenerContainer redisMessageListenerContainer;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener
+    public void send(final RollingpaperEvent rollingpaperEvent) {
+        final Rollingpaper rollingpaper = rollingpaperEvent.getRollingpaper();
+        final Notification notification = createNotification(rollingpaper);
+        notificationRepository.save(notification);
+        final String id = String.valueOf(notification.getMemberId());
+        this.eventRedisOperations.convertAndSend(getChannelName(id), notification);
+    }
+
+    private Notification createNotification(final Rollingpaper rollingpaper) {
+        return new Notification(rollingpaper.getAddressee().getId(), ContentType.MESSAGE_AT_MY_ROLLINGPAPER,
+                rollingpaper.getTeamName(), rollingpaper.getTitle(), createUrl(rollingpaper), false);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener
+    public void send(final RollingpaperAndTeamIdEvent rollingpaperAndTeamIdEvent) {
+        final Rollingpaper rollingpaper = rollingpaperAndTeamIdEvent.getRollingpaper();
+        final Long teamId = rollingpaperAndTeamIdEvent.getTeamId();
+        final List<TeamParticipation> teamParticipations = teamParticipationRepository.findByTeamId(teamId);
+        for (TeamParticipation teamParticipation : teamParticipations) {
+            final Long memberId = teamParticipation.findMemberId();
+            final Notification notification = createNotification(memberId, rollingpaper);
+            notificationRepository.save(notification);
+            final String id = String.valueOf(memberId);
+            this.eventRedisOperations.convertAndSend(getChannelName(id), notification);
+        }
+    }
+
+    private Notification createNotification(final Long memberId, final Rollingpaper rollingpaper) {
+        return new Notification(memberId, ContentType.ROLLINGPAPER_AT_MY_TEAM, rollingpaper.getTeamName(),
+                rollingpaper.getTitle(), createUrl(rollingpaper), false);
+    }
+
+    private String createUrl(final Rollingpaper rollingpaper) {
+        final Long teamId = rollingpaper.getTeam().getId();
+        return "/team/" + teamId + "/rollingpaper/" + rollingpaper.getId();
+    }
+
+    public SseEmitter subscribe(final Long memberId) throws IOException {
+        log.info("정상적으로 전송되나요 ????");
+        String id = String.valueOf(memberId);
+        final SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        //초반 연결용 메시지!!
+        emitter.send(SseEmitter.event().id(id).name("sse"));
+        emitters.add(emitter);
+        MessageListener messageListener = (message, pattern) -> {
+            NotificationResponseDto notificationResponse = serialize(message);
+            sendToClient(emitter, id, notificationResponse);
+        };
+        this.redisMessageListenerContainer.addMessageListener(messageListener, ChannelTopic.of(getChannelName(id)));
+        emitter.onCompletion(()->{
+            emitters.remove(emitter);
+            this.redisMessageListenerContainer.removeMessageListener(messageListener);
+        });
+        return emitter;
+    }
+
+    private NotificationResponseDto serialize(final Message message) {
+        try {
+            final Notification notification = this.objectMapper.readValue(message.getBody(), Notification.class);
+            return NotificationResponseDto.from(notification);
+        } catch (IOException e) {
+            log.error("직렬화 실패");
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void sendToClient(final SseEmitter emitter, final String id, final Object data) {
+        try {
+            log.info("전송중!");
+            emitter.send(SseEmitter.event()
+                    .id(id)
+                    .name("sse")
+                    .data(data));
+            log.info("전송완료");
+        } catch (IOException e) {
+            emitters.remove(emitter);
+            log.error("SSE 연결이 올바르지 않습니다. 해당 memberID={}", id);
+        }
+    }
+
+    private String getChannelName(final String memberId) {
+        return "sample:topics:" + memberId;
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationsResponseDto findAllById(final Long memberId) {
+        List<NotificationResponseDto> responses = notificationRepository.findAllByMemberIdAndUnread(memberId)
+                .stream()
+                .map(NotificationResponseDto::from)
+                .collect(Collectors.toUnmodifiableList());
+        long unreadCount = responses.size();
+
+        return NotificationsResponseDto.of(responses, unreadCount);
+    }
+
+    public void readNotification(final Long id) {
+        final Notification notification = notificationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지않음"));
+        notification.read();
+    }
+
+    public void readAllNotifications(final Long id) {
+        notificationRepository.updateNotificationRead(id);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/NotificationService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/NotificationService.java
@@ -85,15 +85,15 @@ public class NotificationService {
 
     public SseEmitter subscribe(final Long memberId) throws IOException {
         log.info("정상적으로 전송되나요 ????");
-        String id = String.valueOf(memberId);
+        final String id = String.valueOf(memberId);
         final SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         //초반 연결용 메시지!!
         emitter.send(SseEmitter.event()
                 .id(id)
                 .name("sse"));
         emitters.add(emitter);
-        MessageListener messageListener = (message, pattern) -> {
-            NotificationResponseDto notificationResponse = serialize(message);
+        final MessageListener messageListener = (message, pattern) -> {
+            final NotificationResponseDto notificationResponse = serialize(message);
             sendToClient(emitter, id, notificationResponse);
         };
         this.redisMessageListenerContainer.addMessageListener(messageListener, ChannelTopic.of(getChannelName(id)));

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/NotificationService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/NotificationService.java
@@ -88,7 +88,9 @@ public class NotificationService {
         String id = String.valueOf(memberId);
         final SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         //초반 연결용 메시지!!
-        emitter.send(SseEmitter.event().id(id).name("sse"));
+        emitter.send(SseEmitter.event()
+                .id(id)
+                .name("sse"));
         emitters.add(emitter);
         MessageListener messageListener = (message, pattern) -> {
             NotificationResponseDto notificationResponse = serialize(message);

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/NotificationService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/NotificationService.java
@@ -86,7 +86,6 @@ public class NotificationService {
     }
 
     public SseEmitter subscribe(final Long memberId) throws IOException {
-        log.info("정상적으로 전송되나요 ????");
         final String id = String.valueOf(memberId);
         final SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         //초반 연결용 메시지!!
@@ -108,19 +107,16 @@ public class NotificationService {
             final Notification notification = this.objectMapper.readValue(message.getBody(), Notification.class);
             return NotificationResponseDto.from(notification);
         } catch (IOException e) {
-            log.error("직렬화 실패");
             throw new InvalidRedisMessageException(message);
         }
     }
 
     private void sendToClient(final SseEmitter emitter, final String id, final Object data) {
         try {
-            log.info("전송중!");
             emitter.send(SseEmitter.event()
                     .id(id)
                     .name("sse")
                     .data(data));
-            log.info("전송완료");
         } catch (IOException e) {
             emitters.remove(emitter);
             log.error("SSE 연결이 올바르지 않습니다. 해당 memberID={}", id);

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/RollingpaperService.java
@@ -19,10 +19,12 @@ import com.woowacourse.naepyeon.service.dto.ReceivedRollingpapersResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpaperPreviewResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpaperResponseDto;
 import com.woowacourse.naepyeon.service.dto.RollingpapersResponseDto;
+import com.woowacourse.naepyeon.service.event.RollingpaperAndTeamIdEvent;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -40,6 +42,7 @@ public class RollingpaperService {
     private final TeamRepository teamRepository;
     private final TeamParticipationRepository teamParticipationRepository;
     private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public Long createMemberRollingpaper(final String title, final Long teamId,
                                          final Long loginMemberId, final Long addresseeId) {
@@ -51,6 +54,8 @@ public class RollingpaperService {
         final TeamParticipation teamParticipation =
                 teamParticipationRepository.findByTeamIdAndMemberId(teamId, addresseeId);
         final Rollingpaper rollingpaper = new Rollingpaper(title, Recipient.MEMBER, team, addressee, teamParticipation);
+        final RollingpaperAndTeamIdEvent rollingpaperAndTeamIdEvent = new RollingpaperAndTeamIdEvent(rollingpaper,teamId);
+        applicationEventPublisher.publishEvent(rollingpaperAndTeamIdEvent);
         return rollingpaperRepository.save(rollingpaper)
                 .getId();
     }
@@ -71,6 +76,8 @@ public class RollingpaperService {
             throw new UncertificationTeamMemberException(teamId, loginMemberId);
         }
         final Rollingpaper rollingpaper = new Rollingpaper(title, Recipient.TEAM, team, null, null);
+        final RollingpaperAndTeamIdEvent rollingpaperAndTeamIdEvent = new RollingpaperAndTeamIdEvent(rollingpaper, teamId);
+        applicationEventPublisher.publishEvent(rollingpaperAndTeamIdEvent);
         return rollingpaperRepository.save(rollingpaper)
                 .getId();
     }

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/dto/NotificationResponseDto.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/dto/NotificationResponseDto.java
@@ -18,7 +18,7 @@ public class NotificationResponseDto {
 
     private String teamName;
 
-    private String RollingpaperTitle;
+    private String rollingpaperTitle;
 
     private String url;
 

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/dto/NotificationResponseDto.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/dto/NotificationResponseDto.java
@@ -1,0 +1,37 @@
+package com.woowacourse.naepyeon.service.dto;
+
+import com.woowacourse.naepyeon.domain.notification.ContentType;
+import com.woowacourse.naepyeon.domain.notification.Notification;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationResponseDto {
+
+    private Long id;
+
+    private ContentType contentType;
+
+    private String teamName;
+
+    private String RollingpaperTitle;
+
+    private String url;
+
+    private LocalDateTime createAt;
+
+    public static NotificationResponseDto from(final Notification notification) {
+        return new NotificationResponseDto(
+                notification.getId(),
+                notification.getContentType(),
+                notification.getTeamName(),
+                notification.getRollingpaperTitle(),
+                notification.getUrl(),
+                notification.getCreatedDate()
+        );
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/dto/NotificationsResponseDto.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/dto/NotificationsResponseDto.java
@@ -1,0 +1,19 @@
+package com.woowacourse.naepyeon.service.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationsResponseDto {
+
+    private List<NotificationResponseDto> notifications;
+    private long unreadCount;
+
+    public static NotificationsResponseDto of(List<NotificationResponseDto> notifications, long count) {
+        return new NotificationsResponseDto(notifications, count);
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/event/RollingpaperAndTeamIdEvent.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/event/RollingpaperAndTeamIdEvent.java
@@ -1,0 +1,32 @@
+package com.woowacourse.naepyeon.service.event;
+
+import com.woowacourse.naepyeon.domain.rollingpaper.Rollingpaper;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RollingpaperAndTeamIdEvent {
+
+    private final Rollingpaper rollingpaper;
+    private final Long teamId;
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final RollingpaperAndTeamIdEvent that = (RollingpaperAndTeamIdEvent) o;
+        return Objects.equals(getRollingpaper(), that.getRollingpaper()) && Objects.equals(getTeamId(),
+                that.getTeamId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRollingpaper(), getTeamId());
+    }
+}

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/event/RollingpaperEvent.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/event/RollingpaperEvent.java
@@ -1,0 +1,30 @@
+package com.woowacourse.naepyeon.service.event;
+
+import com.woowacourse.naepyeon.domain.rollingpaper.Rollingpaper;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class RollingpaperEvent {
+
+    private final Rollingpaper rollingpaper;
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final RollingpaperEvent that = (RollingpaperEvent) o;
+        return Objects.equals(getRollingpaper(), that.getRollingpaper());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getRollingpaper());
+    }
+}

--- a/backend/src/main/resources/application-deploy.yml
+++ b/backend/src/main/resources/application-deploy.yml
@@ -12,6 +12,9 @@ spring:
         password: ${REPLICA_MYSQL_PASSWORD}
         username: ${REPLICA_MYSQL_USERNAME}
         driver-class-name: com.mysql.cj.jdbc.Driver
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
 
   jpa:

--- a/backend/src/main/resources/application-develop.yml
+++ b/backend/src/main/resources/application-develop.yml
@@ -14,6 +14,9 @@ spring:
         username: ${REPLICA_MYSQL_USERNAME}
         driver-class-name: com.mysql.cj.jdbc.Driver
         maximum-pool-size: ${MAX_CONNECTION_POOL_SIZE}
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application-flywayTest.yml
+++ b/backend/src/main/resources/application-flywayTest.yml
@@ -12,6 +12,9 @@ spring:
         username: sa
         password:
         driver-class-name: org.h2.Driver
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,7 +1,4 @@
 spring:
-  h2:
-    console:
-      enabled: true
   datasource:
     source:
       hikari:
@@ -15,6 +12,9 @@ spring:
         username: user
         password: password
         driver-class-name: com.mysql.cj.jdbc.Driver
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
 
   jpa:
     hibernate:

--- a/backend/src/main/resources/db/migration/V0.5.2__notification.sql
+++ b/backend/src/main/resources/db/migration/V0.5.2__notification.sql
@@ -1,0 +1,15 @@
+CREATE TABLE notification (
+                               notification_id bigint not null auto_increment,
+                               member_id bigint not null,
+                               content_type varchar(40) not null,
+                               team_name varchar(20) not null,
+                               rollingpaper_title varchar(20) not null,
+                               url varchar(255) not null,
+                               is_read tinyint(1) not null,
+                               created_at datetime not null,
+                               last_modified_at datetime not null,
+                               primary key (notification_id)
+) engine=InnoDB default charset utf8mb4;
+
+
+CREATE INDEX notification_read_index ON notification (is_read);

--- a/backend/src/test/java/com/woowacourse/naepyeon/document/NotificationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/document/NotificationControllerTest.java
@@ -44,7 +44,7 @@ class NotificationControllerTest extends TestSupport {
 
     @Test
     @DisplayName("읽지 않은 알림 단건 읽음 처리")
-    void readUnreadNotification() throws Exception {
+    void readNotification() throws Exception {
         mockMvc.perform(
                         put("/api/v1/notifications/{id}", 1L)
                                 .header("Authorization", "Bearer " + joinedMemberAccessToken)
@@ -56,7 +56,7 @@ class NotificationControllerTest extends TestSupport {
 
     @Test
     @DisplayName("읽지 않은 알림들 모두 읽음 처리")
-    void readAllUnreadNotifications() throws Exception {
+    void readAllNotifications() throws Exception {
         mockMvc.perform(
                         put("/api/v1/notifications/all")
                                 .header("Authorization", "Bearer " + joinedMemberAccessToken)

--- a/backend/src/test/java/com/woowacourse/naepyeon/document/NotificationControllerTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/document/NotificationControllerTest.java
@@ -1,0 +1,68 @@
+package com.woowacourse.naepyeon.document;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.woowacourse.naepyeon.service.NotificationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class NotificationControllerTest extends TestSupport {
+
+    @MockBean
+    private NotificationService notificationService;
+
+    @Test
+    @DisplayName("subscribe로 sse연결")
+    void subscribe() throws Exception {
+        when(notificationService.subscribe(any())).thenReturn(new SseEmitter(60L * 1000 * 60));
+        mockMvc.perform(
+                        get("/api/v1/subscribe?id=1")
+                                .contentType(MediaType.TEXT_EVENT_STREAM_VALUE)
+                )
+                .andExpect(status().isOk())
+                .andDo(restDocs.document());
+    }
+
+    @Test
+    @DisplayName("안읽은 알림 전체 조회")
+    void notifications() throws Exception {
+        mockMvc.perform(
+                        get("/api/v1/notifications")
+                                .header("Authorization", "Bearer " + joinedMemberAccessToken)
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(restDocs.document());
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림 단건 읽음 처리")
+    void readUnreadNotification() throws Exception {
+        mockMvc.perform(
+                        put("/api/v1/notifications/{id}", 1L)
+                                .header("Authorization", "Bearer " + joinedMemberAccessToken)
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isNoContent())
+                .andDo(restDocs.document());
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림들 모두 읽음 처리")
+    void readAllUnreadNotifications() throws Exception {
+        mockMvc.perform(
+                        put("/api/v1/notifications/all")
+                                .header("Authorization", "Bearer " + joinedMemberAccessToken)
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isNoContent())
+                .andDo(restDocs.document());
+    }
+}

--- a/backend/src/test/java/com/woowacourse/naepyeon/document/TestSupport.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/document/TestSupport.java
@@ -4,11 +4,15 @@ package com.woowacourse.naepyeon.document;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.woowacourse.naepyeon.config.DatabaseCleaner;
 import com.woowacourse.naepyeon.config.logging.RequestBodyWrappingFilter;
+import com.woowacourse.naepyeon.domain.notification.ContentType;
+import com.woowacourse.naepyeon.domain.notification.Notification;
 import com.woowacourse.naepyeon.repository.member.MemberRepository;
+import com.woowacourse.naepyeon.repository.notification.NotificationRepository;
 import com.woowacourse.naepyeon.repository.refreshtoken.RefreshTokenRepository;
 import com.woowacourse.naepyeon.repository.team.TeamRepository;
 import com.woowacourse.naepyeon.service.MemberService;
 import com.woowacourse.naepyeon.service.MessageService;
+import com.woowacourse.naepyeon.service.NotificationService;
 import com.woowacourse.naepyeon.service.RollingpaperService;
 import com.woowacourse.naepyeon.service.TeamService;
 import com.woowacourse.naepyeon.service.dto.MessageRequestDto;
@@ -56,6 +60,9 @@ public abstract class TestSupport {
 
     @Autowired
     protected RollingpaperService rollingpaperService;
+
+    @Autowired
+    protected NotificationRepository notificationRepository;
 
     @Autowired
     protected MessageService messageService;
@@ -130,5 +137,14 @@ public abstract class TestSupport {
                 new MessageRequestDto("많은 가르침 받았습니다.", "#123456", false, false), rollingpaperId2, memberId2
         );
         messageService.likeMessage(memberId1, rollingpaperId1, messageId);
+
+        final Notification notification1 = new Notification(memberId2, ContentType.MESSAGE_AT_MY_ROLLINGPAPER,
+                "우아한 테크코스 4기", "생일축하해",
+                "/team/" + teamId + "/rollingpaper/" + rollingpaperId2, false);
+        final Notification notification2 = new Notification(memberId2, ContentType.MESSAGE_AT_MY_ROLLINGPAPER,
+                "우아한 테크코스 4기", "생일축하해",
+                "/team/" + teamId + "/rollingpaper/" + rollingpaperId2, false);
+        notificationRepository.save(notification1);
+        notificationRepository.save(notification2);
     }
 }

--- a/backend/src/test/java/com/woowacourse/naepyeon/repository/NotificationRepositoryTest.java
+++ b/backend/src/test/java/com/woowacourse/naepyeon/repository/NotificationRepositoryTest.java
@@ -1,0 +1,92 @@
+package com.woowacourse.naepyeon.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.woowacourse.naepyeon.config.JpaAuditingConfig;
+import com.woowacourse.naepyeon.config.QueryDslConfig;
+import com.woowacourse.naepyeon.domain.notification.ContentType;
+import com.woowacourse.naepyeon.domain.notification.Notification;
+import com.woowacourse.naepyeon.repository.notification.NotificationRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import({JpaAuditingConfig.class, QueryDslConfig.class})
+class NotificationRepositoryTest {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    private final Long seungpangId = 1L;
+    private final Notification notification1 = new Notification(
+            seungpangId,
+            ContentType.MESSAGE_AT_MY_ROLLINGPAPER,
+            "내편",
+            "승팡 생일축하해",
+            "/team/1/rollingpaper/1",
+            false
+    );
+
+    final Notification notification2 = new Notification(
+            seungpangId,
+            ContentType.MESSAGE_AT_MY_ROLLINGPAPER,
+            "내편",
+            "승팡 생일축하해",
+            "/team/1/rollingpaper/1",
+            false);
+
+    @BeforeEach
+    void setUp() {
+        notificationRepository.save(notification1);
+        notificationRepository.save(notification2);
+    }
+    
+    @Test
+    @DisplayName("알림을 저장하고 id를 찾는다.")
+    void save() {
+        final Long memberId = 1L;
+        final ContentType contentType = ContentType.MESSAGE_AT_MY_ROLLINGPAPER;
+        final String teamName = "내편짱짱";
+        final String rollingpaperTitle = "다들 고생했어!";
+        final String url = "team/1/Rollingpaper/1";
+        final boolean isRead = false;
+        final Notification notification = new Notification(memberId, contentType, teamName, rollingpaperTitle,
+                url, isRead);
+
+        final Long id = notificationRepository.save(notification)
+                .getId();
+        final Notification findNotification = notificationRepository.findById(id)
+                .orElseThrow();
+
+        assertThat(findNotification)
+                .extracting("id", "memberId", "contentType", "teamName", "rollingpaperTitle", "url", "isRead")
+                .containsExactly(id, memberId, contentType, teamName, rollingpaperTitle, url, isRead);
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림들을 모두 조회한다.")
+    void findAllByMemberIdUnRead() {
+        final List<Long> notificationsId = notificationRepository.findAllByMemberIdAndUnread(seungpangId)
+                .stream()
+                .map(Notification::getId)
+                .collect(Collectors.toUnmodifiableList());
+
+        assertThat(notificationsId)
+                .containsExactly(notification2.getId(), notification1.getId());
+    }
+
+    @Test
+    @DisplayName("읽지 않은 알림들을 모두 읽음 처리 한다.")
+    void readAllUnreadNotifications() {
+        notificationRepository.updateNotificationRead(seungpangId);
+
+        assertThat(notificationRepository.findAllByMemberIdAndUnread(seungpangId))
+                .isEmpty();
+    }
+}

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -12,6 +12,9 @@ spring:
         username: sa
         password:
         driver-class-name: org.h2.Driver
+  redis:
+    host: localhost
+    port: 6379
 
   jpa:
     hibernate:


### PR DESCRIPTION
### 실시간 알림
SSE와 redis를 활용하여 실시간 알림 기능을 구현했습니다.
현재 당사자에게 메시지가 작성되었을때, 모임에서 롤링페이퍼가 생성되었을때 알림이 가도록했습니다.

그러다 보니 해당 service에 notificationService가 참조되는 상황입니다.
그래서 알림이 실패하더라도 해당 메시지나 롤링페이퍼에 영향이 가지 않게  `@Transactional(propagation = Propagation.REQUIRES_NEW)`와 `@TransactionalEventListener`를 활용했습니다.

그리고 현재 테스트코드와 리팩토링을 하고있습니다. 그걸 다 진행하고 보내면 시간이 빠듯할거 같아서 보낸 후 수정하겠습니다.

추가적으로 수정할 내용은 다음과 같습니다.
+ 테스트 코드 추가
  + adoc 파일 작성
+ 커스텀 Exception 추가
+ 개발때 사용하던 log 지우기

close #592 
