### PR TITLE
fix: HotModuleReplacementPlugin 제거

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -22,7 +22,6 @@ module.exports = {
       template: "./public/index.html",
       favicon: path.resolve(__dirname, "public/logo.png"),
     }),
-    new webpack.HotModuleReplacementPlugin(),
   ],
   resolve: {
     extensions: [".js", ".jsx", ".ts", ".tsx"],


### PR DESCRIPTION
## 구현 사항
- 불필요한 HotModuleReplacementPlugin를 제거했습니다.
> Since webpack-dev-server v4, HMR is enabled by default. It automatically applies [webpack.HotModuleReplacementPlugin](https://webpack.js.org/plugins/hot-module-replacement-plugin/) which is required to enable HMR. So you don't have to add this plugin to your webpack.config.js when hot is set to true in config or via the CLI option --hot. See the [HMR concepts page](https://webpack.js.org/concepts/hot-module-replacement/) for more information.
- 참고자료: https://webpack.js.org/configuration/dev-server/#devserverhot

closed #636 