### PR TITLE
fix: 아이폰에서 버튼 색상이 파란색으로 보이는 문제를 해결

### DIFF
--- a/frontend/src/styles/reset.ts
+++ b/frontend/src/styles/reset.ts
@@ -133,6 +133,7 @@ const reset = css`
       padding: 0;
       background-color: transparent;
       cursor: pointer;
+      color: black;
     }
     a {
       text-decoration: none;


### PR DESCRIPTION
## 구현 사항
- 아이폰에서 버튼 색상이 파란 색상으로 보이는 문제를 해결

closed #612 