### PR TITLE
fix: 롤링페이퍼 만들기 페이지의 가입한 모임 목록 empty state ui 추가

### DIFF
--- a/frontend/src/pages/RollingpaperCreationPage/components/Step1.tsx
+++ b/frontend/src/pages/RollingpaperCreationPage/components/Step1.tsx
@@ -1,9 +1,10 @@
-import { Navigate } from "react-router-dom";
+import { Navigate, useNavigate } from "react-router-dom";
 import styled from "@emotion/styled";
 
 import useIntersect from "@/hooks/useIntersect";
 import { useReadMyTeamsPaging } from "@/hooks/api/team";
 
+import LineButton from "@/components/LineButton";
 import MyTeamCard from "@/components/MyTeamCard";
 import Loading from "@/components/Loading";
 import StepLayout from "@/pages/RollingpaperCreationPage/components/StepLayout";
@@ -48,24 +49,52 @@ const Step1 = ({ onSelectTeam, selected }: Step1Props) => {
 
   return (
     <StepLayout title="모임을 선택해주세요">
-      <StyledCardList>
-        {myTeamListResponse.pages.map((page) =>
-          page.teams.map(({ id, name, description, emoji, color }) => (
-            <MyTeamCard
-              key={id}
-              id={id}
-              name={name}
-              description={description}
-              emoji={emoji}
-              color={color}
-              onClick={() => onSelectTeam(id)}
-              selected={id === selected}
-            />
-          ))
-        )}
-        <div ref={infiniteRef} />
-      </StyledCardList>
+      {myTeamListResponse.pages[0].totalCount === 0 ? (
+        <EmptyMyTeamList />
+      ) : (
+        <StyledCardList>
+          {myTeamListResponse.pages.map((page) =>
+            page.teams.map(({ id, name, description, emoji, color }) => (
+              <MyTeamCard
+                key={id}
+                id={id}
+                name={name}
+                description={description}
+                emoji={emoji}
+                color={color}
+                onClick={() => onSelectTeam(id)}
+                selected={id === selected}
+              />
+            ))
+          )}
+          <div ref={infiniteRef} />
+        </StyledCardList>
+      )}
     </StepLayout>
+  );
+};
+
+const EmptyMyTeamList = () => {
+  const navigate = useNavigate();
+
+  const handleJoinTeamButtonClick = () => {
+    navigate("/search");
+  };
+
+  const handleCreateTeamButtonClick = () => {
+    navigate("/team/new");
+  };
+
+  return (
+    <StyledEmptyCardList>
+      <StyledMessage>아직 참여한 모임이 없어요!</StyledMessage>
+      <LineButton onClick={handleJoinTeamButtonClick}>
+        참가할 모임 찾기
+      </LineButton>
+      <LineButton onClick={handleCreateTeamButtonClick}>
+        새 모임 만들기
+      </LineButton>
+    </StyledEmptyCardList>
   );
 };
 
@@ -88,6 +117,27 @@ const StyledCardList = styled.div`
   a {
     height: fit-content;
   }
+`;
+
+const StyledEmptyCardList = styled.div`
+  display: flex;
+  flex-direction: column;
+
+  align-items: center;
+  justify-content: center;
+
+  width: 100%;
+  height: 100%;
+
+  gap: 8px;
+`;
+
+const StyledMessage = styled.div`
+  font-size: 24px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.GRAY_400};
+
+  margin: 20px 0;
 `;
 
 export default Step1;


### PR DESCRIPTION
## 작업 내용
- RollingpaperCreationPage의 Step1에 가입한 모임이 없는 상태의 UI를 추가했습니다.

### 변경 전
<img src="https://user-images.githubusercontent.com/71116429/198814999-8064cd68-88f9-4388-8f42-5ab985505cc5.png" width="300px" />

### 변경 후
<img src="https://user-images.githubusercontent.com/71116429/198814985-c7a11755-1474-404f-aa3d-55c9d6d20971.png" width="300px" />

## 논의할 부분
- 다른 empty state ui와 똑같이 형식으로 추가했습니다. 코드 레벨이나 디자인 관련해서 의견 있으면 주세요!

closed #633 