### PR TITLE
fix: 롤링페이퍼 만들기 페이지에서 불필요한 Loading 컴포넌트가 보이는 버그를 해결한다.

### DIFF
--- a/frontend/src/pages/RollingpaperCreationPage/components/Step2.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/Step2.tsx
@@ -49,7 +49,11 @@ const Step2 = ({
     setKeywordList(data.members.map((member) => member.nickname));
   };
 
-  const { data: teamMemberResponse, isLoading } = useReadTeamMembers({
+  const {
+    data: teamMemberResponse,
+    isLoading,
+    isFetching,
+  } = useReadTeamMembers({
     teamId: teamId!,
 
     onSuccess: handleReadTeamMembersSuccess,
@@ -89,7 +93,7 @@ const Step2 = ({
     onSelectMember(memeberInfo.id);
   };
 
-  if (isLoading || !teamMemberResponse) {
+  if (isFetching) {
     return <Loading />;
   }
 


### PR DESCRIPTION
## 구현 사항
- 롤링페이퍼 만들기 페이지의 Step2에서 isLoading를 isFetching으로 변경한다.


closed #617 