### PR TITLE
feat: 메세지 좋아요시 동시성 이슈를 해결한다.

### DIFF
--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/message/Message.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/message/Message.java
@@ -19,6 +19,7 @@ import javax.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Version;
 
 @Entity
 @Getter
@@ -57,6 +58,9 @@ public class Message extends BaseEntity {
 
     @Column(name = "likes", nullable = false)
     private Long likes;
+
+    @Version
+    private Integer version;
 
     public Message(final String content, final String color, final Member author, final Rollingpaper rollingpaper,
                    final boolean anonymous, final boolean secret, final Long likes) {

--- a/backend/src/main/java/com/woowacourse/naepyeon/domain/message/Message.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/domain/message/Message.java
@@ -60,7 +60,7 @@ public class Message extends BaseEntity {
     private Long likes;
 
     @Version
-    private Integer version;
+    private Long version;
 
     public Message(final String content, final String color, final Member author, final Rollingpaper rollingpaper,
                    final boolean anonymous, final boolean secret, final Long likes) {

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryCustom.java
@@ -18,5 +18,5 @@ public interface MessageRepositoryCustom {
     Page<WrittenMessageResponseDto> findAllByAuthorId(final Long authorId, final Pageable pageRequest);
 
     @Lock(LockModeType.OPTIMISTIC)
-    Optional<Message> findByIdForUpdate(Long id);
+    Optional<Message> findByIdForUpdate(final Long id);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryCustom.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryCustom.java
@@ -3,12 +3,20 @@ package com.woowacourse.naepyeon.repository.message;
 import com.woowacourse.naepyeon.domain.message.Message;
 import com.woowacourse.naepyeon.service.dto.WrittenMessageResponseDto;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Lock;
+
+import javax.persistence.LockModeType;
 
 public interface MessageRepositoryCustom {
 
     List<Message> findAllByRollingpaperId(final Long rollingpaperId);
 
     Page<WrittenMessageResponseDto> findAllByAuthorId(final Long authorId, final Pageable pageRequest);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    Optional<Message> findByIdForUpdate(Long id);
 }

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
@@ -1,10 +1,5 @@
 package com.woowacourse.naepyeon.repository.message;
 
-import static com.woowacourse.naepyeon.domain.QTeam.team;
-import static com.woowacourse.naepyeon.domain.QTeamParticipation.teamParticipation;
-import static com.woowacourse.naepyeon.domain.message.QMessage.message;
-import static com.woowacourse.naepyeon.domain.rollingpaper.QRollingpaper.rollingpaper;
-
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
@@ -15,12 +10,19 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.woowacourse.naepyeon.domain.message.Message;
 import com.woowacourse.naepyeon.domain.rollingpaper.Recipient;
 import com.woowacourse.naepyeon.service.dto.WrittenMessageResponseDto;
-import java.util.List;
-import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static com.woowacourse.naepyeon.domain.QTeam.team;
+import static com.woowacourse.naepyeon.domain.QTeamParticipation.teamParticipation;
+import static com.woowacourse.naepyeon.domain.message.QMessage.message;
+import static com.woowacourse.naepyeon.domain.rollingpaper.QRollingpaper.rollingpaper;
 
 @RequiredArgsConstructor
 public class MessageRepositoryImpl implements MessageRepositoryCustom {
@@ -56,6 +58,14 @@ public class MessageRepositoryImpl implements MessageRepositoryCustom {
                 .where(isAuthorIdEq(authorId));
 
         return PageableExecutionUtils.getPage(content, pageRequest, countQuery::fetchOne);
+    }
+
+    @Override
+    public Optional<Message> findByIdForUpdate(Long id) {
+        return Optional.ofNullable(queryFactory
+                .selectFrom(message)
+                .where(message.id.eq(id))
+                .fetchOne());
     }
 
     private ConstructorExpression<WrittenMessageResponseDto> makeProjections() {

--- a/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/repository/message/MessageRepositoryImpl.java
@@ -61,7 +61,7 @@ public class MessageRepositoryImpl implements MessageRepositoryCustom {
     }
 
     @Override
-    public Optional<Message> findByIdForUpdate(Long id) {
+    public Optional<Message> findByIdForUpdate(final Long id) {
         return Optional.ofNullable(queryFactory
                 .selectFrom(message)
                 .where(message.id.eq(id))

--- a/backend/src/main/java/com/woowacourse/naepyeon/service/MessageService.java
+++ b/backend/src/main/java/com/woowacourse/naepyeon/service/MessageService.java
@@ -197,7 +197,7 @@ public class MessageService {
     }
 
     public MessageLikeResponseDto likeMessage(Long memberId, Long rollingpaperId, Long messageId) {
-        final Message message = messageRepository.findById(messageId)
+        final Message message = messageRepository.findByIdForUpdate(messageId)
                 .orElseThrow(() -> new NotFoundMessageException(messageId));
         if (messageLikeRepository.existsByMemberIdAndMessageId(memberId, messageId)) {
             throw new InvalidLikeMessageException(messageId, messageId);

--- a/backend/src/main/resources/db/migration/V0.5.3__message_version.sql
+++ b/backend/src/main/resources/db/migration/V0.5.3__message_version.sql
@@ -1,0 +1,2 @@
+ALTER TABLE message
+    ADD version bigint default 0;


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><h3>문제원인</h3>


시퀀스 | Tx1 | Tx2
-- | -- | --
1 | 메시지 A 찾음 |  
2 |   | 메시지 A찾음
3 | 메세지 좋아요 기록 존재하지 않는가? true |  
4 |   | 메세지 좋아요 기록 존재하지 않는가? true
5 | 메세지 좋아요 저장 |  
6 |   | 메세지 좋아요 저장
7 | Tx1 Commit |  
8 |   | Tx2 Commit


<p>원인은 바로 3, 4번에 있습니다.</p>
<p>두 개의 트랜잭션이 검사를 했을 때 <strong>기록이 존재하지않는가?</strong> 에서 둘다 TRUE를 반환했기 때문이었습니다.</p>
<!--EndFragment-->
</body>
</html>

<html>
<body>
<!--StartFragment--><h3>낙관적 락을 적용한 뒤 트랜잭션 변화</h3>


시퀀스 | Tx1 | Tx2
-- | -- | --
1 | Tx1 start |  
2 |   | Tx2 start
3 | 메시지 A 찾음, version = 0 |  
4 |   | 메시지 A찾음, version = 0
5 | 메세지 좋아요 기록 존재하지 않는가? true |  
6 |   | 메세지 좋아요 기록 존재하지 않는가? true
7 | 좋아요 수 증가, 메세지 좋아요 저장 |  
8 |   | 좋아요 수 증가, 메세지 좋아요 저장
9 | version == 0 true, Tx1 Commit, version += 1 |  
10 |   | version == 0 false, Tx2 Rollback


<p>메세지 자체에 낙관적 락을 걸어 중복되는 수정으로 부터 일관성을 유지할 수 있게 되었습니다.</p>
<!--EndFragment-->
</body>
</html>

https://jaehhh.tistory.com/148 에서 자세히 볼 수 있습니다~